### PR TITLE
Add child profile hub with outcome modes and profile nudge

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -15,6 +15,7 @@ import {
   Animated,
   Image,
   KeyboardAvoidingView,
+  Modal,
   Platform,
   Pressable,
   ScrollView,
@@ -52,6 +53,32 @@ const CHILD_COLORS = [
   '#F79566',
   '#C4A46C',
   '#8B7AA8',
+];
+
+// ═══════════════════════════════════════════════
+// OUTCOME MODES
+// 4 internal modes, surfaced as tap cards below the Question input.
+// Routes to /child/[id]?mode=<key>; the per-child hub reads the mode
+// param and adapts its prompt + UI. Backend prompts already exist
+// (getSOSPrompt / getReconnectPrompt / getUnderstandPrompt /
+// getConversationPrompt) — this is purely a UI surface.
+// ═══════════════════════════════════════════════
+
+type OutcomeMode = 'sos' | 'reconnect' | 'understand' | 'conversation';
+
+type Outcome = {
+  mode:        OutcomeMode;
+  emoji:       string;
+  title:       string;
+  subtitle:    string;
+  accentColor: string;
+};
+
+const OUTCOMES: Outcome[] = [
+  { mode: 'sos',          emoji: '🆘', title: 'Right now',         subtitle: 'They\'re melting down',   accentColor: '#E87461' },
+  { mode: 'reconnect',    emoji: '🤝', title: 'Repair',            subtitle: 'After it went sideways',  accentColor: '#C4A46C' },
+  { mode: 'understand',   emoji: '💡', title: 'Understand',        subtitle: 'Why do they do this?',    accentColor: '#5778A3' },
+  { mode: 'conversation', emoji: '💬', title: 'Plan a talk',       subtitle: 'A hard conversation',     accentColor: '#8AA060' },
 ];
 
  // ═══════════════════════════════════════════════
@@ -106,6 +133,10 @@ export default function HomeScreen() {
   const [sending, setSending]         = useState(false);
   const [error, setError]             = useState('');
 
+  // Outcome-selector picker state (shown when 2+ children exist and
+  // the parent taps an outcome card — picks WHICH child the mode is for).
+  const [pickerMode, setPickerMode] = useState<OutcomeMode | null>(null);
+
   // ─── Fetch parent's name ───
   const fetchName = useCallback(async () => {
     if (!session?.user?.id) return;
@@ -152,6 +183,37 @@ export default function HomeScreen() {
   const handleAddChild = () => {
     Haptics.selectionAsync();
     router.push('/child/new');
+  };
+
+  // Outcome card tapped — route to a child's hub with the selected mode.
+  // 0 children: bounce to /child/new (parent adds a child first).
+  // 1 child:    auto-route, no picker.
+  // 2+ children: open picker modal so the parent picks which child this
+  //              outcome applies to.
+  const handleSelectOutcome = (mode: OutcomeMode) => {
+    Haptics.selectionAsync();
+    if (kidList.length === 0) {
+      router.push('/child/new');
+      return;
+    }
+    if (kidList.length === 1) {
+      const onlyKid = kidList[0];
+      router.push({ pathname: `/child/${onlyKid.id}` as any, params: { mode } });
+      return;
+    }
+    setPickerMode(mode);
+  };
+
+  const handlePickerSelectChild = (childId: string) => {
+    if (!pickerMode) return;
+    Haptics.selectionAsync();
+    const mode = pickerMode;
+    setPickerMode(null);
+    router.push({ pathname: `/child/${childId}` as any, params: { mode } });
+  };
+
+  const handlePickerCancel = () => {
+    setPickerMode(null);
   };
 
   const handleSend = async () => {
@@ -350,6 +412,34 @@ export default function HomeScreen() {
               </View>
             </Pressable>
 
+            {/* ─── Outcome selector ─── */}
+            {/* 4 modes surfaced as a 2×2 grid; tapping routes to the
+                per-child hub with mode preset. SOS is visually distinct
+                with a sos-color border accent; the others are calmer. */}
+            <View style={s.outcomeWrap}>
+              <Text style={s.outcomeLabel}>Or pick a mode</Text>
+              <View style={s.outcomeGrid}>
+                {OUTCOMES.map((o) => (
+                  <Pressable
+                    key={o.mode}
+                    onPress={() => handleSelectOutcome(o.mode)}
+                    style={({ pressed }) => [
+                      s.outcomeCard,
+                      { borderColor: `${o.accentColor}55` },
+                      o.mode === 'sos' && s.outcomeCardSos,
+                      pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] },
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${o.title} — ${o.subtitle}`}
+                  >
+                    <Text style={s.outcomeEmoji}>{o.emoji}</Text>
+                    <Text style={s.outcomeTitle}>{o.title}</Text>
+                    <Text style={s.outcomeSubtitle} numberOfLines={1}>{o.subtitle}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+
             {/* ─── 1 child: lite view shows quick link to their hub ─── */}
             {isSingleChild && onlyChild ? (
               <Pressable
@@ -423,6 +513,50 @@ export default function HomeScreen() {
           </ScrollView>
         </KeyboardAvoidingView>
       </SafeAreaView>
+
+      {/* ─── Outcome → multi-child picker modal ─── */}
+      {/* Only used when 2+ children exist. Single-child + zero-child
+          paths route directly without showing the modal. */}
+      <Modal
+        visible={pickerMode !== null}
+        animationType="fade"
+        transparent
+        onRequestClose={handlePickerCancel}
+      >
+        <Pressable style={s.pickerBackdrop} onPress={handlePickerCancel}>
+          <Pressable style={s.pickerSheet} onPress={() => {}}>
+            <Text style={s.pickerTitle}>Which child?</Text>
+            <Text style={s.pickerSub}>
+              {pickerMode ? OUTCOMES.find((o) => o.mode === pickerMode)?.subtitle : ''}
+            </Text>
+            <View style={s.pickerRow}>
+              {kidList.map((kid: any, index: number) => {
+                const color = CHILD_COLORS[index % CHILD_COLORS.length];
+                const initial = (kid?.name?.trim()?.[0] ?? '?').toUpperCase();
+                return (
+                  <Pressable
+                    key={kid.id}
+                    onPress={() => handlePickerSelectChild(kid.id)}
+                    style={({ pressed }) => [
+                      s.pickerChild,
+                      pressed && { opacity: 0.85, transform: [{ scale: 0.97 }] },
+                    ]}
+                  >
+                    <View style={[s.pickerAvatar, { backgroundColor: color, shadowColor: color }]}>
+                      <Text style={s.pickerAvatarText}>{initial}</Text>
+                    </View>
+                    <Text style={s.pickerChildName} numberOfLines={1}>{kid.name}</Text>
+                    <Text style={s.pickerChildAge}>Age {kid.childAge}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            <Pressable onPress={handlePickerCancel} style={s.pickerCancel}>
+              <Text style={s.pickerCancelText}>Cancel</Text>
+            </Pressable>
+          </Pressable>
+        </Pressable>
+      </Modal>
     </View>
   );
 }
@@ -569,6 +703,99 @@ const s = StyleSheet.create({
   },
   addCardText: {
     fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted,
+  },
+
+  // Outcome selector (4 mode cards in a 2×2 grid)
+  outcomeWrap: { gap: 10 },
+  outcomeLabel: {
+    fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, letterSpacing: 0.3,
+  },
+  outcomeGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  outcomeCard: {
+    flexBasis: '47%',
+    flexGrow: 1,
+    padding: 14,
+    gap: 4,
+    borderRadius: 18,
+    borderWidth: 1,
+    backgroundColor: C.cardGlass,
+    minHeight: 96,
+  },
+  outcomeCardSos: {
+    // SOS gets a slightly stronger tint so it reads as the urgent option.
+    backgroundColor: 'rgba(232,116,97,0.08)',
+  },
+  outcomeEmoji: {
+    fontSize: 22,
+    lineHeight: 26,
+    marginBottom: 2,
+  },
+  outcomeTitle: {
+    fontFamily: F.subheading, fontSize: 15, color: C.text, letterSpacing: -0.1,
+  },
+  outcomeSubtitle: {
+    fontFamily: F.body, fontSize: 12, color: C.textSub,
+  },
+
+  // Outcome → child picker modal
+  pickerBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(15,10,18,0.65)',
+    justifyContent: 'flex-end',
+  },
+  pickerSheet: {
+    backgroundColor: 'rgba(28,22,30,0.98)',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    padding: 24,
+    paddingBottom: 36,
+    gap: 16,
+  },
+  pickerTitle: {
+    fontFamily: F.heading, fontSize: 22, color: C.text, letterSpacing: -0.3,
+  },
+  pickerSub: {
+    fontFamily: F.body, fontSize: 14, color: C.textSub,
+  },
+  pickerRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+    paddingTop: 4,
+  },
+  pickerChild: {
+    width: 96,
+    padding: 12, gap: 6,
+    alignItems: 'center', justifyContent: 'center',
+    borderRadius: 16,
+    backgroundColor: C.cardGlass,
+    borderWidth: 1, borderColor: C.border,
+  },
+  pickerAvatar: {
+    width: 48, height: 48, borderRadius: 24,
+    alignItems: 'center', justifyContent: 'center',
+    shadowOpacity: 0.25, shadowRadius: 10,
+    shadowOffset: { width: 0, height: 4 }, elevation: 3,
+  },
+  pickerAvatarText: {
+    fontFamily: F.heading, fontSize: 20, color: '#FFFFFF', letterSpacing: -0.3,
+  },
+  pickerChildName: {
+    fontFamily: F.bodySemi, fontSize: 13, color: C.text, textAlign: 'center',
+  },
+  pickerChildAge: {
+    fontFamily: F.body, fontSize: 11, color: C.textSub,
+  },
+  pickerCancel: {
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  pickerCancelText: {
+    fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted,
   },
 
   // Empty state (0 children)

--- a/apps/mobile/app/child-profile/[id].tsx
+++ b/apps/mobile/app/child-profile/[id].tsx
@@ -1,0 +1,403 @@
+// app/child-profile/[id].tsx
+// "Your Child" profile screen — Master Blueprint's explicit conversion
+// trigger ("parents pay when they see Sturdy knows their child").
+//
+// Sections:
+//   1. Header — avatar, name, age
+//   2. Common triggers — top 5 trigger categories from interaction_logs
+//   3. What works — saved scripts for this child (proxy for "what helped")
+//   4. Emerging patterns — placeholder + lock (table not built yet)
+//   5. Weekly insight — locked teaser + Coming-soon pill
+//   6. Profile basics — read-only name / age / neurotype (editing TBD)
+//
+// Empty states are load-bearing: they tell the parent the profile gets
+// smarter the more they use Sturdy. That IS the conversion hook.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics from 'expo-haptics';
+
+import { useChildProfile } from '../../src/context/ChildProfileContext';
+import { loadSavedScripts, type SavedScriptRow } from '../../src/lib/loadSavedScripts';
+import { loadChildInsights, type ChildInsights } from '../../src/lib/loadChildInsights';
+import { colors as C, fonts as F } from '../../src/theme';
+
+const HORIZON_PHOTO = require('../../assets/images/welcome/welcome-horizon.jpg');
+
+// ═══════════════════════════════════════════════
+// SCREEN
+// ═══════════════════════════════════════════════
+
+export default function ChildProfileScreen() {
+  const params = useLocalSearchParams<{ id?: string }>();
+  const { children } = useChildProfile() as any;
+
+  const child = useMemo(() => {
+    if (!params.id || !Array.isArray(children)) return null;
+    return children.find((c: any) => c?.id === params.id) ?? null;
+  }, [params.id, children]);
+
+  const [insights, setInsights]     = useState<ChildInsights | null>(null);
+  const [savedScripts, setSavedScripts] = useState<SavedScriptRow[]>([]);
+  const [isLoading, setIsLoading]   = useState(true);
+
+  // Bounce home if the child id doesn't resolve.
+  useEffect(() => {
+    if (Array.isArray(children) && children.length > 0 && !child && params.id) {
+      router.replace('/(tabs)');
+    }
+  }, [children, child, params.id]);
+
+  const refresh = useCallback(async () => {
+    if (!child?.id) return;
+    setIsLoading(true);
+    try {
+      const [ins, all] = await Promise.all([
+        loadChildInsights(child.id),
+        loadSavedScripts(),
+      ]);
+      setInsights(ins);
+      setSavedScripts(all.filter((s) => s.child_profile_id === child.id));
+    } catch {
+      // Both helpers swallow their own errors — empty states render either way.
+    } finally {
+      setIsLoading(false);
+    }
+  }, [child?.id]);
+
+  useFocusEffect(
+    useCallback(() => {
+      refresh();
+    }, [refresh]),
+  );
+
+  const handleBack = () => {
+    Haptics.selectionAsync();
+    router.back();
+  };
+
+  if (!child) {
+    return (
+      <View style={s.root}>
+        <StatusBar style="light" />
+        <Image source={HORIZON_PHOTO} style={StyleSheet.absoluteFill} resizeMode="cover" />
+        <LinearGradient
+          colors={['rgba(15,10,18,0.45)', 'rgba(15,10,18,0.65)', 'rgba(15,10,18,0.82)']}
+          style={StyleSheet.absoluteFill}
+        />
+        <SafeAreaView style={s.centerGate}>
+          <ActivityIndicator color={'#E8A855'} />
+        </SafeAreaView>
+      </View>
+    );
+  }
+
+  const initial = (child?.name?.trim()?.[0] ?? '?').toUpperCase();
+  const totalInteractions = insights?.totalInteractions ?? 0;
+  const topTriggers = insights?.topTriggers ?? [];
+  const isNewProfile = totalInteractions < 3 && !isLoading;
+  const neurotypeText = Array.isArray(child?.neurotype) && child.neurotype.length > 0
+    ? child.neurotype.join(', ')
+    : null;
+
+  return (
+    <View style={s.root}>
+      <StatusBar style="light" />
+      <Image source={HORIZON_PHOTO} style={StyleSheet.absoluteFill} resizeMode="cover" />
+      <LinearGradient
+        colors={['rgba(15,10,18,0.45)', 'rgba(15,10,18,0.65)', 'rgba(15,10,18,0.82)']}
+        style={StyleSheet.absoluteFill}
+      />
+
+      <SafeAreaView style={s.safe} edges={['top']}>
+        <ScrollView
+          contentContainerStyle={s.scroll}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* ─── Top bar ─── */}
+          <View style={s.topBar}>
+            <Pressable onPress={handleBack} hitSlop={12} style={s.backBtn}>
+              <Text style={s.backText}>← Back</Text>
+            </Pressable>
+          </View>
+
+          {/* ─── Header ─── */}
+          <View style={s.identity}>
+            <View style={s.avatar}>
+              <Text style={s.avatarText}>{initial}</Text>
+            </View>
+            <Text style={s.childName}>{child.name}'s profile</Text>
+            <Text style={s.childAge}>Age {child.childAge}</Text>
+            {totalInteractions > 0 ? (
+              <Text style={s.interactionMeta}>
+                {totalInteractions} {totalInteractions === 1 ? 'interaction' : 'interactions'} so far
+              </Text>
+            ) : null}
+          </View>
+
+          {/* ─── 1. Common triggers ─── */}
+          <View style={s.section}>
+            <Text style={s.sectionTitle}>What sets {child.name} off</Text>
+            {topTriggers.length === 0 ? (
+              <View style={s.emptyCard}>
+                <Text style={s.emptyEmoji}>🌱</Text>
+                <Text style={s.emptyTitle}>Sturdy is just getting started</Text>
+                <Text style={s.emptyBody}>
+                  Use Sturdy a few more times and this section will fill in with the moments
+                  that come up most for {child.name}.
+                </Text>
+              </View>
+            ) : (
+              <View style={s.card}>
+                {topTriggers.map((t) => {
+                  const max = topTriggers[0]?.count || 1;
+                  const widthPct = Math.max(8, Math.round((t.count / max) * 100));
+                  return (
+                    <View key={t.category} style={s.triggerRow}>
+                      <View style={s.triggerHeader}>
+                        <Text style={s.triggerLabel}>{t.label}</Text>
+                        <Text style={s.triggerCount}>×{t.count}</Text>
+                      </View>
+                      <View style={s.triggerBarBg}>
+                        <View style={[s.triggerBarFill, { width: `${widthPct}%` as any }]} />
+                      </View>
+                    </View>
+                  );
+                })}
+              </View>
+            )}
+          </View>
+
+          {/* ─── 2. What works ─── */}
+          <View style={s.section}>
+            <Text style={s.sectionTitle}>What's helped before</Text>
+            {savedScripts.length === 0 ? (
+              <View style={s.emptyCard}>
+                <Text style={s.emptyEmoji}>💛</Text>
+                <Text style={s.emptyTitle}>Nothing saved yet</Text>
+                <Text style={s.emptyBody}>
+                  When a script lands, save it. They'll show up here so you can find them
+                  again the next time something similar comes up.
+                </Text>
+              </View>
+            ) : (
+              <View style={s.card}>
+                {savedScripts.slice(0, 3).map((sc) => (
+                  <Pressable
+                    key={sc.id}
+                    onPress={() => router.push('/saved')}
+                    style={({ pressed }) => [s.workRow, pressed && { opacity: 0.85 }]}
+                  >
+                    <View style={s.workDot} />
+                    <View style={{ flex: 1 }}>
+                      <Text style={s.workTitle} numberOfLines={1}>
+                        {sc.title || sc.structured?.situation_summary || 'Saved script'}
+                      </Text>
+                      {sc.structured?.regulate?.script ? (
+                        <Text style={s.workQuote} numberOfLines={2}>
+                          "{sc.structured.regulate.script}"
+                        </Text>
+                      ) : null}
+                    </View>
+                  </Pressable>
+                ))}
+                {savedScripts.length > 3 ? (
+                  <Pressable onPress={() => router.push('/saved')} style={s.workSeeAll}>
+                    <Text style={s.workSeeAllText}>See all {savedScripts.length} →</Text>
+                  </Pressable>
+                ) : null}
+              </View>
+            )}
+          </View>
+
+          {/* ─── 3. Emerging patterns (locked / coming soon) ─── */}
+          <View style={s.section}>
+            <Text style={s.sectionTitle}>Emerging patterns</Text>
+            <View style={[s.lockedCard]}>
+              <View style={s.lockedHeader}>
+                <Text style={s.lockedIcon}>🔒</Text>
+                <Text style={s.lockedPill}>COMING SOON</Text>
+              </View>
+              <Text style={s.lockedBody}>
+                Sturdy will start noticing things like "worst moments around 4–6pm" or
+                "{child.name} responds to repair quickly" once we have enough to go on.
+              </Text>
+            </View>
+          </View>
+
+          {/* ─── 4. Weekly insight (locked / coming soon) ─── */}
+          <View style={s.section}>
+            <Text style={s.sectionTitle}>This week's insight</Text>
+            <View style={[s.lockedCard]}>
+              <View style={s.lockedHeader}>
+                <Text style={s.lockedIcon}>🔒</Text>
+                <Text style={s.lockedPill}>COMING SOON</Text>
+              </View>
+              <Text style={s.lockedBody}>
+                A short audio reflection every Sunday — what showed up for {child.name} this
+                week, what worked, and one thing to try next.
+              </Text>
+            </View>
+          </View>
+
+          {/* ─── 5. Profile basics (read-only for now) ─── */}
+          <View style={s.section}>
+            <Text style={s.sectionTitle}>Profile</Text>
+            <View style={s.card}>
+              <View style={s.basicRow}>
+                <Text style={s.basicLabel}>Name</Text>
+                <Text style={s.basicValue}>{child.name ?? '—'}</Text>
+              </View>
+              <View style={s.divider} />
+              <View style={s.basicRow}>
+                <Text style={s.basicLabel}>Age</Text>
+                <Text style={s.basicValue}>{child.childAge}</Text>
+              </View>
+              {neurotypeText ? (
+                <>
+                  <View style={s.divider} />
+                  <View style={s.basicRow}>
+                    <Text style={s.basicLabel}>Neurotype</Text>
+                    <Text style={s.basicValue}>{neurotypeText}</Text>
+                  </View>
+                </>
+              ) : null}
+              <Text style={s.basicHint}>Editing coming soon.</Text>
+            </View>
+          </View>
+
+          <View style={{ height: 32 }} />
+        </ScrollView>
+      </SafeAreaView>
+    </View>
+  );
+}
+
+// ═══════════════════════════════════════════════
+// STYLES
+// ═══════════════════════════════════════════════
+
+const s = StyleSheet.create({
+  root: { flex: 1, backgroundColor: C.base },
+  safe: { flex: 1 },
+  scroll: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 32, gap: 22 },
+  centerGate: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+
+  // Top bar
+  topBar: { flexDirection: 'row', alignItems: 'center', paddingTop: 4, paddingBottom: 4 },
+  backBtn: { paddingVertical: 6, paddingHorizontal: 4 },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.text },
+
+  // Identity header
+  identity: { alignItems: 'center', gap: 6, paddingTop: 4 },
+  avatar: {
+    width: 80, height: 80, borderRadius: 40,
+    alignItems: 'center', justifyContent: 'center',
+    backgroundColor: C.sage,
+    shadowColor: C.sage, shadowOpacity: 0.30, shadowRadius: 16,
+    shadowOffset: { width: 0, height: 6 }, elevation: 4,
+    marginBottom: 8,
+  },
+  avatarText: {
+    fontFamily: F.heading, fontSize: 32, color: '#FFFFFF', letterSpacing: -0.4,
+  },
+  childName: {
+    fontFamily: F.heading, fontSize: 24, color: C.text,
+    letterSpacing: -0.3, textAlign: 'center',
+  },
+  childAge: {
+    fontFamily: F.body, fontSize: 14, color: C.textSub,
+  },
+  interactionMeta: {
+    fontFamily: F.body, fontSize: 12, color: C.textMuted, marginTop: 4,
+  },
+
+  // Sections
+  section: { gap: 10 },
+  sectionTitle: {
+    fontFamily: F.subheading, fontSize: 16, color: C.text, letterSpacing: -0.2,
+  },
+
+  // Generic card
+  card: {
+    backgroundColor: C.cardGlass,
+    borderColor: C.border, borderWidth: 1,
+    borderRadius: 18, padding: 16, gap: 14,
+  },
+
+  // Empty state card (warm, not punitive)
+  emptyCard: {
+    backgroundColor: C.cardGlass,
+    borderColor: C.border, borderWidth: 1,
+    borderRadius: 18, padding: 18, gap: 8,
+    alignItems: 'flex-start',
+  },
+  emptyEmoji: { fontSize: 22, marginBottom: 2 },
+  emptyTitle: {
+    fontFamily: F.subheading, fontSize: 15, color: C.text, letterSpacing: -0.1,
+  },
+  emptyBody: {
+    fontFamily: F.body, fontSize: 14, color: C.textSub, lineHeight: 21,
+  },
+
+  // Triggers
+  triggerRow: { gap: 6 },
+  triggerHeader: { flexDirection: 'row', justifyContent: 'space-between' },
+  triggerLabel: { fontFamily: F.bodyMedium, fontSize: 14, color: C.text },
+  triggerCount: { fontFamily: F.body, fontSize: 13, color: C.textSub },
+  triggerBarBg: {
+    height: 6, borderRadius: 3, backgroundColor: 'rgba(255,255,255,0.06)',
+    overflow: 'hidden',
+  },
+  triggerBarFill: {
+    height: '100%', backgroundColor: C.amber, borderRadius: 3,
+  },
+
+  // What works
+  workRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
+  workDot: {
+    width: 8, height: 8, borderRadius: 4, marginTop: 7,
+    backgroundColor: C.sage,
+  },
+  workTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
+  workQuote: { fontFamily: F.body, fontSize: 13, color: C.textSub, lineHeight: 19, marginTop: 2 },
+  workSeeAll: { paddingTop: 4 },
+  workSeeAllText: { fontFamily: F.bodyMedium, fontSize: 13, color: C.amber },
+
+  // Locked / coming-soon card
+  lockedCard: {
+    backgroundColor: C.cardGlass,
+    borderColor: C.border, borderWidth: 1,
+    borderRadius: 18, padding: 16, gap: 8,
+  },
+  lockedHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  lockedIcon: { fontSize: 16 },
+  lockedPill: {
+    fontFamily: F.label, fontSize: 9, letterSpacing: 0.8,
+    color: C.amber, backgroundColor: 'rgba(247,149,102,0.12)',
+    paddingHorizontal: 8, paddingVertical: 3,
+    borderRadius: 999, overflow: 'hidden',
+  },
+  lockedBody: {
+    fontFamily: F.body, fontSize: 13, color: C.textSub, lineHeight: 19,
+  },
+
+  // Profile basics (read-only)
+  basicRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'baseline' },
+  basicLabel: { fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, letterSpacing: 0.3 },
+  basicValue: { fontFamily: F.bodySemi, fontSize: 15, color: C.text },
+  divider:    { height: 1, backgroundColor: C.divider },
+  basicHint:  { fontFamily: F.body, fontSize: 12, color: C.textMuted, marginTop: 4 },
+});

--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -28,6 +28,7 @@ import { useChildProfile } from '../../src/context/ChildProfileContext';
 import { getParentingScript, CrisisDetectedError } from '../../src/lib/api';
 import { detectCrisis } from '../../src/hooks/useCrisisMode';
 import { loadSavedScripts, type SavedScriptRow } from '../../src/lib/loadSavedScripts';
+import { incrementScriptCount } from '../../src/utils/profileNudge';
 import { colors as C, fonts as F } from '../../src/theme';
 
 const HORIZON_PHOTO = require('../../assets/images/welcome/welcome-horizon.jpg');
@@ -231,6 +232,11 @@ export default function ChildHubScreen() {
         intensity: mode === 'sos' ? intensity : null,
         mode,
       } as any);
+
+      // Bump per-child script counter — feeds the "after 3+ interactions"
+      // profile nudge on the result screen. Fire-and-forget; failures
+      // never block the navigation.
+      incrementScriptCount(child.id).catch(() => { /* no-op */ });
 
       navigation.push({
         pathname: '/result',

--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -45,6 +45,59 @@ const INTENSITY_OPTIONS = [
 
 const TIMEOUT_MS = 20 * 60 * 1000; // 20 min idle → sign out
 
+// ═══════════════════════════════════════════════
+// MODE COPY
+// The hub serves all 4 outcome modes (SOS / Reconnect / Understand /
+// Conversation). The mode comes from the URL `mode` param (set when the
+// parent taps an outcome card on Home). All four backend prompts return
+// the same R/C/G shape — we just adapt the input copy + intensity gating
+// so the parent knows what they're getting.
+// Intensity only matters for SOS — buildPrompt ignores it for the others.
+// ═══════════════════════════════════════════════
+
+type HubMode = 'sos' | 'reconnect' | 'understand' | 'conversation';
+
+const MODE_COPY: Record<HubMode, {
+  placeholder: (name: string) => string;
+  hint:        string;
+  cta:         string;
+  ctaLoading:  string;
+  showIntensity: boolean;
+}> = {
+  sos: {
+    placeholder: (n) => `What's happening with ${n} right now?`,
+    hint:        'A simple snapshot is enough.',
+    cta:         'Get Script',
+    ctaLoading:  'Getting script…',
+    showIntensity: true,
+  },
+  reconnect: {
+    placeholder: (n) => `What needs repair with ${n}?`,
+    hint:        'A few sentences about what just happened.',
+    cta:         'Find the words',
+    ctaLoading:  'Finding the words…',
+    showIntensity: false,
+  },
+  understand: {
+    placeholder: (n) => `What are you trying to understand about ${n}?`,
+    hint:        'Describe the pattern or behaviour.',
+    cta:         'Help me see it',
+    ctaLoading:  'Reading the pattern…',
+    showIntensity: false,
+  },
+  conversation: {
+    placeholder: (n) => `What conversation are you preparing with ${n}?`,
+    hint:        'Tell Sturdy the topic and what makes it hard.',
+    cta:         'Plan it with me',
+    ctaLoading:  'Planning…',
+    showIntensity: false,
+  },
+};
+
+function isHubMode(v: unknown): v is HubMode {
+  return v === 'sos' || v === 'reconnect' || v === 'understand' || v === 'conversation';
+}
+
 
 // ═══════════════════════════════════════════════
 // SCREEN
@@ -52,9 +105,13 @@ const TIMEOUT_MS = 20 * 60 * 1000; // 20 min idle → sign out
 
 export default function ChildHubScreen() {
   const navigation = useRouter();
-  const params = useLocalSearchParams<{ id?: string }>();
+  const params = useLocalSearchParams<{ id?: string; mode?: string }>();
   const { session, signOut } = useAuth();
   const { children, activeChild, setActiveChild } = useChildProfile() as any;
+
+  // ─── Mode (defaults to 'sos' if param absent or invalid) ───
+  const mode: HubMode = isHubMode(params.mode) ? params.mode : 'sos';
+  const copy = MODE_COPY[mode];
 
   // ─── Resolve the child from the URL id ───
   const child = useMemo(() => {
@@ -169,8 +226,10 @@ export default function ChildHubScreen() {
         childAge:  child.childAge ?? 4,
         message:   msg,
         userId:    session?.user?.id,
-        intensity,
-        mode:      'sos',
+        // Intensity is only meaningful for SOS — buildPrompt ignores it
+        // for the other modes anyway, but keep the request body clean.
+        intensity: mode === 'sos' ? intensity : null,
+        mode,
       } as any);
 
       navigation.push({
@@ -192,7 +251,7 @@ export default function ChildHubScreen() {
           guideStrategies:    JSON.stringify(script.guide.strategies ?? []),
           avoid:              JSON.stringify(script.avoid),
           childMessage:       msg,
-          mode:               'sos',
+          mode,
         },
       });
 
@@ -323,7 +382,7 @@ export default function ChildHubScreen() {
               <TextInput
                 multiline
                 numberOfLines={5}
-                placeholder={`What's happening with ${child.name} right now?`}
+                placeholder={copy.placeholder(child.name ?? 'them')}
                 placeholderTextColor={C.textMuted}
                 value={situation}
                 onChangeText={handleTextChange}
@@ -332,7 +391,7 @@ export default function ChildHubScreen() {
                 style={s.textarea}
                 textAlignVertical="top"
               />
-              <Text style={s.textareaHint}>A simple snapshot is enough.</Text>
+              <Text style={s.textareaHint}>{copy.hint}</Text>
 
               {/* Inline crisis banner */}
               <Animated.View style={[s.crisisBanner, { opacity: crisisOpacity }]}>
@@ -346,33 +405,35 @@ export default function ChildHubScreen() {
               </Animated.View>
             </View>
 
-            {/* ─── Intensity ─── */}
-            <View style={s.intensitySection}>
-              <View style={s.intensityHeader}>
-                <Text style={s.intensityLabel}>How intense?</Text>
-                <Text style={s.intensityOpt}>optional</Text>
+            {/* ─── Intensity (SOS mode only) ─── */}
+            {copy.showIntensity ? (
+              <View style={s.intensitySection}>
+                <View style={s.intensityHeader}>
+                  <Text style={s.intensityLabel}>How intense?</Text>
+                  <Text style={s.intensityOpt}>optional</Text>
+                </View>
+                <View style={s.intensityRow}>
+                  {INTENSITY_OPTIONS.map((opt) => {
+                    const sel = intensity === opt.level;
+                    return (
+                      <Pressable
+                        key={opt.level}
+                        onPress={() => handleSelectIntensity(opt.level)}
+                        style={({ pressed }) => [
+                          s.intensityPill,
+                          sel && { backgroundColor: `${opt.color}18`, borderColor: `${opt.color}45` },
+                          pressed && { opacity: 0.8 },
+                        ]}
+                      >
+                        <Text style={[s.intensityPillText, sel && { color: opt.color }]}>
+                          {opt.label}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
               </View>
-              <View style={s.intensityRow}>
-                {INTENSITY_OPTIONS.map((opt) => {
-                  const sel = intensity === opt.level;
-                  return (
-                    <Pressable
-                      key={opt.level}
-                      onPress={() => handleSelectIntensity(opt.level)}
-                      style={({ pressed }) => [
-                        s.intensityPill,
-                        sel && { backgroundColor: `${opt.color}18`, borderColor: `${opt.color}45` },
-                        pressed && { opacity: 0.8 },
-                      ]}
-                    >
-                      <Text style={[s.intensityPillText, sel && { color: opt.color }]}>
-                        {opt.label}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
-            </View>
+            ) : null}
 
             {error ? <Text style={s.errorText}>{error}</Text> : null}
 
@@ -386,7 +447,7 @@ export default function ChildHubScreen() {
             >
               <View style={[s.ctaBtn, (!canSubmit || loading) && s.ctaBtnDisabled]}>
                 <Text style={[s.ctaLabel, (!canSubmit || loading) && { color: C.textMuted }]}>
-                  {loading ? 'Getting script…' : 'Get Script'}
+                  {loading ? copy.ctaLoading : copy.cta}
                 </Text>
               </View>
             </Pressable>

--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -498,13 +498,28 @@ export default function ChildHubScreen() {
               </View>
             ) : null}
 
-            {/* ─── Insights placeholder ─── */}
-            <View style={s.insightsSection}>
-              <Text style={s.insightsTitle}>Patterns for {child.name}</Text>
-              <Text style={s.insightsBody}>
-                Keep talking to Sturdy and patterns will appear here — what triggers {child.name} most, what calms them, and what keeps working.
-              </Text>
-            </View>
+            {/* ─── Profile link (replaces static placeholder) ─── */}
+            {/* Doubles as the discoverable entry to the Your Child profile
+                screen (Feature 2) — patterns, what works, weekly insight. */}
+            <Pressable
+              onPress={() => router.push(`/child-profile/${child.id}` as any)}
+              style={({ pressed }) => [
+                s.insightsSection,
+                pressed && { opacity: 0.92, transform: [{ scale: 0.99 }] },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${child.name}'s profile`}
+            >
+              <View style={s.insightsRow}>
+                <View style={{ flex: 1, gap: 4 }}>
+                  <Text style={s.insightsTitle}>{child.name}'s profile</Text>
+                  <Text style={s.insightsBody}>
+                    Triggers, what works, and what Sturdy is noticing about {child.name}.
+                  </Text>
+                </View>
+                <Text style={s.insightsArrow}>→</Text>
+              </View>
+            </Pressable>
 
             {/* ─── Edit profile link ─── */}
             <Pressable
@@ -649,17 +664,17 @@ const s = StyleSheet.create({
     fontFamily: F.scriptItalic, fontSize: 13, color: C.textBody, lineHeight: 19,
   },
 
-  // Insights
+  // Insights / profile-link card
   insightsSection: {
     padding: 16, gap: 6,
     borderRadius: 16,
     backgroundColor: 'rgba(129,178,154,0.08)',
     borderWidth: 1, borderColor: 'rgba(129,178,154,0.18)',
   },
-  insightsTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.sage },
-  insightsBody: {
-    fontFamily: F.body, fontSize: 13, color: C.textBody, lineHeight: 20,
-  },
+  insightsRow:    { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  insightsTitle:  { fontFamily: F.bodySemi, fontSize: 14, color: C.sage },
+  insightsBody:   { fontFamily: F.body, fontSize: 13, color: C.textBody, lineHeight: 20 },
+  insightsArrow:  { fontFamily: F.bodySemi, fontSize: 18, color: C.sage },
 
   // Edit
   editBtn: { alignSelf: 'center', paddingVertical: 8 },

--- a/apps/mobile/app/result.tsx
+++ b/apps/mobile/app/result.tsx
@@ -30,6 +30,7 @@ import { CrisisDetectedError } from '../src/lib/api';
 import { supabase }       from '../src/lib/supabase';
 import { saveScript }     from '../src/lib/saveScript';
 import { detectCrisis } from '../src/hooks/useCrisisMode';
+import { shouldShowProfileNudge, markNudgeShown } from '../src/utils/profileNudge';
 import { colors as C, fonts as F } from '../src/theme';
 
 const { width: W } = Dimensions.get('window');
@@ -122,6 +123,12 @@ export default function ResultScreen() {
   const [feedbackStep, setFeedbackStep] = useState<'helpful' | 'outcome' | 'done'>('helpful');
   const [feedbackHelpful, setFeedbackHelpful] = useState<string | null>(null);
 
+  // Profile nudge — Master Blueprint: shown once per child after the
+  // 3rd script. Gate via AsyncStorage so the parent sees it at exactly
+  // the moment the personalisation feels real, never again.
+  const [showNudge, setShowNudge] = useState(false);
+  const nudgeOpacity = useRef(new Animated.Value(0)).current;
+
   const isFallback = !isValid(val(params.regulateScript));
   const mode = val(params.mode) ?? 'sos';
   const coachingDefaultOpen = mode !== 'sos';
@@ -156,6 +163,37 @@ export default function ResultScreen() {
     setFeedbackGiven(false); setFeedbackStep('helpful'); setFeedbackHelpful(null);
     return () => { voice.stop(); };
   }, [params.regulateScript]);
+
+  // ─── Profile-nudge gate ───
+  // Check once per child / per script. If eligible, mark shown
+  // immediately so the nudge never reappears for this child on a
+  // subsequent script (even if the parent doesn't tap it). Then fade
+  // in 1s after script renders so it doesn't compete.
+  useEffect(() => {
+    const cid = typeof params.childId === 'string' ? params.childId : null;
+    if (!cid) return;
+    let cancelled = false;
+    nudgeOpacity.setValue(0);
+    setShowNudge(false);
+
+    shouldShowProfileNudge(cid).then((should) => {
+      if (cancelled || !should) return;
+      setShowNudge(true);
+      markNudgeShown(cid).catch(() => { /* no-op */ });
+      const t = setTimeout(() => {
+        Animated.timing(nudgeOpacity, {
+          toValue: 1,
+          duration: 600,
+          useNativeDriver: true,
+        }).start();
+      }, 1000);
+      // store the timer in a closure so cancel can clear it
+      cancelTimer = () => clearTimeout(t);
+    });
+
+    let cancelTimer: (() => void) | null = null;
+    return () => { cancelled = true; if (cancelTimer) cancelTimer(); };
+  }, [params.childId, params.regulateScript]);
 
   const logSafetyEvent = async (excerpt: string, crisisType: string, riskLevel: string) => {
     if (!session?.user?.id) return;
@@ -259,11 +297,29 @@ const handleRetry = () => {
           </View>
         ) : null}
 
-        {/* Nudge */}
-        <View style={s.nudgeCard}>
-          <Text style={s.nudgeText}>Sturdy is learning how {childName || 'your child'} responds.</Text>
-          <Pressable onPress={() => { const cid = typeof params.childId === 'string' ? params.childId : null; if (cid) router.push(`/child/${cid}` as any); else router.replace('/(tabs)'); }}><Text style={s.nudgeLink}>See {childName ? `${childName}'s` : 'their'} profile →</Text></Pressable>
-        </View>
+        {/* Nudge — gated to once-per-child after 3+ scripts; routes to the
+            Your Child profile screen (the spec'd conversion trigger). */}
+        {showNudge ? (
+          <Animated.View style={[s.nudgeCard, { opacity: nudgeOpacity }]}>
+            <Text style={s.nudgeText}>
+              Sturdy is learning how{' '}
+              <Text style={s.nudgeName}>{childName || 'your child'}</Text>
+              {' '}responds.
+            </Text>
+            <Pressable
+              onPress={() => {
+                const cid = typeof params.childId === 'string' ? params.childId : null;
+                if (cid) router.push(`/child-profile/${cid}` as any);
+                else router.replace('/(tabs)');
+              }}
+              hitSlop={8}
+            >
+              <Text style={s.nudgeLink}>
+                See {childName ? `${childName}'s` : 'their'} profile →
+              </Text>
+            </Pressable>
+          </Animated.View>
+        ) : null}
         <Pressable onPress={handleShare} style={{ alignSelf: 'center', paddingVertical: 8 }}><Text style={s.shareText}>Share script</Text></Pressable>
         {saveErr ? <Text style={s.errorText}>{saveErr}</Text> : null}
         <View style={{ height: 100 }} />
@@ -342,8 +398,9 @@ const s = StyleSheet.create({
   escalationBtn: { alignSelf: 'flex-start', paddingVertical: 10, paddingHorizontal: 16, borderRadius: 12, backgroundColor: 'rgba(201,123,99,0.12)', borderWidth: 1, borderColor: 'rgba(201,123,99,0.25)' },
   escalationBtnText: { fontFamily: F.bodySemi, fontSize: 14, color: C.rose },
 
-  nudgeCard: { alignItems: 'center', gap: 4, borderRadius: 18, padding: 16, backgroundColor: 'rgba(129,178,154,0.06)', borderWidth: 1, borderColor: 'rgba(129,178,154,0.12)' },
+  nudgeCard: { alignSelf: 'center', maxWidth: 360, alignItems: 'center', gap: 6, borderRadius: 18, paddingVertical: 14, paddingHorizontal: 18, backgroundColor: 'rgba(129,178,154,0.06)', borderWidth: 1, borderColor: 'rgba(129,178,154,0.12)' },
   nudgeText: { fontFamily: F.body, fontSize: 13, color: C.textSub, textAlign: 'center' },
+  nudgeName: { fontFamily: F.headingItalic, fontSize: 14, color: C.text },
   nudgeLink: { fontFamily: F.bodySemi, fontSize: 13, color: C.sage },
 
   shareText: { fontFamily: F.bodySemi, fontSize: 13, color: C.rose, textDecorationLine: 'underline' },

--- a/apps/mobile/src/lib/loadChildInsights.ts
+++ b/apps/mobile/src/lib/loadChildInsights.ts
@@ -1,0 +1,94 @@
+// src/lib/loadChildInsights.ts
+// Aggregates per-child signals from the data we already collect — used
+// by the Your Child profile screen.
+//
+// Sources today (no new tables, per Feature-2 rule):
+//   • interaction_logs.trigger_category   → top triggers + counts
+//   • saved_scripts (filtered by child)   → "what works" proxy (parent
+//     bookmarked = signal that the script helped)
+//   • count of all interactions            → for the empty-state copy
+//     ("After a few more interactions, Sturdy will fill this in")
+//
+// child_insights / pattern recognition is spec'd as a future table; for
+// now its section renders an empty placeholder + lock icon.
+
+import { supabase } from './supabase';
+
+export type TriggerCount = {
+  category: string;   // raw key from triggerClassifier (e.g. 'homework')
+  label:    string;   // display-formatted ('Homework')
+  count:    number;
+};
+
+export type ChildInsights = {
+  totalInteractions: number;
+  topTriggers:       TriggerCount[];   // up to 5, sorted desc by count
+};
+
+const TRIGGER_LABELS: Record<string, string> = {
+  homework:         'Homework',
+  bedtime:          'Bedtime',
+  screen_time:      'Screen time',
+  leaving_places:   'Leaving places',
+  mealtime:         'Mealtime',
+  morning_routine:  'Morning routine',
+  sharing:          'Sharing',
+  sibling:          'Sibling fights',
+  separation:       'Separation',
+  public_meltdown:  'Public meltdowns',
+  getting_dressed:  'Getting dressed',
+  bath_time:        'Bath time',
+  sport_activity:   'Sport / activities',
+  social_conflict:  'Friend conflict',
+};
+
+function formatTriggerLabel(category: string): string {
+  return TRIGGER_LABELS[category] ?? category.replace(/_/g, ' ');
+}
+
+/**
+ * Aggregate trigger counts + total-interaction count for one child.
+ *
+ * Returns `{ totalInteractions: 0, topTriggers: [] }` if:
+ *   - the table is empty for this child (expected for new accounts), or
+ *   - the query errors (table missing, RLS blocked, etc.) — surfacing
+ *     the empty state is the right UX either way.
+ */
+export async function loadChildInsights(childProfileId: string): Promise<ChildInsights> {
+  if (!childProfileId) return { totalInteractions: 0, topTriggers: [] };
+
+  try {
+    const { data, error } = await supabase
+      .from('interaction_logs')
+      .select('trigger_category')
+      .eq('child_profile_id', childProfileId);
+
+    if (error || !Array.isArray(data)) {
+      return { totalInteractions: 0, topTriggers: [] };
+    }
+
+    const total = data.length;
+
+    // Tally non-null categories
+    const counts: Record<string, number> = {};
+    for (const row of data) {
+      const cat = (row as { trigger_category?: unknown }).trigger_category;
+      if (typeof cat === 'string' && cat.length > 0) {
+        counts[cat] = (counts[cat] ?? 0) + 1;
+      }
+    }
+
+    const topTriggers: TriggerCount[] = Object.entries(counts)
+      .map(([category, count]) => ({
+        category,
+        label: formatTriggerLabel(category),
+        count,
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    return { totalInteractions: total, topTriggers };
+  } catch {
+    return { totalInteractions: 0, topTriggers: [] };
+  }
+}

--- a/apps/mobile/src/utils/profileNudge.ts
+++ b/apps/mobile/src/utils/profileNudge.ts
@@ -1,0 +1,92 @@
+// src/utils/profileNudge.ts
+// Tracks per-child script counts so the result screen can show the
+// Master Blueprint's "Sturdy is learning how [child] responds. See
+// their profile →" nudge exactly once, after the 3rd script for that
+// child.
+//
+// AsyncStorage-backed (per-device, per-child). The counter resets on
+// reinstall — that's acceptable: the nudge is a one-time discovery
+// moment, not analytics. Server-side counting via interaction_logs is
+// possible but unnecessary for this UX.
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const COUNT_KEY = (childId: string) => `@sturdy/script-count-${childId}`;
+const SHOWN_KEY = (childId: string) => `@sturdy/profile-nudge-shown-${childId}`;
+
+export const NUDGE_THRESHOLD = 3;
+
+/**
+ * Increment + persist the script count for one child. Returns the new
+ * value. Call after a successful script generation; safe to await or
+ * fire-and-forget (failures are swallowed).
+ */
+export async function incrementScriptCount(childId: string): Promise<number> {
+  if (!childId) return 0;
+  try {
+    const raw = await AsyncStorage.getItem(COUNT_KEY(childId));
+    const next = (Number(raw) || 0) + 1;
+    await AsyncStorage.setItem(COUNT_KEY(childId), String(next));
+    return next;
+  } catch {
+    return 0;
+  }
+}
+
+export async function getScriptCount(childId: string): Promise<number> {
+  if (!childId) return 0;
+  try {
+    const raw = await AsyncStorage.getItem(COUNT_KEY(childId));
+    return Number(raw) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+export async function wasNudgeShown(childId: string): Promise<boolean> {
+  if (!childId) return true;        // safe default — don't show
+  try {
+    const raw = await AsyncStorage.getItem(SHOWN_KEY(childId));
+    return raw === 'true';
+  } catch {
+    return true;
+  }
+}
+
+export async function markNudgeShown(childId: string): Promise<void> {
+  if (!childId) return;
+  try {
+    await AsyncStorage.setItem(SHOWN_KEY(childId), 'true');
+  } catch {
+    // no-op
+  }
+}
+
+/**
+ * One-call check: should the result screen show the profile nudge for
+ * this child right now? True iff count >= 3 AND nudge has not yet been
+ * shown for this child. Caller is responsible for calling
+ * `markNudgeShown(childId)` once it actually renders.
+ */
+export async function shouldShowProfileNudge(childId: string): Promise<boolean> {
+  if (!childId) return false;
+  const [count, shown] = await Promise.all([
+    getScriptCount(childId),
+    wasNudgeShown(childId),
+  ]);
+  return count >= NUDGE_THRESHOLD && !shown;
+}
+
+/**
+ * DEV-only — wipe the count + shown flag for one child so the nudge
+ * surfaces again on the next 3rd script. Useful for testing the
+ * animation; not used in prod.
+ */
+export async function resetProfileNudge(childId: string): Promise<void> {
+  if (!childId) return;
+  try {
+    await AsyncStorage.multiRemove([COUNT_KEY(childId), SHOWN_KEY(childId)]);
+  } catch {
+    // no-op
+  }
+}


### PR DESCRIPTION
## Summary
This PR implements the Master Blueprint's conversion trigger by adding a dedicated child profile screen and outcome-mode routing system. Parents can now view per-child insights (triggers, saved scripts) and select from four outcome modes (SOS, Repair, Understand, Conversation) that adapt the interaction flow. A profile nudge appears after 3 scripts per child to encourage profile exploration.

## Key Changes

### New Screens & Navigation
- **`app/child-profile/[id].tsx`** — New "Your Child" profile screen showing:
  - Child header with avatar, name, age, interaction count
  - Top 5 trigger categories from `interaction_logs` with frequency bars
  - Saved scripts for the child ("What's helped before")
  - Locked placeholders for emerging patterns & weekly insights
  - Read-only profile basics (name, age, neurotype)
  - Empty states that communicate "Sturdy gets smarter with use"

- **Outcome mode system** — Four interaction modes (SOS, Reconnect, Understand, Conversation):
  - Mode cards added to home screen in a 2×2 grid
  - Tapping a mode routes to `/child/[id]?mode=<key>`
  - Multi-child picker modal appears when 2+ children exist
  - Single-child accounts auto-route without picker
  - Zero-child accounts bounce to child creation

### Mode-Aware Hub (`app/child/[id].tsx`)
- Reads `mode` URL param and adapts:
  - Placeholder text (e.g., "What's happening right now?" for SOS vs. "What needs repair?" for Reconnect)
  - Hint copy and CTA button labels
  - Intensity selector only shown for SOS mode
  - Backend prompt selection via `mode` param to API
- Calls `incrementScriptCount()` after successful script generation to feed the profile nudge

### Profile Nudge System (`src/utils/profileNudge.ts`)
- AsyncStorage-backed per-child script counter
- Nudge shown exactly once per child after 3rd script
- `shouldShowProfileNudge()` gates display; `markNudgeShown()` prevents re-display
- Fire-and-forget error handling (failures don't block navigation)

### Child Insights Aggregation (`src/lib/loadChildInsights.ts`)
- Queries `interaction_logs` to extract:
  - Total interaction count
  - Top 5 trigger categories with counts and formatted labels
- Returns empty state gracefully if table missing or query fails
- No new database tables required (uses existing `interaction_logs`)

### Result Screen Updates (`app/result.tsx`)
- Integrates profile nudge display with fade-in animation
- Nudge appears 1s after script renders
- Tapping nudge navigates to child profile screen
- Marked as shown immediately to prevent re-display on subsequent scripts

### Home Screen Updates (`app/(tabs)/index.tsx`)
- Added outcome selector grid (4 mode cards)
- Outcome → child picker modal for multi-child accounts
- Haptic feedback on mode/child selection
- Accessibility labels for outcome cards

## Implementation Details
- Mode copy centralized in `MODE_COPY` constant for easy localization
- Intensity only sent to API for SOS mode; other modes ignore it
- Profile nudge uses device-local storage (survives app restart, resets on reinstall)
- Empty states use warm emoji + encouraging copy to signal data collection in progress
- All error handling swallows failures gracefully (empty states render either way)
- Trigger labels mapped from database keys to human-readable format

https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj