### PR TITLE
Rebuild welcome onboarding flow with 5-screen funnel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,18 +42,28 @@ Database migrations are plain SQL under `supabase/migrations/` (timestamped). Ap
 ## Mobile app architecture
 
 Routing is Expo Router with the file tree under `apps/mobile/app/`:
-- `_layout.tsx` mounts `AuthProvider` → `ChildProfileProvider` → `<Stack>`. `AuthGate` redirects to `/(tabs)` when there's a session and `/welcome` otherwise.
+- `_layout.tsx` mounts `AuthProvider` → `ChildProfileProvider` → `<Stack>`. `AuthGate` routes:
+  - signed in → `/(tabs)`
+  - no session + onboarding-flag set in `AsyncStorage` (`@sturdy/onboarding-complete`) → `/auth/sign-in`
+  - no session + first-time → `/welcome`
 - `(tabs)/` is currently a 2-tab structure: `index.tsx` (Home / child selector) and `settings.tsx`. The legacy `(tabs)/child.tsx` and root `now.tsx` were removed in the Phase 1 architecture shift — do not reintroduce a single shared SOS screen.
+- `welcome/` is the 5-screen onboarding stack. `_layout.tsx` mounts `OnboardingProvider` so trial input + result + child-setup data carry across screens. Screens: `index` (the moment) → `trial` → `trial-result` (regulate visible, connect/guide blurred via `expo-blur`) → `child-setup` → `signup`. The trial calls `getParentingScript` with no `userId` (no logging, no profile attachment) so it works without an account; crisis responses still route to `/crisis`. `signup` writes the optional child profile to `child_profiles` (with `preferences.challenges` jsonb), calls `markOnboardingComplete()`, and routes to `/(tabs)`.
 - `child/[id].tsx` is the per-child hub. SOS flows are scoped to a specific child here, then route to `result.tsx`. `result.tsx` back-navigates to the originating child hub.
 - `thought/[id].tsx` is the Question-mode result screen.
 - `crisis.tsx` is the safety-support screen reached when the Edge Function returns `response_type: "crisis"`.
 
 State:
 - `src/context/AuthContext.tsx` wraps Supabase auth; `src/context/ChildProfileContext.tsx` loads `child_profiles` for signed-in users and falls back to `AsyncStorage` (`sturdy_guest_child` key) for guests. Guest data migrates on sign-up.
+- `src/context/OnboardingContext.tsx` is scoped to the welcome stack only — holds trial input, AI result, and child-setup data so screens 1→5 carry forward without URL params.
 - `src/lib/supabase.ts` reads `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` and throws at import if missing.
 - `src/lib/api.ts` is the only call-site to the Edge Function. It exposes `getParentingScript()` (SOS) and `getQuestionResponse()` (question mode), both POSTing to `/functions/v1/chat-parenting-assistant`. A `crisis` `response_type` is converted into a thrown `CrisisDetectedError` carrying `crisisType` and `riskLevel` so callers can route to `/crisis`.
+- `src/utils/onboarding.ts` — `hasCompletedOnboarding()` / `markOnboardingComplete()` / `resetOnboarding()` (dev-only) wrap the AsyncStorage key.
+- `src/utils/analytics.ts` — `track(event, props)` stub. Logs in `__DEV__`, no-op in prod until a tracking backend is wired.
 
-Fonts: only Manrope (loaded in `_layout.tsx`). Other Google Font packages are dependencies but the journal-identity layout deliberately uses Manrope alone.
+Theme + fonts (v5 — locked):
+- `src/theme/colors.ts` is the single source of truth. v5 "Logo-derived premium dark" — warm dark base (`#1A1614`, NOT pure black, NOT blue-black) over a `LinearGradient` from `gradientTop` → `gradientBottom`. Brand: coral `#FF5C75` (primary), amber `#F79566` (CTA / active tab), steel `#5778A3` (trust), sage `#8AA060` (success), sos `#E87461` (crisis). Glass surfaces (`surface`, `surfaceRaised`) at 4.5% / 7% white. Backwards-compat aliases (`rose`, `base`, `subtle`, `raised`, `coral`, `peach`, `blue`, `textSub`, `textSecondary`, `cardGlass*`, `cat*`) retained because 21 unmigrated screens still reference them — tracked in Issue #3.
+- Fonts switched from Manrope-only to **Fraunces (serif) + DM Sans (sans)**. Loaded in `app/_layout.tsx`. `fonts.heading`/`script` → Fraunces; `fonts.body`/`label`/`subheading` → DM Sans. Components use the family name string directly: `<Text style={{ fontFamily: fonts.body }}>`.
+- `Screen.tsx` wraps children in the warm-dark gradient. `Card.tsx` (re-exported as `GlassCard`) is a glass-on-dark surface — `surface` fill, `border` border, no `borderTopWidth` (it creates a visible highlight line bug on dark surfaces).
 
 ## Edge Function pipeline
 

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,11 +1,10 @@
 // app/(tabs)/_layout.tsx
-// v5 — Journal identity: frosted glass tab bar, rose active
-// 2 tabs: Home · Settings
-// Child tab removed — each child now has their own hub at /child/[id]
+// v5 — Premium dark tab bar; amber active, muted inactive.
+// Two tabs (post-Phase-1 architecture): Home · Settings.
 
 import { Text } from 'react-native';
 import { Tabs } from 'expo-router';
-import { colors as C, fonts as F } from '../../src/theme';
+import { colors as C, fonts as F } from '../../src/theme/colors';
 
 export default function TabLayout() {
   return (
@@ -13,17 +12,17 @@ export default function TabLayout() {
       screenOptions={{
         headerShown: false,
         tabBarStyle: {
-          backgroundColor: 'rgba(253,250,245,0.85)',
+          backgroundColor: 'rgba(20,17,14,0.92)',   // warm dark, near-opaque
           borderTopWidth: 1,
-          borderTopColor: 'rgba(0,0,0,0.06)',
+          borderTopColor: C.border,
           paddingBottom: 24,
           paddingTop: 8,
           height: 80,
           position: 'absolute',
           elevation: 0,
         },
-        tabBarActiveTintColor: C.rose,
-        tabBarInactiveTintColor: C.textMuted,
+        tabBarActiveTintColor:   C.tabActive,        // amber #F79566
+        tabBarInactiveTintColor: C.tabInactive,
         tabBarLabelStyle: {
           fontFamily: F.bodySemi,
           fontSize: 10,
@@ -50,7 +49,6 @@ export default function TabLayout() {
           ),
         }}
       />
-  
     </Tabs>
   );
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,5 +1,5 @@
 // app/_layout.tsx
-// v8 — Journal identity: Manrope only
+// v5 — Logo-derived premium dark theme; Fraunces (serif) + DM Sans (sans).
 
 import { useEffect } from 'react';
 import { Platform, Text, TextInput } from 'react-native';
@@ -7,14 +7,20 @@ import { Stack, router } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useFonts } from 'expo-font';
 import {
-  Manrope_400Regular,
-  Manrope_500Medium,
-  Manrope_600SemiBold,
-  Manrope_700Bold,
-  Manrope_800ExtraBold,
-} from '@expo-google-fonts/manrope';
+  Fraunces_600SemiBold,
+  Fraunces_600SemiBold_Italic,
+  Fraunces_700Bold,
+  Fraunces_700Bold_Italic,
+} from '@expo-google-fonts/fraunces';
+import {
+  DMSans_400Regular,
+  DMSans_500Medium,
+  DMSans_600SemiBold,
+  DMSans_700Bold,
+} from '@expo-google-fonts/dm-sans';
 import { AuthProvider, useAuth } from '../src/context/AuthContext';
-import { ChildProfileProvider }  from '../src/context/ChildProfileContext';
+import { ChildProfileProvider }   from '../src/context/ChildProfileContext';
+import { colors }                 from '../src/theme/colors';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -64,11 +70,16 @@ function AuthGate() {
 
 export default function RootLayout() {
   const [fontsLoaded] = useFonts({
-    'Manrope-Regular':    Manrope_400Regular,
-    'Manrope-Medium':     Manrope_500Medium,
-    'Manrope-SemiBold':   Manrope_600SemiBold,
-    'Manrope-Bold':       Manrope_700Bold,
-    'Manrope-ExtraBold':  Manrope_800ExtraBold,
+    // Fraunces (serif) — headings, hero, AI script text
+    Fraunces_600SemiBold,
+    Fraunces_600SemiBold_Italic,
+    Fraunces_700Bold,
+    Fraunces_700Bold_Italic,
+    // DM Sans (sans) — body, controls, labels
+    DMSans_400Regular,
+    DMSans_500Medium,
+    DMSans_600SemiBold,
+    DMSans_700Bold,
   });
 
   if (!fontsLoaded) return null;
@@ -80,7 +91,7 @@ export default function RootLayout() {
         <Stack
           screenOptions={{
             headerShown: false,
-            contentStyle: { backgroundColor: '#FDFAF5' },
+            contentStyle: { backgroundColor: colors.background },
             animation: 'slide_from_right',
             orientation: 'portrait',
           }}
@@ -89,4 +100,3 @@ export default function RootLayout() {
     </AuthProvider>
   );
 }
-

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,7 +1,7 @@
 // app/_layout.tsx
 // v5 — Logo-derived premium dark theme; Fraunces (serif) + DM Sans (sans).
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Platform, Text, TextInput } from 'react-native';
 import { Stack, router } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
@@ -21,6 +21,7 @@ import {
 import { AuthProvider, useAuth } from '../src/context/AuthContext';
 import { ChildProfileProvider }   from '../src/context/ChildProfileContext';
 import { colors }                 from '../src/theme/colors';
+import { hasCompletedOnboarding } from '../src/utils/onboarding';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -48,6 +49,7 @@ if (Platform.OS !== 'web') {
 
 function AuthGate() {
   const { session, isLoading } = useAuth();
+  const [routed, setRouted] = useState(false);
 
   useEffect(() => {
     if (!isLoading) {
@@ -56,14 +58,29 @@ function AuthGate() {
   }, [isLoading]);
 
   useEffect(() => {
-    if (isLoading) return;
+    if (isLoading || routed) return;
+    let cancelled = false;
 
-    if (session) {
-      router.replace('/(tabs)');
-      return;
-    }
-    router.replace('/welcome');
-  }, [session, isLoading]);
+    (async () => {
+      // Signed-in users skip onboarding entirely.
+      if (session) {
+        if (!cancelled) {
+          router.replace('/(tabs)');
+          setRouted(true);
+        }
+        return;
+      }
+
+      // No session — branch on whether they've finished onboarding before.
+      // Returning users land on sign-in; first-timers land on /welcome.
+      const done = await hasCompletedOnboarding();
+      if (cancelled) return;
+      router.replace(done ? '/auth/sign-in' : '/welcome');
+      setRouted(true);
+    })();
+
+    return () => { cancelled = true; };
+  }, [session, isLoading, routed]);
 
   return null;
 }

--- a/apps/mobile/app/welcome/_layout.tsx
+++ b/apps/mobile/app/welcome/_layout.tsx
@@ -1,16 +1,24 @@
 // app/welcome/_layout.tsx
-// Nested layout for onboarding flow
+// v5 — Onboarding stack. Wraps the 5 screens with OnboardingProvider so
+// trial input → trial result → child setup carry forward across screens.
+// Background colour is the warm-dark base (set on Stack contentStyle);
+// each screen renders its own LinearGradient via the Screen wrapper.
 
 import { Stack } from 'expo-router';
+import { colors } from '../../src/theme/colors';
+import { OnboardingProvider } from '../../src/context/OnboardingContext';
 
 export default function WelcomeLayout() {
   return (
-    <Stack
-      screenOptions={{
-        headerShown: false,
-        contentStyle: { backgroundColor: '#09090B' },
-        animation: 'slide_from_right',
-      }}
-    />
+    <OnboardingProvider>
+      <Stack
+        screenOptions={{
+          headerShown: false,
+          contentStyle: { backgroundColor: colors.background },
+          animation: 'slide_from_right',
+          orientation: 'portrait',
+        }}
+      />
+    </OnboardingProvider>
   );
 }

--- a/apps/mobile/app/welcome/child-setup.tsx
+++ b/apps/mobile/app/welcome/child-setup.tsx
@@ -1,0 +1,313 @@
+// app/welcome/child-setup.tsx
+// Onboarding Screen 4 — "Your Child".
+// Collects the minimum needed to personalise. Stored in OnboardingContext
+// (no Supabase yet — no account exists). Created in the DB after Screen 5
+// signup completes.
+//
+// Pre-fills age from the trial screen if the parent already picked one —
+// it should feel like the app already remembers them.
+
+import { useEffect, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import { router } from 'expo-router';
+import { colors as C, fonts as F } from '../../src/theme/colors';
+import { ProgressDots } from '../../src/components/welcome/ProgressDots';
+import { useOnboarding } from '../../src/context/OnboardingContext';
+import { track } from '../../src/utils/analytics';
+
+const AGES = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
+
+const CHALLENGES = [
+  'Meltdowns & tantrums',
+  'Not listening',
+  'Screen time battles',
+  'Bedtime resistance',
+  'Sibling conflict',
+  'Back-talk & attitude',
+] as const;
+
+export default function WelcomeChildSetup() {
+  const { trialInput, childSetup, setChildSetup } = useOnboarding();
+
+  const [name, setName]                = useState<string>(childSetup?.name ?? '');
+  const [age, setAge]                  = useState<number>(childSetup?.childAge ?? trialInput?.childAge ?? 5);
+  const [challenges, setChallenges]    = useState<string[]>(childSetup?.challenges ?? []);
+
+  useEffect(() => {
+    track('onboarding_screen_viewed', { screen: 4 });
+  }, []);
+
+  function toggleChallenge(c: string) {
+    setChallenges((prev) =>
+      prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c],
+    );
+  }
+
+  function onContinue() {
+    setChildSetup({
+      name:        name.trim() || null,
+      childAge:    age,
+      challenges,
+    });
+    track('onboarding_child_setup_completed', {
+      has_name:   Boolean(name.trim()),
+      age,
+      challenges,
+    });
+    router.push('/welcome/signup');
+  }
+
+  function onSkip() {
+    setChildSetup(null);
+    track('onboarding_child_setup_skipped', {});
+    router.push('/welcome/signup');
+  }
+
+  return (
+    <View style={s.root}>
+      <LinearGradient
+        colors={[C.gradientTop, C.gradientBottom]}
+        style={StyleSheet.absoluteFillObject}
+      />
+      <SafeAreaView style={s.safe}>
+        <StatusBar style="light" />
+        <ProgressDots step={4} />
+
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={s.kav}
+        >
+          <ScrollView
+            contentContainerStyle={s.scroll}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <Text style={s.h1}>Who are you here for?</Text>
+            <Text style={s.sub}>
+              This helps Sturdy match scripts to your child's age.{'\n'}
+              Every year matters.
+            </Text>
+
+            <View style={s.card}>
+              <Text style={s.label}>Child's name <Text style={s.optional}>(optional)</Text></Text>
+              <TextInput
+                style={s.input}
+                value={name}
+                onChangeText={setName}
+                placeholder="Their first name"
+                placeholderTextColor={C.textMuted}
+                autoCapitalize="words"
+                maxLength={40}
+                returnKeyType="done"
+              />
+
+              <View style={s.divider} />
+
+              <Text style={s.label}>Age</Text>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={s.ageRow}
+              >
+                {AGES.map((a) => {
+                  const selected = a === age;
+                  return (
+                    <Pressable
+                      key={a}
+                      onPress={() => setAge(a)}
+                      style={[s.agePill, selected && s.agePillSelected]}
+                      accessibilityRole="button"
+                    >
+                      <Text style={[s.agePillText, selected && s.agePillTextSelected]}>
+                        {a === 12 ? '12+' : a}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </ScrollView>
+
+              <View style={s.divider} />
+
+              <Text style={s.label}>What's your biggest challenge right now? <Text style={s.optional}>(optional)</Text></Text>
+              <Text style={s.helper}>Pick as many as you like</Text>
+              <View style={s.challengeWrap}>
+                {CHALLENGES.map((c) => {
+                  const selected = challenges.includes(c);
+                  return (
+                    <Pressable
+                      key={c}
+                      onPress={() => toggleChallenge(c)}
+                      style={[s.challengePill, selected && s.challengePillSelected]}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected }}
+                    >
+                      <Text style={[s.challengeText, selected && s.challengeTextSelected]}>
+                        {c}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+          </ScrollView>
+
+          <View style={s.ctaBlock}>
+            <Pressable
+              onPress={onContinue}
+              style={({ pressed }) => [s.cta, pressed && s.ctaPressed]}
+              accessibilityRole="button"
+            >
+              <Text style={s.ctaText}>Continue →</Text>
+            </Pressable>
+            <Pressable onPress={onSkip} style={s.linkBtn}>
+              <Text style={s.link}>Skip for now →</Text>
+            </Pressable>
+          </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  root: { flex: 1, backgroundColor: C.background },
+  safe: { flex: 1, paddingHorizontal: 20 },
+  kav:  { flex: 1 },
+  scroll: { paddingTop: 16, paddingBottom: 16, gap: 16 },
+
+  h1: {
+    fontFamily: F.heading,
+    fontSize: 28,
+    lineHeight: 34,
+    color: C.text,
+    letterSpacing: -0.3,
+  },
+  sub: {
+    fontFamily: F.body,
+    fontSize: 15,
+    lineHeight: 22,
+    color: C.textSecondary,
+  },
+
+  card: {
+    backgroundColor: C.surface,
+    borderColor:     C.border,
+    borderWidth: 1,
+    borderRadius: 20,
+    padding: 16,
+    gap: 14,
+  },
+
+  label: {
+    fontFamily: F.label,
+    fontSize: 11,
+    letterSpacing: 0.8,
+    color: C.textMuted,
+    textTransform: 'uppercase',
+  },
+  optional: {
+    fontFamily: F.body,
+    fontSize: 11,
+    letterSpacing: 0,
+    color: C.textFaint,
+    textTransform: 'none',
+  },
+  helper: {
+    fontFamily: F.body,
+    fontSize: 12,
+    lineHeight: 18,
+    color: C.textMuted,
+    marginTop: -6,
+  },
+
+  input: {
+    backgroundColor: C.inputBg,
+    borderColor:     C.inputBorder,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontFamily: F.body,
+    fontSize: 16,
+    color: C.text,
+  },
+
+  divider: { height: 1, backgroundColor: C.divider },
+
+  ageRow: { gap: 8, paddingVertical: 4 },
+  agePill: {
+    minWidth: 40,
+    height: 40,
+    borderRadius: 12,
+    backgroundColor: C.chipBg,
+    borderColor:     C.chipBorder,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+  },
+  agePillSelected: {
+    backgroundColor: C.amberLight,
+    borderColor:     C.amber,
+  },
+  agePillText: {
+    fontFamily: F.bodySemi,
+    fontSize: 16,
+    color: C.textSecondary,
+  },
+  agePillTextSelected: { color: C.amber },
+
+  challengeWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  challengePill: {
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    backgroundColor: C.chipBg,
+    borderColor:     C.chipBorder,
+    borderWidth: 1,
+  },
+  challengePillSelected: {
+    backgroundColor: C.amberLight,
+    borderColor:     C.amber,
+  },
+  challengeText: {
+    fontFamily: F.body,
+    fontSize: 13,
+    color: C.textSecondary,
+  },
+  challengeTextSelected: { color: C.amber },
+
+  ctaBlock: { paddingBottom: 12, gap: 8, alignItems: 'center' },
+  cta: {
+    backgroundColor: C.amber,
+    borderRadius: 14,
+    paddingVertical: 16,
+    width: '100%',
+    alignItems: 'center',
+  },
+  ctaPressed: { opacity: 0.85 },
+  ctaText: {
+    fontFamily: F.bodySemi,
+    fontSize: 17,
+    color: C.textInverse,
+    letterSpacing: 0.3,
+  },
+  linkBtn: { paddingVertical: 8 },
+  link: { fontFamily: F.body, fontSize: 14, color: C.textMuted },
+});

--- a/apps/mobile/app/welcome/index.tsx
+++ b/apps/mobile/app/welcome/index.tsx
@@ -1,822 +1,182 @@
 // app/welcome/index.tsx
-// v12 — Native photo identity welcome flow
-//
-// 5 screens: splash → 3 feature slides → final CTA
-// Native patterns:
-//   - Paged horizontal ScrollView (real swipe)
-//   - BlurView glass cards anchored to bottom edge
-//   - LinearGradient photo dim overlays
-//   - Spring card entrance animation (Animated API)
-//   - Page dots (not progress bar)
-//   - Plain text Skip (not pill button)
-//   - Haptics on every interaction
-//
-// Auth wiring preserved from v11:
-//   - Session check → redirect to tabs
-//   - GUEST_SEEN_KEY in AsyncStorage
-//   - Get started → /child-setup
-//   - Try without account → guest flag → tabs
-//   - Sign in → /auth/sign-in
+// Onboarding Screen 1 — "The Moment".
+// Emotional hook. Three lines fade in line by line, then the subtext,
+// then the CTA. The parent should feel seen in 3 seconds.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   Animated,
-  Dimensions,
-  Image,
   Pressable,
-  ScrollView,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
-import { router }          from 'expo-router';
-import { StatusBar }       from 'expo-status-bar';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { LinearGradient }  from 'expo-linear-gradient';
-import { BlurView }        from 'expo-blur';
-import * as Haptics        from 'expo-haptics';
-import AsyncStorage        from '@react-native-async-storage/async-storage';
-import { useAuth }         from '../../src/context/AuthContext';
+import { LinearGradient } from 'expo-linear-gradient';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import { router } from 'expo-router';
 import { colors as C, fonts as F } from '../../src/theme/colors';
+import { ProgressDots } from '../../src/components/welcome/ProgressDots';
+import { track } from '../../src/utils/analytics';
 
-const { width: W, height: H } = Dimensions.get('window');
-const GUEST_SEEN_KEY = 'sturdy_guest_seen_v1';
-
-// Static requires — resolved at build time, images must exist before running
-const FAMILY_PHOTO  = require('../../assets/images/welcome/welcome-family.jpg');
-const HORIZON_PHOTO = require('../../assets/images/welcome/welcome-horizon.jpg');
-
-// ─── Feature slide data ───────────────────────────────────────────────────────
-
-const FEATURES = [
-  {
-    badge:       'When chaos hits',
-    badgeBg:     'rgba(232,116,97,0.22)',
-    badgeColor:  '#FFA294',
-    titlePre:    'The right words.',
-    titleAccent: '',
-    titlePost:   '\nIn seconds.',
-    accentColor: '#FFA294',
-    desc:        'Describe the moment. Get calm, age-specific words you can say out loud — before it escalates.',
-    items: [
-      { icon: '⚡', text: 'Scripts in under 5 seconds' },
-      { icon: '🎯', text: "Adapted to your child's exact age" },
-      { icon: '🧩', text: 'Aware of ADHD, autism, anxiety' },
-    ],
-  },
-  {
-    badge:       'When you need to think',
-    badgeBg:     'rgba(106,146,188,0.24)',
-    badgeColor:  '#A8C4E2',
-    titlePre:    'Ask the question',
-    titleAccent: '',
-    titlePost:   "\nyou can't ask anyone.",
-    accentColor: '#A8C4E2',
-    desc:        'Why is this happening? Is it normal? What do I do next? Sturdy answers — no judgment, no jargon.',
-    items: [
-      { icon: '🎙️', text: 'No therapy speak. No lectures.' },
-      { icon: '📌', text: 'Saves your thoughts for later' },
-      { icon: '✨', text: "Knows which child you're asking about" },
-    ],
-  },
-  {
-    badge:       'Always specific',
-    badgeBg:     'rgba(212,148,74,0.24)',
-    badgeColor:  '#E8A855',
-    titlePre:    'Built around',
-    titleAccent: '',
-    titlePost:   '\nyour child.',
-    accentColor: '#E8A855',
-    desc:        "Every script, every answer shaped by their exact age and what you actually described. Never generic.",
-    items: [
-      { icon: '👶', text: 'Exact age, every time' },
-      { icon: '📖', text: 'Reads what you share' },
-      { icon: '📈', text: 'Adapts as things escalate' },
-    ],
-  },
+const HERO_LINES = [
+  "It's 8pm.",
+  "They won't brush their teeth.",
+  "You've already asked three times.",
 ];
-// ─── Main component ───────────────────────────────────────────────────────────
 
-export default function WelcomeScreen() {
-  const { session }  = useAuth();
-  const insets       = useSafeAreaInsets();
-  const scrollRef    = useRef<ScrollView>(null);
-  const [page, setPage] = useState(0);
+const SUBTEXT = "Sturdy gives you the right words\nfor moments like this.";
 
-  // Splash fade-in
-  const splashOpacity = useRef(new Animated.Value(0)).current;
-
-  // Card spring entrance (shared, reset per page)
-  const cardY       = useRef(new Animated.Value(40)).current;
-  const cardOpacity = useRef(new Animated.Value(0)).current;
-
-  // ─── Effects ───────────────────────────────────────────────────────────────
+export default function WelcomeMoment() {
+  const lineOpacity   = useRef(HERO_LINES.map(() => new Animated.Value(0))).current;
+  const lineSlide     = useRef(HERO_LINES.map(() => new Animated.Value(8))).current;
+  const subtextOpacity = useRef(new Animated.Value(0)).current;
+  const ctaOpacity     = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
-    if (session) {
-      router.replace('/(tabs)');
-      return;
-    }
+    track('onboarding_screen_viewed', { screen: 1 });
 
-    // Fade in splash branding
-    Animated.timing(splashOpacity, {
-      toValue:         1,
-      duration:        700,
-      useNativeDriver: true,
+    // Stagger lines (300ms apart, each fades up over 600ms).
+    HERO_LINES.forEach((_, i) => {
+      Animated.parallel([
+        Animated.timing(lineOpacity[i], {
+          toValue: 1, duration: 600, delay: i * 300, useNativeDriver: true,
+        }),
+        Animated.timing(lineSlide[i], {
+          toValue: 0, duration: 600, delay: i * 300, useNativeDriver: true,
+        }),
+      ]).start();
+    });
+
+    // Subtext + CTA fade in after the last line settles.
+    const tailDelay = HERO_LINES.length * 300 + 1500;
+    Animated.timing(subtextOpacity, {
+      toValue: 1, duration: 700, delay: tailDelay, useNativeDriver: true,
     }).start();
+    Animated.timing(ctaOpacity, {
+      toValue: 1, duration: 700, delay: tailDelay + 200, useNativeDriver: true,
+    }).start();
+  }, []);
 
-    // Auto-advance to first feature slide after 3s
-    const timer = setTimeout(() => {
-      goToPage(1);
-    }, 3000);
+  function onTryNow() {
+    track('onboarding_screen_dropped', { screen: 1, action: 'try_now' });
+    router.push('/welcome/trial');
+  }
 
-    return () => clearTimeout(timer);
-  }, [session]);
-
-  // Animate card in whenever page changes to a non-splash screen
-  useEffect(() => {
-    if (page === 0) return;
-    cardY.setValue(40);
-    cardOpacity.setValue(0);
-    Animated.parallel([
-      Animated.spring(cardY, {
-        toValue:         0,
-        damping:         22,
-        stiffness:       180,
-        useNativeDriver: true,
-      }),
-      Animated.timing(cardOpacity, {
-        toValue:         1,
-        duration:        350,
-        useNativeDriver: true,
-      }),
-    ]).start();
-  }, [page]);
-
-  // ─── Handlers ──────────────────────────────────────────────────────────────
-
-  const goToPage = (index: number) => {
-    scrollRef.current?.scrollTo({ x: W * index, animated: true });
-    setPage(index);
-  };
-
-  const onMomentumScrollEnd = (e: any) => {
-    const newPage = Math.round(e.nativeEvent.contentOffset.x / W);
-    if (newPage !== page) {
-      setPage(newPage);
-    }
-  };
-
-  const handleSkip = async () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    await AsyncStorage.setItem(GUEST_SEEN_KEY, 'true');
-    router.replace('/(tabs)');
-  };
-
-  const handleGetStarted = () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-    router.push('/child-setup');
-  };
-
-  const handleTryWithout = async () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    await AsyncStorage.setItem(GUEST_SEEN_KEY, 'true');
-    router.replace('/(tabs)');
-  };
-
-  const handleSignIn = () => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  function onSignIn() {
+    track('onboarding_screen_dropped', { screen: 1, action: 'sign_in' });
     router.push('/auth/sign-in');
-  };
-
-  // ─── Shared animated card style ────────────────────────────────────────────
-
-  const cardAnimStyle = {
-    opacity:   cardOpacity,
-    transform: [{ translateY: cardY }],
-  };
-
-  // ─── Render ────────────────────────────────────────────────────────────────
+  }
 
   return (
     <View style={s.root}>
-      <StatusBar style="light" />
+      <LinearGradient
+        colors={[C.gradientTop, C.gradientBottom]}
+        style={StyleSheet.absoluteFillObject}
+      />
+      <SafeAreaView style={s.safe}>
+        <StatusBar style="light" />
+        <ProgressDots step={1} />
 
-      {/* Skip — plain text, top-right, only on feature slides */}
-      {page >= 1 && page <= 3 && (
-        <Pressable
-          style={[s.skipBtn, { top: insets.top + 16 }]}
-          onPress={handleSkip}
-          hitSlop={12}
-        >
-          <Text style={s.skipText}>Skip</Text>
-        </Pressable>
-      )}
-
-      <ScrollView
-        ref={scrollRef}
-        horizontal
-        pagingEnabled
-        showsHorizontalScrollIndicator={false}
-        scrollEventThrottle={16}
-        onMomentumScrollEnd={onMomentumScrollEnd}
-      >
-        {/* ══════════════════════════════════════════
-            PAGE 0 — SPLASH
-            Logo at top, family photo full-bleed
-            Family figures visible in lower portion
-            ══════════════════════════════════════════ */}
-        <View style={s.page}>
-          <Image
-            source={FAMILY_PHOTO}
-            style={s.photoBg}
-            resizeMode="cover"
-          />
-          <LinearGradient
-            colors={[
-              'rgba(15,10,18,0.52)',
-              'rgba(15,10,18,0.18)',
-              'rgba(15,10,18,0.04)',
-              'rgba(15,10,18,0.22)',
-            ]}
-            locations={[0, 0.28, 0.60, 1]}
-            style={StyleSheet.absoluteFill}
-          />
-
-          {/* Branding anchored to top */}
-          <Animated.View
-            style={[
-              s.splashContent,
-              { paddingTop: insets.top + 70 },
-              { opacity: splashOpacity },
-            ]}
-          >
-            <LinearGradient
-              colors={['#D4944A', '#E87461']}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 1, y: 1 }}
-              style={s.logoBox}
-            >
-              <Text style={s.logoLetter}>S</Text>
-            </LinearGradient>
-
-            <Text style={s.splashName}>Sturdy</Text>
-            <Text style={s.splashTagline}>
-  The bridge between chaos and calm.
-</Text>
-          </Animated.View>
-        </View>
-
-        {/* ══════════════════════════════════════════
-            PAGES 1-3 — FEATURE SLIDES
-            Horizon photo background
-            BlurView glass card anchored to bottom
-            ══════════════════════════════════════════ */}
-        {FEATURES.map((feat, i) => {
-          const slideIndex = i + 1;
-          return (
-            <View key={i} style={s.page}>
-              <Image
-                source={HORIZON_PHOTO}
-                style={s.photoBg}
-                resizeMode="cover"
-              />
-              <LinearGradient
-                colors={[
-                  'rgba(15,10,18,0.25)',
-                  'rgba(15,10,18,0.20)',
-                  'rgba(15,10,18,0.62)',
-                ]}
-                locations={[0, 0.40, 1]}
-                style={StyleSheet.absoluteFill}
-              />
-
-              {/* Page dots */}
-              <View style={[s.dotsRow, { top: insets.top + 20 }]}>
-                {FEATURES.map((_, di) => (
-                  <View
-                    key={di}
-                    style={[s.dot, di === i && s.dotActive]}
-                  />
-                ))}
-              </View>
-
-              {/* Glass card — bottom anchored */}
-              <Animated.View
+        <View style={s.center}>
+          <View style={s.heroBlock}>
+            {HERO_LINES.map((line, i) => (
+              <Animated.Text
+                key={i}
                 style={[
-                  s.cardWrap,
-                  { paddingBottom: insets.bottom + 36 },
-                  page === slideIndex ? cardAnimStyle : null,
+                  s.heroLine,
+                  { opacity: lineOpacity[i], transform: [{ translateY: lineSlide[i] }] },
                 ]}
               >
-                <BlurView
-                  intensity={50}
-                  tint="dark"
-                  style={s.card}
-                >
-                  {/* Badge */}
-                  <View style={[s.badge, { backgroundColor: feat.badgeBg }]}>
-                    <Text style={[s.badgeText, { color: feat.badgeColor }]}>
-                      {feat.badge.toUpperCase()}
-                    </Text>
-                  </View>
+                {line}
+              </Animated.Text>
+            ))}
+          </View>
 
-                  {/* Title */}
-                  <Text style={s.featTitle}>
-                    {feat.titlePre}
-                    <Text style={[s.featAccent, { color: feat.accentColor }]}>
-                      {feat.titleAccent}
-                    </Text>
-                    {feat.titlePost}
-                  </Text>
-
-                  {/* Description */}
-                  <Text style={s.featDesc}>{feat.desc}</Text>
-
-                  {/* Feature list */}
-                  <View style={s.itemList}>
-                    {feat.items.map((item, ii) => (
-                      <View key={ii} style={s.item}>
-                        <Text style={s.itemIcon}>{item.icon}</Text>
-                        <Text style={s.itemText}>{item.text}</Text>
-                      </View>
-                    ))}
-                  </View>
-                </BlurView>
-              </Animated.View>
-            </View>
-          );
-        })}
-
-        {/* ══════════════════════════════════════════
-            PAGE 4 — FINAL CTA
-            Family photo returns (bookend)
-            BlurView card with buttons
-            ══════════════════════════════════════════ */}
-        <View style={s.page}>
-          <Image
-            source={FAMILY_PHOTO}
-            style={s.photoBg}
-            resizeMode="cover"
-          />
-          <LinearGradient
-            colors={[
-              'rgba(15,10,18,0.22)',
-              'rgba(15,10,18,0.30)',
-              'rgba(15,10,18,0.72)',
-            ]}
-            locations={[0, 0.30, 1]}
-            style={StyleSheet.absoluteFill}
-          />
-
-          {/* Glass CTA card — bottom anchored */}
-          <Animated.View
-            style={[
-              s.cardWrap,
-              { paddingBottom: insets.bottom + 36 },
-              page === 4 ? cardAnimStyle : null,
-            ]}
-          >
-            <BlurView
-              intensity={50}
-              tint="dark"
-              style={[s.card, s.finalCard]}
-            >
-              {/* Logo */}
-              <LinearGradient
-                colors={['#D4944A', '#E87461']}
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 1 }}
-                style={s.finalLogoBox}
-              >
-                <Text style={s.finalLogoLetter}>S</Text>
-              </LinearGradient>
-
-              {/* Headline */}
-              <Text style={s.finalTitle}>
-  {'From chaos.\n'}
-  <Text style={s.finalAccent}>To calm.</Text>
-</Text>
-
-<Text style={s.finalSub}>
-  The two things every parent needs — exactly when you need them.
-</Text>
-
-              {/* Feature list */}
-              <View style={s.finalFeats}>
-                {[
-                 { icon: '⚡', title: 'Hard moment scripts',   sub: 'Free · Always' },
-{ icon: '💭', title: 'Ask Sturdy anything',   sub: 'Free · Always' },
-{ icon: '👶', title: 'Adapts to your child',  sub: 'Free · Always' },
-                ].map((f, i) => (
-                  <View key={i} style={s.finalFeat}>
-                    <Text style={s.finalFeatIcon}>{f.icon}</Text>
-                    <View style={s.finalFeatInfo}>
-                      <Text style={s.finalFeatTitle}>{f.title}</Text>
-                      <Text style={s.finalFeatSub}>{f.sub}</Text>
-                    </View>
-                    <Text style={s.check}>✓</Text>
-                  </View>
-                ))}
-              </View>
-
-              {/* Get started */}
-              <Pressable
-                onPress={handleGetStarted}
-                style={({ pressed }) => [{ opacity: pressed ? 0.88 : 1, width: '100%' }]}
-              >
-                <LinearGradient
-                  colors={['#C8883A', '#E8A855']}
-                  start={{ x: 0, y: 0 }}
-                  end={{ x: 1, y: 0 }}
-                  style={s.btnPrimary}
-                >
-                  <Text style={s.btnPrimaryText}>Get started</Text>
-                </LinearGradient>
-              </Pressable>
-
-              {/* Try without account */}
-              <Pressable
-                style={({ pressed }) => [s.btnSecondary, { opacity: pressed ? 0.7 : 1 }]}
-                onPress={handleTryWithout}
-              >
-                <Text style={s.btnSecondaryText}>Try it without an account</Text>
-              </Pressable>
-
-              {/* Sign in */}
-              <View style={s.signInRow}>
-                <Text style={s.signInGrey}>Already with us? </Text>
-                <Pressable onPress={handleSignIn} hitSlop={8}>
-                  <Text style={s.signInLink}>Sign in</Text>
-                </Pressable>
-              </View>
-            </BlurView>
-          </Animated.View>
+          <Animated.Text style={[s.subtext, { opacity: subtextOpacity }]}>
+            {SUBTEXT}
+          </Animated.Text>
         </View>
-      </ScrollView>
+
+        <Animated.View style={[s.ctaBlock, { opacity: ctaOpacity }]}>
+          <Pressable
+            onPress={onTryNow}
+            style={({ pressed }) => [s.cta, pressed && s.ctaPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Try it now — free"
+          >
+            <Text style={s.ctaText}>Try it now — free</Text>
+          </Pressable>
+
+          <Pressable
+            onPress={onSignIn}
+            style={s.linkBtn}
+            accessibilityRole="button"
+            accessibilityLabel="I already have an account, sign in"
+          >
+            <Text style={s.link}>I already have an account → Sign in</Text>
+          </Pressable>
+        </Animated.View>
+      </SafeAreaView>
     </View>
   );
 }
 
-// ─── Styles ───────────────────────────────────────────────────────────────────
-
 const s = StyleSheet.create({
-  root: {
-    flex:            1,
-    backgroundColor: '#0E0A12',
-  },
+  root: { flex: 1, backgroundColor: C.background },
+  safe: { flex: 1, paddingHorizontal: 24 },
 
-page: {
-    width:          W,
-    height:         H,
+  center: {
+    flex: 1,
     justifyContent: 'center',
-    alignItems:     'stretch',
-  },
-
-  photoBg: {
-    position: 'absolute',
-    top:      0,
-    left:     0,
-    width:    W,
-    height:   H,
-  },
-
-  // ── Skip ────────────────────────────────────────────────────────────────────
-
-  skipBtn: {
-    position: 'absolute',
-    right:    24,
-    zIndex:   50,
-    padding:  8,
-  },
-
-  skipText: {
-    fontFamily: F.body,
-    fontSize:   14,
-    color:      'rgba(255,255,255,0.75)',
-    letterSpacing: 0.5,
-  },
-
-  // ── Splash ──────────────────────────────────────────────────────────────────
-
-  splashContent: {
-    position:        'absolute',
-    top:             0,
-    left:            0,
-    right:           0,
-    alignItems:      'center',
-    paddingHorizontal: 32,
-  },
-
-  logoBox: {
-    width:          60,
-    height:         60,
-    borderRadius:   17,
-    alignItems:     'center',
-    justifyContent: 'center',
-    marginBottom:   12,
-    shadowColor:    '#D4944A',
-    shadowOffset:   { width: 0, height: 8 },
-    shadowOpacity:  0.55,
-    shadowRadius:   20,
-    elevation:      12,
-  },
-
-  logoLetter: {
-    fontFamily:    F.heading,
-    fontSize:      28,
-    color:         '#FFFFFF',
-    letterSpacing: -1,
-  },
-
-  splashName: {
-    fontFamily:       F.heading,
-    fontSize:         32,
-    color:            '#FFFFFF',
-    letterSpacing:    0.5,
-    marginBottom:     8,
-    textShadowColor:  'rgba(0,0,0,0.5)',
-    textShadowOffset: { width: 0, height: 2 },
-    textShadowRadius: 12,
-  },
-
-  splashTagline: {
-    fontFamily:       F.body,
-    fontSize:         14,
-    color:            'rgba(255,255,255,0.88)',
-    letterSpacing:    0.3,
-    textAlign:        'center',
-    textShadowColor:  'rgba(0,0,0,0.6)',
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 8,
-  },
-
-  // ── Page dots ───────────────────────────────────────────────────────────────
-
-  dotsRow: {
-    position:        'absolute',
-    left:            0,
-    right:           0,
-    flexDirection:   'row',
-    justifyContent:  'center',
-    alignItems:      'center',
-    gap:             6,
-    zIndex:          10,
-  },
-
-  dot: {
-    width:           6,
-    height:          6,
-    borderRadius:    3,
-    backgroundColor: 'rgba(255,255,255,0.30)',
-  },
-
-  dotActive: {
-    width:           18,
-    backgroundColor: '#E8A855',
-  },
-
-  // ── Card wrapper (bottom-anchored) ──────────────────────────────────────────
-cardWrap: {
-    alignSelf:         'stretch',
-    paddingHorizontal: 20,
-    paddingVertical:   20,
-  },
-
-  card: {
-    borderRadius:  24,
-    overflow:      'hidden',
-    padding:       22,
-    borderWidth:   1,
-    borderColor:   'rgba(255,255,255,0.14)',
-  },
-
-  // ── Feature slide card content ───────────────────────────────────────────────
-
-  badge: {
-    alignSelf:       'flex-start',
-    paddingHorizontal: 12,
-    paddingVertical: 5,
-    borderRadius:    20,
-    marginBottom:    12,
-  },
-
-  badgeText: {
-    fontFamily:    F.label,
-    fontSize:      10,
-    letterSpacing: 1.4,
-  },
-
-  featTitle: {
-    fontFamily:       F.heading,
-    fontSize:         26,
-    color:            '#FFFFFF',
-    lineHeight:       32,
-    letterSpacing:    -0.4,
-    marginBottom:     10,
-    textShadowColor:  'rgba(0,0,0,0.4)',
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 8,
-  },
-
-  featAccent: {
-    fontFamily: F.heading,
-    fontSize:   26,
-    lineHeight: 32,
-  },
-
-  featDesc: {
-    fontFamily:    F.body,
-    fontSize:      14,
-    color:         'rgba(255,255,255,0.78)',
-    lineHeight:    21,
-    marginBottom:  12,
-  },
-
-  itemList: {
-    gap: 7,
-  },
-
-  item: {
-    flexDirection:   'row',
-    alignItems:      'center',
-    gap:             11,
-    paddingHorizontal: 13,
-    paddingVertical: 9,
-    borderRadius:    11,
-    backgroundColor: 'rgba(255,255,255,0.08)',
-    borderWidth:     1,
-    borderColor:     'rgba(255,255,255,0.08)',
-  },
-
-  itemIcon: {
-    fontSize:   14,
-    lineHeight: 18,
-  },
-
-  itemText: {
-    fontFamily: F.bodyMedium,
-    fontSize:   13,
-    color:      'rgba(255,255,255,0.92)',
-    lineHeight: 18,
-    flex:       1,
-  },
-
-  // ── Final CTA card ──────────────────────────────────────────────────────────
-
-  finalCard: {
     alignItems: 'center',
   },
 
-  finalLogoBox: {
-    width:          52,
-    height:         52,
-    borderRadius:   15,
-    alignItems:     'center',
-    justifyContent: 'center',
-    marginBottom:   10,
-    shadowColor:    '#D4944A',
-    shadowOffset:   { width: 0, height: 6 },
-    shadowOpacity:  0.50,
-    shadowRadius:   16,
-    elevation:      10,
+  heroBlock: {
+    alignItems: 'center',
+    gap: 4,
+    marginBottom: 36,
+  },
+  heroLine: {
+    fontFamily: F.heading,
+    fontSize: 32,
+    lineHeight: 40,
+    color: C.text,
+    textAlign: 'center',
+    letterSpacing: -0.4,
   },
 
-  finalLogoLetter: {
-    fontFamily:    F.heading,
-    fontSize:      24,
-    color:         '#FFFFFF',
-    letterSpacing: -1,
-  },
-
-  finalTitle: {
-    fontFamily:       F.heading,
-    fontSize:         22,
-    color:            '#FFFFFF',
-    textAlign:        'center',
-    lineHeight:       28,
-    letterSpacing:    -0.3,
-    marginBottom:     6,
-    textShadowColor:  'rgba(0,0,0,0.4)',
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 8,
-  },
-
-  finalAccent: {
-    color: '#E8A855',
-  },
-
-  finalSub: {
-    fontFamily:    F.body,
-    fontSize:      13,
-    color:         'rgba(255,255,255,0.72)',
-    textAlign:     'center',
-    lineHeight:    19,
-    marginBottom:  12,
-  },
-
-  finalFeats: {
-    width:         '100%',
-    gap:           6,
-    marginBottom:  14,
-  },
-
-  finalFeat: {
-    flexDirection:   'row',
-    alignItems:      'center',
-    gap:             10,
-    paddingHorizontal: 12,
-    paddingVertical: 9,
-    borderRadius:    11,
-    backgroundColor: 'rgba(255,255,255,0.08)',
-    borderWidth:     1,
-    borderColor:     'rgba(255,255,255,0.08)',
-  },
-
-  finalFeatIcon: {
-    fontSize:   16,
-    lineHeight: 20,
-  },
-
-  finalFeatInfo: {
-    flex: 1,
-  },
-
-  finalFeatTitle: {
-    fontFamily: F.bodySemi,
-    fontSize:   13,
-    color:      '#FFFFFF',
-  },
-
-  finalFeatSub: {
+  subtext: {
     fontFamily: F.body,
-    fontSize:   11,
-    color:      'rgba(255,255,255,0.50)',
-    marginTop:  1,
+    fontSize: 16,
+    lineHeight: 24,
+    color: C.textSecondary,
+    textAlign: 'center',
   },
 
-  check: {
-    fontSize:   13,
-    color:      '#A0C880',
-    fontWeight: '700',
+  ctaBlock: {
+    paddingBottom: 32,
+    gap: 16,
+    alignItems: 'center',
   },
-
-  // ── Buttons ─────────────────────────────────────────────────────────────────
-
-  btnPrimary: {
-    width:           '100%',
-    paddingVertical: 15,
-    borderRadius:    14,
-    alignItems:      'center',
-    marginBottom:    10,
-    shadowColor:     '#D4944A',
-    shadowOffset:    { width: 0, height: 8 },
-    shadowOpacity:   0.55,
-    shadowRadius:    20,
-    elevation:       12,
+  cta: {
+    backgroundColor: C.amber,
+    borderRadius: 14,
+    paddingVertical: 16,
+    width: '100%',
+    alignItems: 'center',
   },
-
-  btnPrimaryText: {
-    fontFamily:    F.heading,
-    fontSize:      15,
-    color:         '#FFFFFF',
+  ctaPressed: { opacity: 0.85 },
+  ctaText: {
+    fontFamily: F.bodySemi,
+    fontSize: 17,
+    color: C.textInverse,
     letterSpacing: 0.3,
   },
-
-  btnSecondary: {
-    width:           '100%',
-    paddingVertical: 13,
-    borderRadius:    12,
-    borderWidth:     1,
-    borderColor:     'rgba(255,255,255,0.22)',
-    backgroundColor: 'rgba(255,255,255,0.08)',
-    alignItems:      'center',
-    marginBottom:    10,
-  },
-
-  btnSecondaryText: {
+  linkBtn: { paddingVertical: 8 },
+  link: {
     fontFamily: F.body,
-    fontSize:   13,
-    color:      'rgba(255,255,255,0.88)',
-  },
-
-  signInRow: {
-    flexDirection:  'row',
-    alignItems:     'center',
-    justifyContent: 'center',
-  },
-
-  signInGrey: {
-    fontFamily: F.body,
-    fontSize:   12,
-    color:      'rgba(255,255,255,0.50)',
-  },
-
-  signInLink: {
-    fontFamily:          F.bodySemi,
-    fontSize:            12,
-    color:               '#E8A855',
-    textDecorationLine:  'underline',
-    textDecorationColor: '#E8A855',
+    fontSize: 14,
+    color: C.textMuted,
   },
 });

--- a/apps/mobile/app/welcome/signup.tsx
+++ b/apps/mobile/app/welcome/signup.tsx
@@ -1,0 +1,338 @@
+// app/welcome/signup.tsx
+// Onboarding Screen 5 — "Create Account".
+// Email + password → Supabase auth → optional child_profiles insert →
+// markOnboardingComplete → /(tabs).
+//
+// Apple/Google buttons are placeholder — render the layout the spec calls
+// for, but disabled with an explanatory tooltip until those flows are
+// wired (separate work).
+
+import { useEffect, useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import { router } from 'expo-router';
+import { colors as C, fonts as F } from '../../src/theme/colors';
+import { ProgressDots } from '../../src/components/welcome/ProgressDots';
+import { useAuth } from '../../src/context/AuthContext';
+import { useOnboarding } from '../../src/context/OnboardingContext';
+import { supabase } from '../../src/lib/supabase';
+import { markOnboardingComplete } from '../../src/utils/onboarding';
+import { track } from '../../src/utils/analytics';
+
+function ageToBand(age: number): '2-4' | '5-7' | '8-12' {
+  if (age <= 4) return '2-4';
+  if (age <= 7) return '5-7';
+  return '8-12';
+}
+
+export default function WelcomeSignup() {
+  const { signUpWithEmail } = useAuth();
+  const { childSetup, reset } = useOnboarding();
+
+  const [email, setEmail]       = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading]   = useState(false);
+  const [error, setError]       = useState<string | null>(null);
+
+  useEffect(() => {
+    track('onboarding_screen_viewed', { screen: 5 });
+  }, []);
+
+  const canSubmit = email.trim().length > 3 && password.length >= 6 && !loading;
+
+  async function onCreate() {
+    if (!canSubmit) return;
+    setError(null);
+    setLoading(true);
+
+    try {
+      const { session } = await signUpWithEmail(email.trim(), password);
+
+      // Some Supabase configurations require email confirmation before a
+      // session is issued. We can still complete onboarding locally — the
+      // user just needs to confirm and sign back in.
+      const userId = session?.user?.id ?? (await supabase.auth.getUser()).data.user?.id ?? null;
+
+      // If the user gave us child setup data, persist it now.
+      if (userId && childSetup && typeof childSetup.childAge === 'number') {
+        const { error: insertErr } = await supabase
+          .from('child_profiles')
+          .insert({
+            user_id:    userId,
+            name:       childSetup.name ?? null,
+            age_band:   ageToBand(childSetup.childAge),
+            child_age:  childSetup.childAge,
+            preferences: childSetup.challenges?.length
+              ? { challenges: childSetup.challenges }
+              : {},
+          });
+        if (insertErr) {
+          // Don't block the user from getting into the app — log + continue.
+          // The dashboard will prompt them to add a child profile.
+          console.warn('[signup] child_profiles insert failed:', insertErr.message);
+        }
+      }
+
+      await markOnboardingComplete();
+      track('onboarding_signup_completed', { method: 'email' });
+      reset();
+      router.replace('/(tabs)');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not create account.';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function onSignInLink() {
+    track('onboarding_screen_dropped', { screen: 5, action: 'sign_in' });
+    router.push('/auth/sign-in');
+  }
+
+  return (
+    <View style={s.root}>
+      <LinearGradient
+        colors={[C.gradientTop, C.gradientBottom]}
+        style={StyleSheet.absoluteFillObject}
+      />
+      <SafeAreaView style={s.safe}>
+        <StatusBar style="light" />
+        <ProgressDots step={5} />
+
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={s.kav}
+        >
+          <ScrollView
+            contentContainerStyle={s.scroll}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <Text style={s.h1}>Save your scripts.{'\n'}Build your child's profile.</Text>
+            <Text style={s.sub}>Free forever · No credit card needed</Text>
+
+            <View style={s.card}>
+              <Text style={s.label}>Email</Text>
+              <TextInput
+                style={s.input}
+                value={email}
+                onChangeText={setEmail}
+                placeholder="you@example.com"
+                placeholderTextColor={C.textMuted}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoComplete="email"
+                editable={!loading}
+                returnKeyType="next"
+              />
+
+              <Text style={s.label}>Password</Text>
+              <TextInput
+                style={s.input}
+                value={password}
+                onChangeText={setPassword}
+                placeholder="At least 6 characters"
+                placeholderTextColor={C.textMuted}
+                secureTextEntry
+                autoComplete="password-new"
+                editable={!loading}
+                returnKeyType="go"
+                onSubmitEditing={onCreate}
+              />
+            </View>
+
+            {error ? (
+              <View style={s.errorBox}>
+                <Text style={s.errorText}>{error}</Text>
+              </View>
+            ) : null}
+
+            <Pressable
+              onPress={onCreate}
+              disabled={!canSubmit}
+              style={({ pressed }) => [
+                s.cta,
+                !canSubmit && s.ctaDisabled,
+                pressed && canSubmit && s.ctaPressed,
+              ]}
+              accessibilityRole="button"
+            >
+              <Text style={s.ctaText}>
+                {loading ? 'Creating your account…' : 'Create my free account'}
+              </Text>
+            </Pressable>
+
+            <View style={s.dividerRow}>
+              <View style={s.dividerLine} />
+              <Text style={s.dividerText}>or</Text>
+              <View style={s.dividerLine} />
+            </View>
+
+            <Pressable
+              style={[s.socialBtn, s.socialDisabled]}
+              disabled
+              accessibilityRole="button"
+              accessibilityLabel="Continue with Apple — not yet available"
+            >
+              <Text style={s.socialText}>Continue with Apple</Text>
+              <Text style={s.soonPill}>SOON</Text>
+            </Pressable>
+            <Pressable
+              style={[s.socialBtn, s.socialDisabled]}
+              disabled
+              accessibilityRole="button"
+              accessibilityLabel="Continue with Google — not yet available"
+            >
+              <Text style={s.socialText}>Continue with Google</Text>
+              <Text style={s.soonPill}>SOON</Text>
+            </Pressable>
+
+            <View style={s.bottomRow}>
+              <Text style={s.bottomText}>Already have an account?</Text>
+              <Pressable onPress={onSignInLink} style={s.linkBtn} disabled={loading}>
+                <Text style={s.link}>Sign in</Text>
+              </Pressable>
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  root: { flex: 1, backgroundColor: C.background },
+  safe: { flex: 1, paddingHorizontal: 20 },
+  kav:  { flex: 1 },
+  scroll: { paddingTop: 16, paddingBottom: 24, gap: 16 },
+
+  h1: {
+    fontFamily: F.heading,
+    fontSize: 26,
+    lineHeight: 32,
+    color: C.text,
+    letterSpacing: -0.3,
+  },
+  sub: {
+    fontFamily: F.body,
+    fontSize: 14,
+    lineHeight: 22,
+    color: C.amber,
+  },
+
+  card: {
+    backgroundColor: C.surface,
+    borderColor:     C.border,
+    borderWidth: 1,
+    borderRadius: 20,
+    padding: 16,
+    gap: 14,
+  },
+
+  label: {
+    fontFamily: F.label,
+    fontSize: 11,
+    letterSpacing: 0.8,
+    color: C.textMuted,
+    textTransform: 'uppercase',
+  },
+
+  input: {
+    backgroundColor: C.inputBg,
+    borderColor:     C.inputBorder,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontFamily: F.body,
+    fontSize: 16,
+    color: C.text,
+  },
+
+  errorBox: {
+    backgroundColor: C.sosLight,
+    borderColor:     C.sos,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+  },
+  errorText: { fontFamily: F.bodySemi, fontSize: 14, color: C.sos },
+
+  cta: {
+    backgroundColor: C.amber,
+    borderRadius: 14,
+    paddingVertical: 16,
+    width: '100%',
+    alignItems: 'center',
+  },
+  ctaPressed:  { opacity: 0.85 },
+  ctaDisabled: { backgroundColor: C.disabled },
+  ctaText: {
+    fontFamily: F.bodySemi,
+    fontSize: 17,
+    color: C.textInverse,
+    letterSpacing: 0.3,
+  },
+
+  dividerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 4,
+  },
+  dividerLine: { flex: 1, height: 1, backgroundColor: C.divider },
+  dividerText: {
+    fontFamily: F.body,
+    fontSize: 12,
+    color: C.textMuted,
+    textTransform: 'lowercase',
+  },
+
+  socialBtn: {
+    backgroundColor: C.surfaceRaised,
+    borderColor:     C.border,
+    borderWidth: 1,
+    borderRadius: 14,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  socialDisabled: { opacity: 0.55 },
+  socialText: { fontFamily: F.bodySemi, fontSize: 15, color: C.text },
+  soonPill: {
+    fontFamily: F.label,
+    fontSize: 9,
+    letterSpacing: 0.8,
+    color: C.amber,
+    backgroundColor: C.amberLight,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 999,
+    overflow: 'hidden',
+  },
+
+  bottomRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    marginTop: 8,
+  },
+  bottomText: { fontFamily: F.body, fontSize: 14, color: C.textMuted },
+  linkBtn:    { paddingVertical: 6 },
+  link:       { fontFamily: F.bodySemi, fontSize: 14, color: C.amber },
+});

--- a/apps/mobile/app/welcome/trial-result.tsx
+++ b/apps/mobile/app/welcome/trial-result.tsx
@@ -1,0 +1,259 @@
+// app/welcome/trial-result.tsx
+// Onboarding Screen 3 — "The Magic Moment".
+// Shows the Regulate step in full; blurs Connect + Guide using BlurView
+// (the parent SEES there's more, but can't read it — creates desire).
+// Pitch text below ties what they just experienced to personalisation.
+
+import { useEffect } from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { BlurView } from 'expo-blur';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import { router } from 'expo-router';
+import { colors as C, fonts as F } from '../../src/theme/colors';
+import { ProgressDots } from '../../src/components/welcome/ProgressDots';
+import { useOnboarding } from '../../src/context/OnboardingContext';
+import { track } from '../../src/utils/analytics';
+
+export default function WelcomeTrialResult() {
+  const { trialResult, setTrialInput, setTrialResult } = useOnboarding();
+
+  useEffect(() => {
+    track('onboarding_screen_viewed', { screen: 3 });
+    track('onboarding_trial_result_viewed', {});
+  }, []);
+
+  // If user lands here directly without trial data, route back to /welcome.
+  useEffect(() => {
+    if (!trialResult) {
+      router.replace('/welcome');
+    }
+  }, [trialResult]);
+
+  if (!trialResult) return null;
+
+  const { situation_summary, regulate, connect, guide } = trialResult;
+
+  function onMakeItPersonal() {
+    track('onboarding_screen_dropped', { screen: 3, action: 'make_it_personal' });
+    router.push('/welcome/child-setup');
+  }
+
+  function onTryAnother() {
+    track('onboarding_screen_dropped', { screen: 3, action: 'try_another' });
+    setTrialInput(null);
+    setTrialResult(null);
+    router.replace('/welcome/trial');
+  }
+
+  function onSignIn() {
+    track('onboarding_screen_dropped', { screen: 3, action: 'sign_in' });
+    router.push('/auth/sign-in');
+  }
+
+  return (
+    <View style={s.root}>
+      <LinearGradient
+        colors={[C.gradientTop, C.gradientBottom]}
+        style={StyleSheet.absoluteFillObject}
+      />
+      <SafeAreaView style={s.safe}>
+        <StatusBar style="light" />
+        <ProgressDots step={3} />
+
+        <ScrollView
+          contentContainerStyle={s.scroll}
+          showsVerticalScrollIndicator={false}
+        >
+          <Text style={s.summary}>“{situation_summary}”</Text>
+
+          {/* Card 1 — REGULATE (fully visible, primary border accent) */}
+          <View style={[s.stepCard, s.stepCardActive]}>
+            <View style={[s.stepAccent, { backgroundColor: C.sos }]} />
+            <View style={s.stepBody}>
+              <Text style={s.stepLabel}>STEP 1 · REGULATE</Text>
+              <Text style={s.parentAction}>{regulate.parent_action}</Text>
+              <Text style={s.scriptText}>“{regulate.script}”</Text>
+            </View>
+          </View>
+
+          {/* Card 2 — CONNECT (blurred) */}
+          <BlurredStepCard
+            label="STEP 2 · CONNECT"
+            parentAction={connect.parent_action}
+            scriptText={connect.script}
+          />
+
+          {/* Card 3 — GUIDE (blurred) */}
+          <BlurredStepCard
+            label="STEP 3 · GUIDE"
+            parentAction={guide.parent_action}
+            scriptText={guide.script}
+          />
+
+          <Text style={s.pitch}>
+            That's one script. Sturdy builds hundreds —{'\n'}
+            each one matched to your child's age,{'\n'}
+            personality, and the moment you're in.
+          </Text>
+        </ScrollView>
+
+        <View style={s.ctaBlock}>
+          <Pressable
+            onPress={onMakeItPersonal}
+            style={({ pressed }) => [s.cta, pressed && s.ctaPressed]}
+            accessibilityRole="button"
+          >
+            <Text style={s.ctaText}>Make it personal — it's free</Text>
+          </Pressable>
+
+          <View style={s.linkRow}>
+            <Pressable onPress={onTryAnother} style={s.linkBtn}>
+              <Text style={s.link}>Try another scenario</Text>
+            </Pressable>
+            <Text style={s.linkSep}>·</Text>
+            <Pressable onPress={onSignIn} style={s.linkBtn}>
+              <Text style={s.link}>Sign in</Text>
+            </Pressable>
+          </View>
+        </View>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+function BlurredStepCard({
+  label, parentAction, scriptText,
+}: { label: string; parentAction: string; scriptText: string }) {
+  return (
+    <View style={s.stepCard}>
+      <View style={s.stepBody}>
+        <Text style={[s.stepLabel, s.stepLabelMuted]}>{label}</Text>
+        <Text style={s.parentAction}>{parentAction}</Text>
+        <Text style={s.scriptText}>“{scriptText}”</Text>
+      </View>
+      <BlurView intensity={28} tint="dark" style={[StyleSheet.absoluteFill, s.blurOverlay]}>
+        <View style={s.lockChip}>
+          <Text style={s.lockEmoji}>🔒</Text>
+        </View>
+      </BlurView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  root: { flex: 1, backgroundColor: C.background },
+  safe: { flex: 1, paddingHorizontal: 20 },
+  scroll: { paddingTop: 8, paddingBottom: 20, gap: 16 },
+
+  summary: {
+    fontFamily: F.headingItalic,
+    fontSize: 18,
+    lineHeight: 26,
+    color: C.amber,
+    textAlign: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+  },
+
+  stepCard: {
+    backgroundColor: C.surface,
+    borderColor:     C.border,
+    borderWidth: 1,
+    borderRadius: 20,
+    overflow: 'hidden',
+    flexDirection: 'row',
+    minHeight: 140,
+  },
+  stepCardActive: {
+    // Subtle SOS accent on the regulate card edge.
+    borderColor: 'rgba(232,116,97,0.20)',
+  },
+  stepAccent: {
+    width: 4,
+  },
+  stepBody: {
+    flex: 1,
+    padding: 16,
+    gap: 8,
+  },
+
+  stepLabel: {
+    fontFamily: F.label,
+    fontSize: 11,
+    letterSpacing: 0.8,
+    color: C.amber,
+    textTransform: 'uppercase',
+  },
+  stepLabelMuted: { color: C.textMuted },
+
+  parentAction: {
+    fontFamily: F.body,
+    fontSize: 13,
+    lineHeight: 20,
+    color: C.textSecondary,
+    fontStyle: 'italic',
+  },
+
+  scriptText: {
+    fontFamily: F.script,
+    fontSize: 18,
+    lineHeight: 28,
+    color: C.text,
+    marginTop: 4,
+  },
+
+  blurOverlay: {
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  lockChip: {
+    width: 44,
+    height: 44,
+    borderRadius: 999,
+    backgroundColor: 'rgba(20,17,14,0.7)',
+    borderColor: C.borderHi,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  lockEmoji: { fontSize: 18 },
+
+  pitch: {
+    fontFamily: F.body,
+    fontSize: 14,
+    lineHeight: 22,
+    color: C.textSecondary,
+    textAlign: 'center',
+    marginTop: 8,
+    paddingHorizontal: 12,
+  },
+
+  ctaBlock: { paddingBottom: 12, gap: 12, alignItems: 'center' },
+  cta: {
+    backgroundColor: C.amber,
+    borderRadius: 14,
+    paddingVertical: 16,
+    width: '100%',
+    alignItems: 'center',
+  },
+  ctaPressed: { opacity: 0.85 },
+  ctaText: {
+    fontFamily: F.bodySemi,
+    fontSize: 17,
+    color: C.textInverse,
+    letterSpacing: 0.3,
+  },
+  linkRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  linkBtn: { paddingVertical: 8 },
+  link: { fontFamily: F.body, fontSize: 14, color: C.textMuted },
+  linkSep: { color: C.textFaint, fontSize: 14 },
+});

--- a/apps/mobile/app/welcome/trial.tsx
+++ b/apps/mobile/app/welcome/trial.tsx
@@ -1,0 +1,355 @@
+// app/welcome/trial.tsx
+// Onboarding Screen 2 — "Live Trial".
+// The parent describes a moment, picks an age + intensity, and we hit
+// the existing edge function in trial mode (no userId → no logging,
+// no profile attachment). On success → /welcome/trial-result with the
+// payload stashed in OnboardingContext. Crisis path → /crisis.
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  Animated,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StatusBar } from 'expo-status-bar';
+import { router } from 'expo-router';
+import { colors as C, fonts as F } from '../../src/theme/colors';
+import { ProgressDots } from '../../src/components/welcome/ProgressDots';
+import { useOnboarding } from '../../src/context/OnboardingContext';
+import { CrisisDetectedError, getParentingScript } from '../../src/lib/api';
+import { track } from '../../src/utils/analytics';
+
+const AGES = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
+type Intensity = 'Mild' | 'Heated' | 'Crisis';
+const INTENSITIES: Intensity[] = ['Mild', 'Heated', 'Crisis'];
+const INTENSITY_VALUE: Record<Intensity, 1 | 3 | 5> = {
+  Mild:   1,
+  Heated: 3,
+  Crisis: 5,
+};
+
+export default function WelcomeTrial() {
+  const { trialInput, setTrialInput, setTrialResult } = useOnboarding();
+  const [situation, setSituation]   = useState(trialInput?.situation ?? '');
+  const [age, setAge]               = useState<number>(trialInput?.childAge ?? 5);
+  const [intensity, setIntensity]   = useState<Intensity>(trialInput?.intensityLabel ?? 'Heated');
+  const [loading, setLoading]       = useState(false);
+  const [error, setError]           = useState<string | null>(null);
+  const startTime = useRef<number>(0);
+
+  // Subtle pulse on the loading button.
+  const pulse = useRef(new Animated.Value(1)).current;
+  useEffect(() => {
+    if (!loading) return;
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, { toValue: 0.7, duration: 700, useNativeDriver: true }),
+        Animated.timing(pulse, { toValue: 1.0, duration: 700, useNativeDriver: true }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [loading]);
+
+  useEffect(() => {
+    track('onboarding_screen_viewed', { screen: 2 });
+  }, []);
+
+  const canSubmit = situation.trim().length > 0 && !loading;
+
+  async function onSubmit() {
+    if (!canSubmit) return;
+    setError(null);
+    setLoading(true);
+    startTime.current = Date.now();
+
+    const intensityValue = INTENSITY_VALUE[intensity];
+    track('onboarding_trial_started', { age, intensity });
+
+    setTrialInput({
+      situation:      situation.trim(),
+      childAge:       age,
+      intensity:      intensityValue,
+      intensityLabel: intensity,
+    });
+
+    try {
+      const result = await getParentingScript({
+        childName: 'Your child',
+        childAge:  age,
+        message:   situation.trim(),
+        intensity: intensityValue,
+        mode:      'sos',
+      });
+      const duration = Date.now() - startTime.current;
+      track('onboarding_trial_completed', { age, duration_ms: duration });
+      setTrialResult(result);
+      router.push('/welcome/trial-result');
+    } catch (err) {
+      if (err instanceof CrisisDetectedError) {
+        // Safety route is always free — never block on onboarding.
+        track('onboarding_trial_failed', { reason: 'crisis', age });
+        router.push('/crisis');
+        return;
+      }
+      const message = err instanceof Error ? err.message : 'request-failed';
+      track('onboarding_trial_failed', { reason: message, age });
+      setError("Something went wrong. Try again?");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function onSkip() {
+    track('onboarding_screen_dropped', { screen: 2, action: 'skip' });
+    router.push('/welcome/signup');
+  }
+
+  return (
+    <View style={s.root}>
+      <LinearGradient
+        colors={[C.gradientTop, C.gradientBottom]}
+        style={StyleSheet.absoluteFillObject}
+      />
+      <SafeAreaView style={s.safe}>
+        <StatusBar style="light" />
+        <ProgressDots step={2} />
+
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={s.kav}
+        >
+          <ScrollView
+            contentContainerStyle={s.scroll}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            <Text style={s.h1}>What's happening{'\n'}right now?</Text>
+            <Text style={s.sub}>
+              Describe the moment. Sturdy will show you{'\n'}exactly what to say.
+            </Text>
+
+            <View style={s.card}>
+              <TextInput
+                style={s.input}
+                value={situation}
+                onChangeText={setSituation}
+                placeholder="They're screaming that homework is stupid and threw their pencil…"
+                placeholderTextColor={C.textMuted}
+                multiline
+                numberOfLines={4}
+                autoFocus
+                editable={!loading}
+                maxLength={1000}
+              />
+
+              <View style={s.divider} />
+
+              <Text style={s.label}>How old is your child?</Text>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={s.ageRow}
+              >
+                {AGES.map((a) => {
+                  const selected = a === age;
+                  return (
+                    <Pressable
+                      key={a}
+                      onPress={() => setAge(a)}
+                      style={[s.agePill, selected && s.agePillSelected]}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Age ${a}${selected ? ', selected' : ''}`}
+                    >
+                      <Text style={[s.agePillText, selected && s.agePillTextSelected]}>
+                        {a === 12 ? '12+' : a}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </ScrollView>
+
+              <View style={s.divider} />
+
+              <Text style={s.label}>How intense is this?</Text>
+              <View style={s.intensityRow}>
+                {INTENSITIES.map((opt) => {
+                  const selected = opt === intensity;
+                  return (
+                    <Pressable
+                      key={opt}
+                      onPress={() => setIntensity(opt)}
+                      style={[s.intensityPill, selected && s.intensityPillSelected]}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Intensity ${opt}${selected ? ', selected' : ''}`}
+                    >
+                      <Text style={[s.intensityPillText, selected && s.intensityPillTextSelected]}>
+                        {opt}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+
+            {error ? (
+              <View style={s.errorBox}>
+                <Text style={s.errorText}>{error}</Text>
+              </View>
+            ) : null}
+          </ScrollView>
+
+          <View style={s.ctaBlock}>
+            <Pressable
+              onPress={onSubmit}
+              disabled={!canSubmit}
+              style={({ pressed }) => [
+                s.cta,
+                !canSubmit && s.ctaDisabled,
+                pressed && canSubmit && s.ctaPressed,
+              ]}
+              accessibilityRole="button"
+            >
+              <Animated.Text style={[s.ctaText, loading && { opacity: pulse }]}>
+                {loading ? 'Finding the right words…' : 'Get my script →'}
+              </Animated.Text>
+            </Pressable>
+
+            <Pressable onPress={onSkip} style={s.linkBtn} disabled={loading}>
+              <Text style={s.link}>Skip to sign up →</Text>
+            </Pressable>
+          </View>
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  root: { flex: 1, backgroundColor: C.background },
+  safe: { flex: 1, paddingHorizontal: 20 },
+  kav:  { flex: 1 },
+  scroll: { paddingTop: 16, paddingBottom: 16, gap: 16 },
+
+  h1: {
+    fontFamily: F.heading,
+    fontSize: 28,
+    lineHeight: 34,
+    color: C.text,
+    letterSpacing: -0.3,
+  },
+  sub: {
+    fontFamily: F.body,
+    fontSize: 15,
+    lineHeight: 22,
+    color: C.textSecondary,
+  },
+
+  card: {
+    backgroundColor: C.surface,
+    borderColor:     C.border,
+    borderWidth: 1,
+    borderRadius: 20,
+    padding: 16,
+    gap: 14,
+  },
+  input: {
+    fontFamily: F.body,
+    fontSize: 16,
+    lineHeight: 24,
+    color: C.text,
+    minHeight: 96,
+    textAlignVertical: 'top',
+    padding: 0,
+  },
+  divider: { height: 1, backgroundColor: C.divider },
+
+  label: {
+    fontFamily: F.label,
+    fontSize: 11,
+    letterSpacing: 0.8,
+    color: C.textMuted,
+    textTransform: 'uppercase',
+  },
+
+  ageRow: { gap: 8, paddingVertical: 4 },
+  agePill: {
+    minWidth: 40,
+    height: 40,
+    borderRadius: 12,
+    backgroundColor: C.chipBg,
+    borderColor:     C.chipBorder,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+  },
+  agePillSelected: {
+    backgroundColor: C.amberLight,
+    borderColor:     C.amber,
+  },
+  agePillText: {
+    fontFamily: F.bodySemi,
+    fontSize: 16,
+    color: C.textSecondary,
+  },
+  agePillTextSelected: { color: C.amber },
+
+  intensityRow: { flexDirection: 'row', gap: 8 },
+  intensityPill: {
+    flex: 1,
+    height: 40,
+    borderRadius: 12,
+    backgroundColor: C.chipBg,
+    borderColor:     C.chipBorder,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  intensityPillSelected: {
+    backgroundColor: C.amberLight,
+    borderColor:     C.amber,
+  },
+  intensityPillText: {
+    fontFamily: F.bodySemi,
+    fontSize: 14,
+    color: C.textSecondary,
+  },
+  intensityPillTextSelected: { color: C.amber },
+
+  errorBox: {
+    backgroundColor: C.sosLight,
+    borderColor:     C.sos,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+  },
+  errorText: { fontFamily: F.bodySemi, fontSize: 14, color: C.sos },
+
+  ctaBlock: { paddingBottom: 12, gap: 10, alignItems: 'center' },
+  cta: {
+    backgroundColor: C.amber,
+    borderRadius: 14,
+    paddingVertical: 16,
+    width: '100%',
+    alignItems: 'center',
+  },
+  ctaPressed:  { opacity: 0.85 },
+  ctaDisabled: { backgroundColor: C.disabled },
+  ctaText: {
+    fontFamily: F.bodySemi,
+    fontSize: 17,
+    color: C.textInverse,
+    letterSpacing: 0.3,
+  },
+  linkBtn: { paddingVertical: 8 },
+  link: { fontFamily: F.body, fontSize: 14, color: C.textMuted },
+});

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@expo-google-fonts/cormorant-garamond": "^0.4.1",
         "@expo-google-fonts/crimson-pro": "^0.4.2",
+        "@expo-google-fonts/dm-sans": "^0.4.2",
+        "@expo-google-fonts/fraunces": "^0.4.1",
         "@expo-google-fonts/manrope": "^0.4.2",
         "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
         "@expo/metro-runtime": "~6.1.2",
@@ -1616,6 +1618,18 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@expo-google-fonts/crimson-pro/-/crimson-pro-0.4.2.tgz",
       "integrity": "sha512-X5pfxna/aQBhxB6CowczCL2mOsObwlxhI2EJ84fE6OMrxie1bd2ro9xBywCfeVg588eQYvzYBBdkHkPWmFTXug==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/dm-sans": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/dm-sans/-/dm-sans-0.4.2.tgz",
+      "integrity": "sha512-e/fLH5aCJzkEenz7axvEn8N7IJAKhUwNjIxS75h9j+Ip1M9S7d22M19gJN3A7QW4egVkBJRyQh1hQFhngQn9yA==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/fraunces": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/fraunces/-/fraunces-0.4.1.tgz",
+      "integrity": "sha512-gYc9P92ObyWvz1rWPOeWSvVKyBFIuA8hgOdhvo4DSiPBaWLbFA6v8uLIEIBwW+0oWTlXbBzjeBReHQI2H7UNjQ==",
       "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo-google-fonts/manrope": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@expo-google-fonts/cormorant-garamond": "^0.4.1",
     "@expo-google-fonts/crimson-pro": "^0.4.2",
+    "@expo-google-fonts/dm-sans": "^0.4.2",
+    "@expo-google-fonts/fraunces": "^0.4.1",
     "@expo-google-fonts/manrope": "^0.4.2",
     "@expo-google-fonts/plus-jakarta-sans": "^0.4.2",
     "@expo/metro-runtime": "~6.1.2",

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -1,15 +1,16 @@
 // src/components/ui/Card.tsx
-// v5 — Clean raised surface card
-// Replaces GlassCard — no gradient, no glow
-
+// v5 — Glass surface card on warm dark background.
+//
+// Re-exported as `GlassCard` (see ./GlassCard.tsx) — the names are
+// interchangeable. v5 design: rgba(255,255,255,0.045) fill, subtle
+// rgba(255,255,255,0.07) border, no top-edge highlight, 20px radius.
 
 import { type ReactNode } from 'react';
 import { Pressable, StyleSheet, View, type ViewStyle } from 'react-native';
 import { colors } from '../../theme/colors';
 
-
-type AccentColor = 'coral' | 'blue' | 'sage' | 'peach' | 'amber' | 'none';
-
+type AccentColor = 'primary' | 'amber' | 'steel' | 'sage' | 'sos'
+                 | 'coral' | 'blue' | 'peach' | 'none';
 
 type Props = {
   children: ReactNode;
@@ -18,20 +19,22 @@ type Props = {
   accent?: AccentColor;
 };
 
-
 const ACCENT_COLORS: Record<AccentColor, string | null> = {
-  coral: colors.coral,
-  blue:  colors.blue,
-  sage:  colors.sage,
-  peach: colors.peach,
-  amber: colors.amber,
-  none:  null,
+  // v5 names
+  primary: colors.primary,
+  amber:   colors.amber,
+  steel:   colors.steel,
+  sage:    colors.sage,
+  sos:     colors.sos,
+  // v4 aliases (still used by some screens)
+  coral:   colors.coral,   // == primary
+  blue:    colors.blue,    // == steel
+  peach:   colors.peach,   // == amber
+  none:    null,
 };
-
 
 export function Card({ children, style, onPress, accent = 'none' }: Props) {
   const accentColor = ACCENT_COLORS[accent];
-
 
   const cardStyle = [
     st.card,
@@ -41,7 +44,6 @@ export function Card({ children, style, onPress, accent = 'none' }: Props) {
     },
     style,
   ];
-
 
   if (onPress) {
     return (
@@ -58,21 +60,21 @@ export function Card({ children, style, onPress, accent = 'none' }: Props) {
     );
   }
 
-
   return <View style={cardStyle}>{children}</View>;
 }
 
-
 const st = StyleSheet.create({
   card: {
-    backgroundColor: colors.raised,
+    backgroundColor: colors.surface,
     borderRadius: 20,
     padding: 20,
     gap: 8,
     borderWidth: 1,
     borderColor: colors.border,
+    // NOTE: do NOT add borderTopWidth or borderTopColor here — it creates a
+    // visible highlight line at the top of every card on dark surfaces.
   },
   pressed: {
-    backgroundColor: colors.subtle,
+    backgroundColor: colors.surfaceRaised,
   },
 });

--- a/apps/mobile/src/components/ui/Screen.tsx
+++ b/apps/mobile/src/components/ui/Screen.tsx
@@ -1,6 +1,7 @@
 // src/components/ui/Screen.tsx
-// v5 — Clean dark base, no gradient, no stars
-
+// v5 — Warm dark gradient base. Children render over a LinearGradient
+// from colors.gradientTop → colors.gradientBottom (warm charcoal, NOT
+// the old plum night sky and NOT the cream linen).
 
 import { PropsWithChildren, ReactNode } from 'react';
 import {
@@ -10,17 +11,16 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaView, type Edge } from 'react-native-safe-area-context';
 import { colors } from '../../theme/colors';
-
 
 type ScreenProps = PropsWithChildren<{
   footer?: ReactNode;
   scrollable?: boolean;
   edges?: Edge[];
 }>;
-
 
 export function Screen({
   children,
@@ -41,9 +41,12 @@ export function Screen({
     <View style={styles.fixed}>{children}</View>
   );
 
-
   return (
     <View style={styles.root}>
+      <LinearGradient
+        colors={[colors.gradientTop, colors.gradientBottom]}
+        style={StyleSheet.absoluteFillObject}
+      />
       <SafeAreaView edges={edges} style={styles.safe}>
         <StatusBar style="light" />
         <KeyboardAvoidingView
@@ -58,11 +61,10 @@ export function Screen({
   );
 }
 
-
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: colors.base,
+    backgroundColor: colors.background,
   },
   safe: {
     flex: 1,
@@ -86,6 +88,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingTop: 10,
     paddingBottom: 16,
-    backgroundColor: colors.base,
+    backgroundColor: 'transparent',
   },
 });

--- a/apps/mobile/src/components/welcome/ProgressDots.tsx
+++ b/apps/mobile/src/components/welcome/ProgressDots.tsx
@@ -1,0 +1,53 @@
+// src/components/welcome/ProgressDots.tsx
+// 5 dots positioned at the top of every onboarding screen.
+// Active = amber 8px, inactive = white-15% 6px, 12px gap.
+// "This is short" — reduces drop-off.
+
+import { StyleSheet, View } from 'react-native';
+import { colors } from '../../theme/colors';
+
+type Props = {
+  step: 1 | 2 | 3 | 4 | 5;
+  total?: number;
+};
+
+export function ProgressDots({ step, total = 5 }: Props) {
+  return (
+    <View style={s.row} accessibilityLabel={`Step ${step} of ${total}`}>
+      {Array.from({ length: total }, (_, i) => {
+        const idx = i + 1;
+        const isActive = idx === step;
+        return (
+          <View
+            key={idx}
+            style={[s.dot, isActive ? s.active : s.inactive]}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
+  dot: {
+    borderRadius: 999,
+  },
+  active: {
+    width: 8,
+    height: 8,
+    backgroundColor: colors.amber,
+  },
+  inactive: {
+    width: 6,
+    height: 6,
+    backgroundColor: 'rgba(255,255,255,0.15)',
+  },
+});

--- a/apps/mobile/src/context/OnboardingContext.tsx
+++ b/apps/mobile/src/context/OnboardingContext.tsx
@@ -1,0 +1,62 @@
+// src/context/OnboardingContext.tsx
+// Holds trial + child-setup state across the welcome stack.
+// Lives only inside <WelcomeLayout> so it resets when the user leaves
+// the flow (signup completes → routed to /(tabs) → provider unmounts).
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react';
+import type { ParentingScriptResponse } from '../lib/api';
+
+export type TrialInput = {
+  situation: string;
+  childAge:  number;
+  intensity: 1 | 2 | 3 | 4 | 5;
+  intensityLabel: 'Mild' | 'Heated' | 'Crisis';
+};
+
+export type ChildSetup = {
+  name?:        string | null;
+  childAge?:    number | null;
+  challenges?:  string[];
+};
+
+type Ctx = {
+  trialInput:    TrialInput  | null;
+  trialResult:   ParentingScriptResponse | null;
+  childSetup:    ChildSetup  | null;
+
+  setTrialInput:  (v: TrialInput  | null) => void;
+  setTrialResult: (v: ParentingScriptResponse | null) => void;
+  setChildSetup:  (v: ChildSetup  | null) => void;
+  reset:          () => void;
+};
+
+const OnboardingContext = createContext<Ctx | null>(null);
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const [trialInput,  setTrialInput]  = useState<TrialInput  | null>(null);
+  const [trialResult, setTrialResult] = useState<ParentingScriptResponse | null>(null);
+  const [childSetup,  setChildSetup]  = useState<ChildSetup  | null>(null);
+
+  const reset = useCallback(() => {
+    setTrialInput(null);
+    setTrialResult(null);
+    setChildSetup(null);
+  }, []);
+
+  const value = useMemo<Ctx>(
+    () => ({
+      trialInput, trialResult, childSetup,
+      setTrialInput, setTrialResult, setChildSetup,
+      reset,
+    }),
+    [trialInput, trialResult, childSetup, reset],
+  );
+
+  return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>;
+}
+
+export function useOnboarding(): Ctx {
+  const ctx = useContext(OnboardingContext);
+  if (!ctx) throw new Error('useOnboarding must be used within an OnboardingProvider');
+  return ctx;
+}

--- a/apps/mobile/src/theme/colors.ts
+++ b/apps/mobile/src/theme/colors.ts
@@ -1,495 +1,220 @@
 // src/theme/colors.ts
-// Sturdy v7 — "Sunset" mature visual identity
+// Sturdy v5 — Logo-derived premium dark palette
 //
-// Time-aware automatic palette system. The background and surface
-// colors shift smoothly based on device time of day, creating the
-// "the app knows what time it is for me" feel.
+// Logo colors: Coral #FF5C75, Peach #F79566, Terra #DC785A, Steel #5778A3, Navy #484F6B
 //
-// 4 palettes:
-//   🌅 Sunrise     — 5am–9am   pale gold + soft peach (hopeful)
-//   ☀️ Daylight   — 9am–5pm   warm parchment (quiet daylight)
-//   🌇 Golden Hour — 5pm–9pm   burnt sienna + terracotta (exhale)
-//   🌃 Deep Dusk  — 9pm–5am   indigo + plum (intimate, weighted)
+// Design intent: warm dark base (NOT pure black, NOT blue-black). Glass surfaces
+// over a warm charcoal gradient. Premium-app-at-night feel — not bedtime/sleep,
+// not cold blue-black, not meditation.
+
+export const colors = {
+  // ═══════════════════════════════════════════════
+  // SURFACES
+  // ═══════════════════════════════════════════════
+  background:       '#1A1614',                       // warm dark base
+  backgroundDeep:   '#141110',                       // deeper variant for gradients
+  surface:          'rgba(255,255,255,0.045)',       // glass card fill
+  surfaceRaised:    'rgba(255,255,255,0.07)',        // elevated glass
+
+  // ═══════════════════════════════════════════════
+  // PRIMARY — Coral (from logo)
+  // Main CTA color, buttons, active states
+  // ═══════════════════════════════════════════════
+  primary:          '#FF5C75',
+  primaryPressed:   '#E8506A',
+  primaryLight:     'rgba(255,92,117,0.12)',
+  primaryMuted:     'rgba(255,92,117,0.06)',
+
+  // ═══════════════════════════════════════════════
+  // ACCENT — Peach/Amber
+  // Secondary actions, highlights, active tabs
+  // ═══════════════════════════════════════════════
+  amber:            '#F79566',
+  amberLight:       'rgba(247,149,102,0.12)',
+  amberDark:        '#DC785A',                       // terra
+
+  // ═══════════════════════════════════════════════
+  // BRAND — Steel Blue (from logo)
+  // Trust color — headers, links, informational
+  // ═══════════════════════════════════════════════
+  steel:            '#5778A3',
+  steelLight:       'rgba(87,120,163,0.12)',
+
+  // ═══════════════════════════════════════════════
+  // SUPPORT — Sage
+  // Success states, positive feedback
+  // ═══════════════════════════════════════════════
+  sage:             '#8AA060',
+  sageLight:        'rgba(138,160,96,0.12)',
+
+  // ═══════════════════════════════════════════════
+  // SOS — Red (crisis-distinct from primary coral)
+  // ═══════════════════════════════════════════════
+  sos:              '#E87461',
+  sosLight:         'rgba(232,116,97,0.12)',
+  sosDark:          '#C85A48',
+
+  // ═══════════════════════════════════════════════
+  // NAVY (from logo)
+  // ═══════════════════════════════════════════════
+  navy:             '#484F6B',
+  navyLight:        'rgba(72,79,107,0.15)',
+
+  // ═══════════════════════════════════════════════
+  // TEXT — high contrast on warm dark
+  // ═══════════════════════════════════════════════
+  text:             'rgba(255,255,255,0.92)',
+  textSecondary:    'rgba(255,255,255,0.55)',
+  textMuted:        'rgba(255,255,255,0.30)',
+  textFaint:        'rgba(255,255,255,0.15)',
+  textInverse:      '#1A1614',                       // dark text on light buttons
+
+  // ═══════════════════════════════════════════════
+  // STRUCTURE
+  // ═══════════════════════════════════════════════
+  border:           'rgba(255,255,255,0.07)',
+  borderHi:         'rgba(255,255,255,0.12)',
+  borderFocus:      '#F79566',                       // amber focus ring
+  divider:          'rgba(255,255,255,0.05)',
+
+  // ═══════════════════════════════════════════════
+  // COMPONENT-LEVEL
+  // ═══════════════════════════════════════════════
+  tabActive:        '#F79566',                       // amber for active tab
+  tabInactive:      'rgba(255,255,255,0.25)',
+  chipBg:           'rgba(255,255,255,0.06)',
+  chipBorder:       'rgba(255,255,255,0.10)',
+  inputBg:          'rgba(255,255,255,0.04)',
+  inputBorder:      'rgba(255,255,255,0.08)',
+  inputFocus:       'rgba(247,149,102,0.20)',
+
+  // ═══════════════════════════════════════════════
+  // GRADIENTS (use with LinearGradient)
+  // ═══════════════════════════════════════════════
+  gradientTop:      '#1A1614',
+  gradientBottom:   '#14100E',
+
+
+  // ═══════════════════════════════════════════════
+  // BACKWARDS-COMPAT ALIASES
+  // Retained because the 21 unmigrated screens still reference the old
+  // v3/v4 token names. Drop each alias when its consumer migrates
+  // (tracked in Issue #3).
+  // ═══════════════════════════════════════════════
+
+  // Old surface names → new dark surfaces
+  base:             '#1A1614',
+  backgroundLight:  '#1A1614',
+  raised:           'rgba(255,255,255,0.045)',
+  elevated:         'rgba(255,255,255,0.07)',
+  subtle:           'rgba(255,255,255,0.03)',
+  glass:            'rgba(255,255,255,0.045)',
+  glassStrong:      'rgba(255,255,255,0.07)',
+  glassSoft:        'rgba(255,255,255,0.03)',
+  cardGlass:        'rgba(255,255,255,0.045)',
+  cardGlassStrong:  'rgba(255,255,255,0.07)',
+  cardGlassSoft:    'rgba(255,255,255,0.03)',
+
+  // Old brand names → new logo-derived
+  coral:            '#FF5C75',                       // → primary
+  coralLight:       '#E8506A',
+  coralMuted:       'rgba(255,92,117,0.12)',
+  rose:             '#FF5C75',                       // → primary
+  roseLight:        '#E8506A',
+  roseMuted:        'rgba(255,92,117,0.12)',
+  peach:            '#F79566',                       // → amber
+  peachMuted:       'rgba(247,149,102,0.12)',
+  blue:             '#5778A3',                       // → steel
+  blueLight:        '#A0C4DA',
+  blueMuted:        'rgba(87,120,163,0.12)',
+  amberMuted:       'rgba(247,149,102,0.12)',
+  sageMuted:        'rgba(138,160,96,0.12)',
+
+  // Old text token aliases
+  textBody:         'rgba(255,255,255,0.78)',
+  textSub:          'rgba(255,255,255,0.55)',
+  textGhost:        'rgba(255,255,255,0.16)',
+  textSoft:         'rgba(255,255,255,0.78)',
+
+  // Old border alias
+  borderLight:      'rgba(255,255,255,0.12)',
+
+  // Old semantic
+  success:          '#8AA060',
+  warning:          '#F79566',
+  danger:           '#E87461',
+  disabled:         'rgba(255,255,255,0.06)',
+  disabledText:     'rgba(255,255,255,0.20)',
+  pressed:          'rgba(255,255,255,0.04)',
+
+  // Old gradient stops — kept warm-dark, used by some screens
+  gradStart:        '#1A1614',
+  gradMid1:         '#161210',
+  gradMid2:         '#14110F',
+  gradEnd:          '#14100E',
+
+  // Old category card backgrounds (now warm-dark tints)
+  catPink:          'rgba(255,92,117,0.10)',
+  catBlue:          'rgba(87,120,163,0.10)',
+  catGreen:         'rgba(138,160,96,0.10)',
+  catYellow:        'rgba(247,149,102,0.10)',
+
+  linkAction:       '#F79566',
+  linkSecondary:    'rgba(255,255,255,0.30)',
+} as const;
+
+
+// ═══════════════════════════════════════════════
+// FONTS — Fraunces (serif) + DM Sans (sans)
+// ═══════════════════════════════════════════════
 //
-// Architecture:
-// - 4 raw palette objects defined below
-// - getActivePalette() reads device time + override
-// - colors export is a Proxy that resolves to active palette per access
-// - Every existing token name still works (backwards compat preserved)
-// - setPaletteOverride() lets Settings toggle Auto / Light / Dark
-// - DEV-only setForcedHour() for previewing palettes without time-travel
+// Loaded in app/_layout.tsx via @expo-google-fonts/fraunces and
+// @expo-google-fonts/dm-sans. Components use the string family name
+// directly: <Text style={{ fontFamily: fonts.body }}>.
+//
+// The journal-Manrope identity is retired; v5 commits to Fraunces for
+// emotional/headline text and DM Sans for everything else (per the
+// LOCKED design system).
 
-// ═══════════════════════════════════════════════
-// PALETTE TYPE
-// ═══════════════════════════════════════════════
+export const fonts = {
+  // ─── Canonical (paired with logical role) ───
+  heading:        'Fraunces_700Bold',                // hero, screen titles
+  headingItalic:  'Fraunces_700Bold_Italic',         // situation summaries, philosophy lines
+  subheading:     'DMSans_600SemiBold',
+  body:           'DMSans_400Regular',
+  bodyMedium:     'DMSans_500Medium',
+  bodySemi:       'DMSans_600SemiBold',
+  script:         'Fraunces_600SemiBold',            // AI script text the parent reads aloud
+  scriptItalic:   'Fraunces_600SemiBold_Italic',
+  label:          'DMSans_700Bold',
+  caption:        'DMSans_400Regular',
+  accent:         'DMSans_500Medium',
 
-type Palette = {
-  // Backgrounds
-  base:            string;
-  raised:          string;
-  elevated:        string;
-  subtle:          string;
-  background:      string;
-
-  // Brand
-  rose:            string;
-  roseLight:       string;
-  roseMuted:       string;
-  sage:            string;
-  sageLight:       string;
-  sageMuted:       string;
-
-  // Legacy brand aliases
-  blue:            string;
-  blueLight:       string;
-  blueMuted:       string;
-  coral:           string;
-  coralLight:      string;
-  coralMuted:      string;
-  peach:           string;
-  peachMuted:      string;
-  amber:           string;
-  amberMuted:      string;
-
-  // Category card colors
-  catPink:         string;
-  catBlue:         string;
-  catGreen:        string;
-  catYellow:       string;
-
-  // Gradient stops
-  gradStart:       string;
-  gradMid1:        string;
-  gradMid2:        string;
-  gradEnd:         string;
-
-  // Text
-  text:            string;
-  textBody:        string;
-  textSub:         string;
-  textMuted:       string;
-  textGhost:       string;
-  textSoft:        string;
-  textSecondary:   string;
-  textFaint:       string;
-
-  // Links
-  linkAction:      string;
-  linkSecondary:   string;
-
-  // Borders
-  border:          string;
-  borderLight:     string;
-  borderFocus:     string;
-
-  // Semantic
-  success:         string;
-  warning:         string;
-  danger:          string;
-  disabled:        string;
-  disabledText:    string;
-  pressed:         string;
-
-  // Card surfaces
-  cardGlass:       string;
-  cardGlassStrong: string;
-  cardGlassSoft:   string;
-};
+  // ─── Backwards-compat aliases (retained until consumers migrate) ───
+  display:           'Fraunces_700Bold',
+  displaySemi:       'Fraunces_600SemiBold',
+  scriptMedium:      'Fraunces_600SemiBold',
+  scriptLight:       'Fraunces_600SemiBold',
+  scriptLightItalic: 'Fraunces_600SemiBold_Italic',
+  regular:           'DMSans_400Regular',
+  medium:            'DMSans_500Medium',
+  semi:              'DMSans_600SemiBold',
+  bold:              'DMSans_700Bold',
+  extraBold:         'Fraunces_700Bold',
+} as const;
 
 
 // ═══════════════════════════════════════════════
-// PALETTE 1 — 🌅 SUNRISE  (5am – 9am)
-// ═══════════════════════════════════════════════
-
-const SUNRISE: Palette = {
-  // Backgrounds
-  base:            '#F4D9C4',
-  raised:          'rgba(255,255,255,0.55)',
-  elevated:        'rgba(255,255,255,0.75)',
-  subtle:          'rgba(255,255,255,0.40)',
-  background:      '#F4D9C4',
-
-  // Brand
-  rose:            '#C97B63',
-  roseLight:       '#D9917C',
-  roseMuted:       'rgba(201,123,99,0.12)',
-  sage:            '#81B29A',
-  sageLight:       '#97C5AE',
-  sageMuted:       'rgba(129,178,154,0.12)',
-
-  // Legacy aliases
-  blue:            '#81B29A',
-  blueLight:       '#97C5AE',
-  blueMuted:       'rgba(129,178,154,0.12)',
-  coral:           '#C97B63',
-  coralLight:      '#D9917C',
-  coralMuted:      'rgba(201,123,99,0.12)',
-  peach:           '#E89F73',
-  peachMuted:      'rgba(232,159,115,0.10)',
-  amber:           '#C97B63',
-  amberMuted:      'rgba(201,123,99,0.12)',
-
-  // Category cards
-  catPink:         '#F5C8B5',
-  catBlue:         '#D6E8F7',
-  catGreen:        '#D4E8D1',
-  catYellow:       '#F4D9C4',
-
-  // Gradient: pale gold → peach → dusty rose-cream → warm sage
-  gradStart:       '#F4D9C4',
-  gradMid1:        '#F5C8B5',
-  gradMid2:        '#E8BEB1',
-  gradEnd:         '#D4D0BF',
-
-  // Text — dark warm brown for warmth
-  text:            '#3D2D1F',
-  textBody:        'rgba(61,45,31,0.78)',
-  textSub:         'rgba(61,45,31,0.55)',
-  textMuted:       'rgba(61,45,31,0.32)',
-  textGhost:       'rgba(61,45,31,0.14)',
-  textSoft:        'rgba(61,45,31,0.78)',
-  textSecondary:   'rgba(61,45,31,0.55)',
-  textFaint:       'rgba(61,45,31,0.20)',
-
-  // Links
-  linkAction:      '#C97B63',
-  linkSecondary:   'rgba(61,45,31,0.32)',
-
-  // Borders
-  border:          'rgba(61,45,31,0.08)',
-  borderLight:     'rgba(61,45,31,0.12)',
-  borderFocus:     'rgba(129,178,154,0.45)',
-
-  // Semantic
-  success:         '#81B29A',
-  warning:         '#E89F73',
-  danger:          '#C97B63',
-  disabled:        'rgba(61,45,31,0.08)',
-  disabledText:    'rgba(61,45,31,0.22)',
-  pressed:         'rgba(61,45,31,0.06)',
-
-  // Cards
-  cardGlass:       'rgba(251,246,238,0.78)',
-  cardGlassStrong: 'rgba(251,246,238,0.92)',
-  cardGlassSoft:   'rgba(251,246,238,0.55)',
-};
-
-
-// ═══════════════════════════════════════════════
-// PALETTE 2 — ☀️ DAYLIGHT  (9am – 5pm)
-// ═══════════════════════════════════════════════
-
-const DAYLIGHT: Palette = {
-  base:            '#F5EDDF',
-  raised:          'rgba(255,255,255,0.65)',
-  elevated:        'rgba(255,255,255,0.82)',
-  subtle:          'rgba(255,255,255,0.45)',
-  background:      '#F5EDDF',
-
-  rose:            '#C97B63',
-  roseLight:       '#D9917C',
-  roseMuted:       'rgba(201,123,99,0.10)',
-  sage:            '#81B29A',
-  sageLight:       '#97C5AE',
-  sageMuted:       'rgba(129,178,154,0.10)',
-
-  blue:            '#81B29A',
-  blueLight:       '#97C5AE',
-  blueMuted:       'rgba(129,178,154,0.10)',
-  coral:           '#C97B63',
-  coralLight:      '#D9917C',
-  coralMuted:      'rgba(201,123,99,0.10)',
-  peach:           '#E89F73',
-  peachMuted:      'rgba(232,159,115,0.08)',
-  amber:           '#C97B63',
-  amberMuted:      'rgba(201,123,99,0.10)',
-
-  catPink:         '#FDDDE6',
-  catBlue:         '#D6E8F7',
-  catGreen:        '#D4E8D1',
-  catYellow:       '#FDE8D0',
-
-  // Gradient: warm parchment → cream → sand → warm linen
-  gradStart:       '#F5EDDF',
-  gradMid1:        '#EDE3D2',
-  gradMid2:        '#E5DBC8',
-  gradEnd:         '#DDD3BF',
-
-  // Text
-  text:            '#2C2A26',
-  textBody:        'rgba(44,42,38,0.78)',
-  textSub:         'rgba(44,42,38,0.52)',
-  textMuted:       'rgba(44,42,38,0.30)',
-  textGhost:       'rgba(44,42,38,0.12)',
-  textSoft:        'rgba(44,42,38,0.78)',
-  textSecondary:   'rgba(44,42,38,0.52)',
-  textFaint:       'rgba(44,42,38,0.18)',
-
-  linkAction:      '#C97B63',
-  linkSecondary:   'rgba(44,42,38,0.30)',
-
-  border:          'rgba(44,42,38,0.07)',
-  borderLight:     'rgba(44,42,38,0.11)',
-  borderFocus:     'rgba(129,178,154,0.40)',
-
-  success:         '#81B29A',
-  warning:         '#E89F73',
-  danger:          '#C97B63',
-  disabled:        'rgba(44,42,38,0.06)',
-  disabledText:    'rgba(44,42,38,0.20)',
-  pressed:         'rgba(44,42,38,0.04)',
-
-  cardGlass:       'rgba(255,252,246,0.75)',
-  cardGlassStrong: 'rgba(255,252,246,0.90)',
-  cardGlassSoft:   'rgba(255,252,246,0.50)',
-};
-
-
-// ═══════════════════════════════════════════════
-// PALETTE 3 — 🌇 GOLDEN HOUR  (5pm – 9pm)
-// ═══════════════════════════════════════════════
-
-const GOLDEN_HOUR: Palette = {
-  base:            '#E8B68A',
-  raised:          'rgba(251,238,221,0.62)',
-  elevated:        'rgba(251,238,221,0.80)',
-  subtle:          'rgba(251,238,221,0.45)',
-  background:      '#E8B68A',
-
-  rose:            '#C97B63',
-  roseLight:       '#D9917C',
-  roseMuted:       'rgba(201,123,99,0.14)',
-  sage:            '#81B29A',
-  sageLight:       '#97C5AE',
-  sageMuted:       'rgba(129,178,154,0.14)',
-
-  blue:            '#81B29A',
-  blueLight:       '#97C5AE',
-  blueMuted:       'rgba(129,178,154,0.14)',
-  coral:           '#C97B63',
-  coralLight:      '#D9917C',
-  coralMuted:      'rgba(201,123,99,0.14)',
-  peach:           '#E8A573',
-  peachMuted:      'rgba(232,165,115,0.10)',
-  amber:           '#C97B63',
-  amberMuted:      'rgba(201,123,99,0.14)',
-
-  catPink:         '#E8B68A',
-  catBlue:         '#D6E8F7',
-  catGreen:        '#D4E8D1',
-  catYellow:       '#F4D9C4',
-
-  // Gradient: burnt apricot → terracotta → dusty sienna → warm taupe
-  gradStart:       '#E8B68A',
-  gradMid1:        '#D89674',
-  gradMid2:        '#B8755C',
-  gradEnd:         '#6B5644',
-
-  // Text — deep warm brown
-  text:            '#2D1E14',
-  textBody:        'rgba(45,30,20,0.80)',
-  textSub:         'rgba(45,30,20,0.58)',
-  textMuted:       'rgba(45,30,20,0.36)',
-  textGhost:       'rgba(45,30,20,0.16)',
-  textSoft:        'rgba(45,30,20,0.80)',
-  textSecondary:   'rgba(45,30,20,0.58)',
-  textFaint:       'rgba(45,30,20,0.22)',
-
-  linkAction:      '#3D2418',
-  linkSecondary:   'rgba(45,30,20,0.36)',
-
-  border:          'rgba(45,30,20,0.10)',
-  borderLight:     'rgba(45,30,20,0.14)',
-  borderFocus:     'rgba(129,178,154,0.50)',
-
-  success:         '#81B29A',
-  warning:         '#E8A573',
-  danger:          '#C97B63',
-  disabled:        'rgba(45,30,20,0.10)',
-  disabledText:    'rgba(45,30,20,0.26)',
-  pressed:         'rgba(45,30,20,0.08)',
-
-  cardGlass:       'rgba(251,238,221,0.78)',
-  cardGlassStrong: 'rgba(251,238,221,0.92)',
-  cardGlassSoft:   'rgba(251,238,221,0.55)',
-};
-
-
-// ═══════════════════════════════════════════════
-// PALETTE 4 — 🌃 DEEP DUSK  (9pm – 5am)
-// Inverted: light text on dark backgrounds.
-// ═══════════════════════════════════════════════
-
-const DUSK: Palette = {
-  base:            '#2D2A3E',
-  raised:          'rgba(61,56,72,0.62)',
-  elevated:        'rgba(61,56,72,0.80)',
-  subtle:          'rgba(61,56,72,0.45)',
-  background:      '#2D2A3E',
-
-  rose:            '#D9917C',
-  roseLight:       '#E8A89A',
-  roseMuted:       'rgba(217,145,124,0.18)',
-  sage:            '#97C5AE',
-  sageLight:       '#B0D4C2',
-  sageMuted:       'rgba(151,197,174,0.18)',
-
-  blue:            '#97C5AE',
-  blueLight:       '#B0D4C2',
-  blueMuted:       'rgba(151,197,174,0.18)',
-  coral:           '#D9917C',
-  coralLight:      '#E8A89A',
-  coralMuted:      'rgba(217,145,124,0.18)',
-  peach:           '#E8A573',
-  peachMuted:      'rgba(232,165,115,0.14)',
-  amber:           '#D9917C',
-  amberMuted:      'rgba(217,145,124,0.18)',
-
-  catPink:         '#4D4252',
-  catBlue:         '#3D4858',
-  catGreen:        '#3D4D44',
-  catYellow:       '#4D4538',
-
-  // Gradient: deep dusk navy → indigo → plum-charcoal → near-black
-  gradStart:       '#2D2A3E',
-  gradMid1:        '#3D3548',
-  gradMid2:        '#4D4252',
-  gradEnd:         '#1F1D2B',
-
-  // Text — light cream on dark
-  text:            '#F0EBE0',
-  textBody:        'rgba(240,235,224,0.82)',
-  textSub:         'rgba(240,235,224,0.62)',
-  textMuted:       'rgba(240,235,224,0.42)',
-  textGhost:       'rgba(240,235,224,0.18)',
-  textSoft:        'rgba(240,235,224,0.82)',
-  textSecondary:   'rgba(240,235,224,0.62)',
-  textFaint:       'rgba(240,235,224,0.28)',
-
-  linkAction:      '#E8A89A',
-  linkSecondary:   'rgba(240,235,224,0.42)',
-
-  border:          'rgba(240,235,224,0.10)',
-  borderLight:     'rgba(240,235,224,0.16)',
-  borderFocus:     'rgba(151,197,174,0.50)',
-
-  success:         '#97C5AE',
-  warning:         '#E8A573',
-  danger:          '#D9917C',
-  disabled:        'rgba(240,235,224,0.10)',
-  disabledText:    'rgba(240,235,224,0.32)',
-  pressed:         'rgba(240,235,224,0.08)',
-
-  cardGlass:       'rgba(61,56,72,0.78)',
-  cardGlassStrong: 'rgba(61,56,72,0.92)',
-  cardGlassSoft:   'rgba(61,56,72,0.55)',
-};
-
-
-// ═══════════════════════════════════════════════
-// PALETTE SELECTION
+// LEGACY API SHIMS — NO-OP
+// Older theme (v7 Sunset Proxy) had a setPaletteOverride / setForcedHour
+// API. Nothing outside theme/colors.ts ever called it. Shims kept so
+// stale imports don't crash.
 // ═══════════════════════════════════════════════
 
 export type PaletteMode = 'auto' | 'light' | 'dark';
-
-let paletteOverride: PaletteMode = 'auto';
-let forcedHour: number | null = null; // dev-only override
-
-/**
- * Set the user's palette preference.
- * 'auto' = time-aware (default)
- * 'light' = always Daylight
- * 'dark' = always Deep Dusk
- */
-export function setPaletteOverride(mode: PaletteMode): void {
-  paletteOverride = mode;
-}
-
-export function getPaletteOverride(): PaletteMode {
-  return paletteOverride;
-}
-
-/**
- * DEV ONLY — force a specific hour for palette preview.
- * Pass null to clear the override.
- * Never used in production.
- */
-export function setForcedHour(hour: number | null): void {
-  forcedHour = hour;
-}
-
-/**
- * Returns the active palette object based on time of day + override.
- * Each call resolves fresh — palette can change mid-session if the
- * device clock crosses a boundary.
- */
-export function getActivePalette(): Palette {
-  if (paletteOverride === 'light') return DAYLIGHT;
-  if (paletteOverride === 'dark')  return DUSK;
-
-  const hour = forcedHour !== null ? forcedHour : new Date().getHours();
-
-  if (hour >= 5  && hour < 9)  return SUNRISE;
-  if (hour >= 9  && hour < 17) return DAYLIGHT;
-  if (hour >= 17 && hour < 21) return GOLDEN_HOUR;
-  return DUSK; // 21–24 and 0–5
-}
-
-/**
- * Returns which palette name is currently active.
- * Useful for conditional logic in screens (e.g. swap a logo asset
- * between light and dark variants).
- */
 export type PaletteName = 'sunrise' | 'daylight' | 'golden_hour' | 'dusk';
 
-export function getActivePaletteName(): PaletteName {
-  if (paletteOverride === 'light') return 'daylight';
-  if (paletteOverride === 'dark')  return 'dusk';
-
-  const hour = forcedHour !== null ? forcedHour : new Date().getHours();
-
-  if (hour >= 5  && hour < 9)  return 'sunrise';
-  if (hour >= 9  && hour < 17) return 'daylight';
-  if (hour >= 17 && hour < 21) return 'golden_hour';
-  return 'dusk';
-}
-
-
-// ═══════════════════════════════════════════════
-// COLORS PROXY — DYNAMIC RESOLUTION
-// Every property access resolves against the active palette.
-// All existing screens continue to work without changes.
-// ═══════════════════════════════════════════════
-
-export const colors = new Proxy({} as Palette, {
-  get(_target, prop: string) {
-    const palette = getActivePalette();
-    return (palette as any)[prop];
-  },
-}) as Palette;
-
-
-// ═══════════════════════════════════════════════
-// FONTS — UNCHANGED
-// Typography refresh is a separate decision.
-// ═══════════════════════════════════════════════
-
-export const fonts = {
-  // Manrope — UI body text
-  heading:          'Manrope-ExtraBold',
-  subheading:       'Manrope-Bold',
-  body:             'Manrope-Regular',
-  bodyMedium:       'Manrope-Medium',
-  bodySemi:         'Manrope-SemiBold',
-  label:            'Manrope-Bold',
-  display:          'Manrope-ExtraBold',
-  displaySemi:      'Manrope-Bold',
-  script:           'Manrope-Medium',
-  scriptItalic:     'Manrope-Medium',
-  accent:           'Manrope-Medium',
-
-  // Legacy aliases
-  scriptMedium:     'Manrope-Bold',
-  scriptLight:      'Manrope-Medium',
-  scriptLightItalic:'Manrope-Medium',
-} as const;
+export function setPaletteOverride(_mode: PaletteMode): void { /* no-op */ }
+export function getPaletteOverride(): PaletteMode { return 'dark'; }
+export function setForcedHour(_hour: number | null): void { /* no-op */ }
+export function getActivePaletteName(): PaletteName { return 'dusk'; }

--- a/apps/mobile/src/utils/analytics.ts
+++ b/apps/mobile/src/utils/analytics.ts
@@ -1,0 +1,28 @@
+// src/utils/analytics.ts
+// Event-tracking stubs for the onboarding funnel.
+//
+// In dev: logs to console with an [ANALYTICS] prefix.
+// In prod: no-op until a tracking backend is wired (PostHog, Mixpanel, Amplitude…).
+// Adding the calls now means the funnel is already instrumented — the only
+// follow-up work to make events flow is replacing the `track()` body.
+
+declare const __DEV__: boolean;
+
+export type AnalyticsEvent =
+  | 'onboarding_screen_viewed'
+  | 'onboarding_trial_started'
+  | 'onboarding_trial_completed'
+  | 'onboarding_trial_failed'
+  | 'onboarding_trial_result_viewed'
+  | 'onboarding_child_setup_completed'
+  | 'onboarding_child_setup_skipped'
+  | 'onboarding_signup_completed'
+  | 'onboarding_signup_skipped'
+  | 'onboarding_screen_dropped';
+
+export function track(event: AnalyticsEvent, props?: Record<string, unknown>): void {
+  if (typeof __DEV__ !== 'undefined' && __DEV__) {
+    // eslint-disable-next-line no-console
+    console.log('[ANALYTICS]', event, props ?? {});
+  }
+}

--- a/apps/mobile/src/utils/onboarding.ts
+++ b/apps/mobile/src/utils/onboarding.ts
@@ -1,0 +1,42 @@
+// src/utils/onboarding.ts
+// AsyncStorage helpers for the welcome / onboarding flow.
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ONBOARDING_KEY = '@sturdy/onboarding-complete';
+
+/**
+ * Has this device finished the welcome flow at least once?
+ * Used by the root layout to decide whether to route a signed-out user
+ * to /welcome (first-time) or /auth/sign-in (returning).
+ */
+export async function hasCompletedOnboarding(): Promise<boolean> {
+  try {
+    const v = await AsyncStorage.getItem(ONBOARDING_KEY);
+    return v === 'true';
+  } catch {
+    // If AsyncStorage is broken, treat the device as fresh — better to
+    // re-show onboarding than block a returning user from signing in.
+    return false;
+  }
+}
+
+export async function markOnboardingComplete(): Promise<void> {
+  try {
+    await AsyncStorage.setItem(ONBOARDING_KEY, 'true');
+  } catch {
+    // No-op — onboarding completion is not load-bearing.
+  }
+}
+
+/**
+ * DEV-only — wipe the flag so the welcome flow shows again on next launch.
+ * Useful for testing the onboarding flow without reinstalling the app.
+ */
+export async function resetOnboarding(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(ONBOARDING_KEY);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
Completely redesigned the welcome/onboarding experience from a single multi-screen carousel into a focused 5-screen funnel that guides parents through a live trial before signup. The new flow emphasizes emotional connection, immediate value demonstration, and progressive personalization.

## Key Changes

**New Onboarding Screens:**
- **Screen 1** (`/welcome/index.tsx`): "The Moment" — emotional hook with staggered text animation showing a relatable parenting scenario
- **Screen 2** (`/welcome/trial.tsx`): "Live Trial" — parent describes a situation, picks child age + intensity, gets a real parenting script via API
- **Screen 3** (`/welcome/trial-result.tsx`): "The Magic Moment" — displays the Regulate step in full, blurs Connect/Guide to create desire for personalization
- **Screen 4** (`/welcome/child-setup.tsx`): "Your Child" — collects name, age, and challenge areas (stored in OnboardingContext, persisted to DB after signup)
- **Screen 5** (`/welcome/signup.tsx`): "Create Account" — email/password signup with optional child profile insertion

**New Infrastructure:**
- `OnboardingContext` — React context holding trial input, trial result, and child setup state across the welcome stack; resets when user completes onboarding
- `ProgressDots` component — 5-dot progress indicator at top of each screen (active = amber 8px, inactive = white-15% 6px)
- `analytics.ts` — Event tracking stubs for onboarding funnel (console logs in dev, no-op in prod)
- `onboarding.ts` — AsyncStorage helpers (`hasCompletedOnboarding()`, `markOnboardingComplete()`)

**Theme & Design Updates:**
- Replaced Manrope-only typography with **Fraunces** (serif, 600/700 weights) + **DM Sans** (sans, 400/500/600/700)
- Simplified color palette to logo-derived premium dark theme: warm charcoal base (#1A1614), glass surfaces (rgba white 4.5%–7%), coral/peach/terra/steel/navy accents
- Removed time-aware palette system (Sunrise/Daylight/Golden Hour/Deep Dusk) in favor of single warm-dark identity
- Updated `colors.ts` with new token names and removed complex palette switching logic

**Layout & Navigation:**
- `_layout.tsx` now wraps welcome stack with `OnboardingProvider`
- Root layout checks `hasCompletedOnboarding()` to route first-time users to `/welcome` vs returning users to `/auth/sign-in`
- Crisis detection in trial flow routes to `/crisis` (safety always free)
- Signup completion calls `markOnboardingComplete()` and routes to `/(tabs)`

**Notable Implementation Details:**
- Trial screen uses existing `getParentingScript()` API in "sos" mode (no userId, no logging)
- Child setup data pre-fills age from trial if parent already selected one (creates continuity)
- Trial result blurs Connect/Guide steps using `BlurView` to show there's more content without revealing it
- All screens track analytics events (viewed, dropped, completed) for funnel analysis
- Keyboard handling via `KeyboardAvoidingView` on input-heavy screens
- Error states and loading states with visual feedback (pulse animation on loading button)

## Migration Notes
- Old welcome carousel (splash + 3 feature slides) completely removed
- `GUEST_SEEN_KEY` and guest mode logic removed in favor of `hasCompletedOnboarding()`
- Auth context still handles session checks; onboarding context is separate concern

https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj