### PR TITLE
feat: mock subscription hook + tone selector + voice playback (premium-gated)

### DIFF
--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -29,6 +29,9 @@ import { getParentingScript, CrisisDetectedError } from '../../src/lib/api';
 import { detectCrisis } from '../../src/hooks/useCrisisMode';
 import { loadSavedScripts, type SavedScriptRow } from '../../src/lib/loadSavedScripts';
 import { incrementScriptCount } from '../../src/utils/profileNudge';
+import { useSubscription } from '../../src/hooks/useSubscription';
+import { getTone, setTone, type Tone, TONE_DEFAULT } from '../../src/utils/tone';
+import { PaywallSheet } from '../../src/components/ui/PaywallSheet';
 import { colors as C, fonts as F } from '../../src/theme';
 
 const HORIZON_PHOTO = require('../../assets/images/welcome/welcome-horizon.jpg');
@@ -43,6 +46,14 @@ const INTENSITY_OPTIONS = [
   { level: 3, label: 'Hard',     color: '#F79566' },
   { level: 4, label: 'Intense',  color: C.rose },
 ] as const;
+
+// Tone selector — Sturdy+ only. Free users default to Gentle (per
+// Master Blueprint); Soft + Direct are locked behind PaywallSheet.
+const TONE_OPTIONS: Array<{ key: Tone; label: string; sub: string; premium: boolean }> = [
+  { key: 'soft',   label: 'Soft',   sub: 'Warm, spacious',  premium: true },
+  { key: 'gentle', label: 'Gentle', sub: 'Calm but clear',  premium: false },
+  { key: 'direct', label: 'Direct', sub: 'Short, firm',     premium: true },
+];
 
 const TIMEOUT_MS = 20 * 60 * 1000; // 20 min idle → sign out
 
@@ -142,6 +153,27 @@ export default function ChildHubScreen() {
   const [crisisFlag, setCrisisFlag]     = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
 
+  // ─── Tone (Sturdy+) ───
+  const { isPremium } = useSubscription();
+  const [tone, setToneState]            = useState<Tone>(TONE_DEFAULT);
+  const [paywallFor, setPaywallFor]     = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getTone().then((t) => { if (!cancelled) setToneState(t); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleSelectTone = (next: Tone, premium: boolean) => {
+    Haptics.selectionAsync();
+    if (premium && !isPremium) {
+      setPaywallFor(`${next.charAt(0).toUpperCase() + next.slice(1)} tone`);
+      return;
+    }
+    setToneState(next);
+    setTone(next).catch(() => { /* no-op */ });
+  };
+
   // ─── State: saved scripts ───
   const [savedScripts, setSavedScripts] = useState<SavedScriptRow[]>([]);
   const [refreshing, setRefreshing]     = useState(false);
@@ -231,6 +263,10 @@ export default function ChildHubScreen() {
         // for the other modes anyway, but keep the request body clean.
         intensity: mode === 'sos' ? intensity : null,
         mode,
+        // Tone preference — sent forward-compat. Free users always send
+        // Gentle (the locked default); premium users send their pick.
+        // Backend will use this once buildPrompt accepts a tone block.
+        tone: isPremium ? tone : 'gentle',
       } as any);
 
       // Bump per-child script counter — feeds the "after 3+ interactions"
@@ -411,6 +447,41 @@ export default function ChildHubScreen() {
               </Animated.View>
             </View>
 
+            {/* ─── Tone selector ─── */}
+            {/* Sturdy+ feature. Free users see all 3 chips; tapping a
+                locked one (Soft/Direct) opens the PaywallSheet. */}
+            <View style={s.toneSection}>
+              <View style={s.toneHeader}>
+                <Text style={s.toneLabel}>Tone</Text>
+                {!isPremium ? <Text style={s.tonePremiumPill}>Sturdy+</Text> : null}
+              </View>
+              <View style={s.toneRow}>
+                {TONE_OPTIONS.map((opt) => {
+                  const sel = tone === opt.key;
+                  const locked = opt.premium && !isPremium;
+                  return (
+                    <Pressable
+                      key={opt.key}
+                      onPress={() => handleSelectTone(opt.key, opt.premium)}
+                      style={({ pressed }) => [
+                        s.tonePill,
+                        sel && s.tonePillSelected,
+                        pressed && { opacity: 0.85 },
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityState={{ selected: sel, disabled: locked }}
+                    >
+                      <View style={s.toneTopRow}>
+                        <Text style={[s.tonePillLabel, sel && s.tonePillLabelSelected]}>{opt.label}</Text>
+                        {locked ? <Text style={s.toneLockIcon}>🔒</Text> : null}
+                      </View>
+                      <Text style={s.tonePillSub}>{opt.sub}</Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+
             {/* ─── Intensity (SOS mode only) ─── */}
             {copy.showIntensity ? (
               <View style={s.intensitySection}>
@@ -539,6 +610,12 @@ export default function ChildHubScreen() {
           </ScrollView>
         </KeyboardAvoidingView>
       </SafeAreaView>
+
+      <PaywallSheet
+        visible={paywallFor !== null}
+        onClose={() => setPaywallFor(null)}
+        feature={paywallFor ?? ''}
+      />
     </View>
   );
 }
@@ -669,6 +746,33 @@ const s = StyleSheet.create({
   savedPreview: {
     fontFamily: F.scriptItalic, fontSize: 13, color: C.textBody, lineHeight: 19,
   },
+
+  // Tone selector
+  toneSection: { gap: 8 },
+  toneHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  toneLabel: { fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, letterSpacing: 0.3 },
+  tonePremiumPill: {
+    fontFamily: F.label, fontSize: 9, letterSpacing: 0.8,
+    color: C.amber, backgroundColor: 'rgba(247,149,102,0.12)',
+    paddingHorizontal: 8, paddingVertical: 3,
+    borderRadius: 999, overflow: 'hidden',
+  },
+  toneRow: { flexDirection: 'row', gap: 8 },
+  tonePill: {
+    flex: 1, padding: 12, gap: 4,
+    borderRadius: 14,
+    backgroundColor: C.cardGlass,
+    borderColor: C.border, borderWidth: 1,
+  },
+  tonePillSelected: {
+    backgroundColor: 'rgba(247,149,102,0.10)',
+    borderColor: 'rgba(247,149,102,0.45)',
+  },
+  toneTopRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  tonePillLabel: { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
+  tonePillLabelSelected: { color: C.amber },
+  tonePillSub: { fontFamily: F.body, fontSize: 11, color: C.textSub },
+  toneLockIcon: { fontSize: 11 },
 
   // Insights / profile-link card
   insightsSection: {

--- a/apps/mobile/app/result.tsx
+++ b/apps/mobile/app/result.tsx
@@ -31,6 +31,8 @@ import { supabase }       from '../src/lib/supabase';
 import { saveScript }     from '../src/lib/saveScript';
 import { detectCrisis } from '../src/hooks/useCrisisMode';
 import { shouldShowProfileNudge, markNudgeShown } from '../src/utils/profileNudge';
+import { useSubscription } from '../src/hooks/useSubscription';
+import { PaywallSheet } from '../src/components/ui/PaywallSheet';
 import { colors as C, fonts as F } from '../src/theme';
 
 const { width: W } = Dimensions.get('window');
@@ -129,9 +131,15 @@ export default function ResultScreen() {
   const [showNudge, setShowNudge] = useState(false);
   const nudgeOpacity = useRef(new Animated.Value(0)).current;
 
+  // Voice playback gating — SOS is free for everyone; other modes
+  // require Sturdy+. Free user tapping locked voice opens PaywallSheet.
+  const { isPremium } = useSubscription();
+  const [voicePaywall, setVoicePaywall] = useState(false);
+
   const isFallback = !isValid(val(params.regulateScript));
   const mode = val(params.mode) ?? 'sos';
   const coachingDefaultOpen = mode !== 'sos';
+  const voiceLocked = mode !== 'sos' && !isPremium;
   const childName = activeChild?.name?.trim() ?? '';
   const childAge = activeChild?.childAge;
   const childInitial = childName ? childName[0].toUpperCase() : '?';
@@ -253,18 +261,31 @@ const handleRetry = () => {
           <Text style={s.safetyText}>If this feels unsafe, <Text style={s.safetyLinkText}>get immediate help →</Text></Text>
         </Pressable>
 
-        {/* Voice */}
-        <Pressable onPress={voice.toggle}>
+        {/* Voice — SOS free; other modes Sturdy+ */}
+        <Pressable onPress={() => voiceLocked ? setVoicePaywall(true) : voice.toggle()}>
           <View style={s.voiceCard}>
-            <View style={[s.playBtn, isPlaying && s.playBtnActive]}>
-              <Text style={{ color: '#FFF', fontSize: 14, marginLeft: isPlaying ? 0 : 2 }}>{isPlaying ? '⏹' : '▶'}</Text>
+            <View style={[s.playBtn, isPlaying && s.playBtnActive, voiceLocked && s.playBtnLocked]}>
+              <Text style={{ color: '#FFF', fontSize: 14, marginLeft: isPlaying ? 0 : 2 }}>
+                {voiceLocked ? '🔒' : isPlaying ? '⏹' : '▶'}
+              </Text>
             </View>
             <View style={{ flex: 1 }}>
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <Text style={s.voiceTitle}>{isPlaying ? 'Playing script…' : 'Listen to this script'}</Text>
+                <Text style={s.voiceTitle}>
+                  {voiceLocked
+                    ? 'Listen to this script'
+                    : isPlaying ? 'Playing script…' : 'Listen to this script'}
+                </Text>
                 {isPlaying && <PulsingDot />}
+                {voiceLocked ? <Text style={s.voicePremiumPill}>Sturdy+</Text> : null}
               </View>
-              <Text style={s.voiceSub}>{isPlaying ? `Now: ${voice.currentStep === 'regulate' ? 'Regulate' : voice.currentStep === 'connect' ? 'Connect' : 'Guide'}` : 'Put in your earbuds — Sturdy walks you through it'}</Text>
+              <Text style={s.voiceSub}>
+                {voiceLocked
+                  ? 'Voice playback is part of Sturdy+ for non-SOS modes.'
+                  : isPlaying
+                    ? `Now: ${voice.currentStep === 'regulate' ? 'Regulate' : voice.currentStep === 'connect' ? 'Connect' : 'Guide'}`
+                    : 'Put in your earbuds — Sturdy walks you through it'}
+              </Text>
             </View>
           </View>
         </Pressable>
@@ -325,6 +346,13 @@ const handleRetry = () => {
         <View style={{ height: 100 }} />
       </ScrollView>
 
+      <PaywallSheet
+        visible={voicePaywall}
+        onClose={() => setVoicePaywall(false)}
+        feature="Voice playback"
+        body="Sturdy reads the script aloud for Reconnect, Understand, and Conversation modes when you're on Sturdy+. SOS voice is always free."
+      />
+
       {/* Footer */}
       <View style={s.footer}>
         <LinearGradient colors={['transparent', 'rgba(253,250,245,0.95)', C.base]} locations={[0, 0.35, 0.75]} style={s.footerFade} pointerEvents="none" />
@@ -374,6 +402,13 @@ const s = StyleSheet.create({
   voiceCard: { flexDirection: 'row', alignItems: 'center', gap: 12, padding: 14, borderRadius: 18, backgroundColor: C.cardGlass, borderWidth: 1, borderColor: C.border },
   playBtn: { width: 42, height: 42, borderRadius: 21, backgroundColor: C.sage, alignItems: 'center', justifyContent: 'center' },
   playBtnActive: { backgroundColor: C.rose },
+  playBtnLocked: { backgroundColor: 'rgba(247,149,102,0.45)' },
+  voicePremiumPill: {
+    fontFamily: F.label, fontSize: 9, letterSpacing: 0.8,
+    color: C.amber, backgroundColor: 'rgba(247,149,102,0.12)',
+    paddingHorizontal: 8, paddingVertical: 3,
+    borderRadius: 999, overflow: 'hidden', marginLeft: 4,
+  },
   voiceTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
   voiceSub: { fontFamily: F.body, fontSize: 12, color: C.textMuted, marginTop: 2 },
 

--- a/apps/mobile/src/components/ui/PaywallSheet.tsx
+++ b/apps/mobile/src/components/ui/PaywallSheet.tsx
@@ -1,0 +1,96 @@
+// src/components/ui/PaywallSheet.tsx
+//
+// Reusable bottom-sheet modal shown when a free user taps a Sturdy+
+// feature (locked tone chip, locked voice playback, etc.).
+//
+// Calls the mock useSubscription().purchase() — when real RevenueCat is
+// wired, that hook's body is the only thing that needs to change. The
+// purchase button text + behaviour can stay identical.
+
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors as C, fonts as F } from '../../theme';
+import { useSubscription } from '../../hooks/useSubscription';
+
+type Props = {
+  visible:  boolean;
+  onClose:  () => void;
+  feature:  string;          // e.g. "Soft tone", "Voice playback"
+  body?:    string;          // optional supplementary explanation
+};
+
+export function PaywallSheet({ visible, onClose, feature, body }: Props) {
+  const { purchase } = useSubscription();
+
+  const handlePurchase = async () => {
+    await purchase();
+    onClose();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="fade"
+      transparent
+      onRequestClose={onClose}
+    >
+      <Pressable style={s.backdrop} onPress={onClose}>
+        <Pressable style={s.sheet} onPress={() => { /* stop bubble */ }}>
+          <Text style={s.lock}>🔒</Text>
+          <Text style={s.title}>{feature} is part of Sturdy+</Text>
+          {body ? <Text style={s.body}>{body}</Text> : null}
+          <Text style={s.body}>
+            Sturdy+ unlocks tone, voice playback, weekly insights, and the full
+            child profile. Try it free, cancel any time.
+          </Text>
+          <Pressable
+            onPress={handlePurchase}
+            style={({ pressed }) => [s.cta, pressed && { opacity: 0.9 }]}
+            accessibilityRole="button"
+          >
+            <Text style={s.ctaText}>Start Sturdy+</Text>
+          </Pressable>
+          <Pressable onPress={onClose} style={s.cancel}>
+            <Text style={s.cancelText}>Not right now</Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const s = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(15,10,18,0.65)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: 'rgba(28,22,30,0.98)',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: 36,
+    gap: 12,
+  },
+  lock:  { fontSize: 28, marginBottom: 4 },
+  title: {
+    fontFamily: F.heading, fontSize: 22, color: C.text,
+    letterSpacing: -0.3,
+  },
+  body:  {
+    fontFamily: F.body, fontSize: 14, color: C.textSub, lineHeight: 21,
+  },
+  cta: {
+    backgroundColor: C.amber,
+    borderRadius: 14,
+    paddingVertical: 16,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  ctaText: {
+    fontFamily: F.bodySemi, fontSize: 17, color: C.textInverse, letterSpacing: 0.3,
+  },
+  cancel:     { paddingVertical: 12, alignItems: 'center' },
+  cancelText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted },
+});

--- a/apps/mobile/src/hooks/useSubscription.ts
+++ b/apps/mobile/src/hooks/useSubscription.ts
@@ -1,0 +1,20 @@
+// src/hooks/useSubscription.ts
+//
+// MOCK subscription hook — billing is intentionally not wired yet.
+// When real RevenueCat / StoreKit lands, replace this file's body with
+// the live implementation; every call site already imports from here
+// and uses { isPremium, plan, purchase, restore }, so unlocking the
+// app is a single-file swap.
+
+export const useSubscription = () => ({
+  isPremium: false,
+  plan: 'free' as const,
+  purchase: async () => {
+    // eslint-disable-next-line no-console
+    console.log('[BILLING] purchase() — wire RevenueCat later');
+  },
+  restore: async () => {
+    // eslint-disable-next-line no-console
+    console.log('[BILLING] restore() — wire RevenueCat later');
+  },
+});

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -37,6 +37,11 @@ export type ParentingScriptRequest = {
   childProfileId?: string;
   intensity?:      number | null;
   mode?:           string;
+  // Tone preference — Soft / Gentle / Direct. Sent in the request body
+  // as a forward-compat hook; backend currently accepts and ignores
+  // (validateInput strips unknown fields). Activates once buildPrompt
+  // adds a tone-injection block.
+  tone?:           'soft' | 'gentle' | 'direct';
   isFollowUp?:     boolean;
   followUpType?:   string;
   originalScript?: {

--- a/apps/mobile/src/utils/tone.ts
+++ b/apps/mobile/src/utils/tone.ts
@@ -1,0 +1,33 @@
+// src/utils/tone.ts
+//
+// Per-device tone preference (Soft / Gentle / Direct) — Master Blueprint
+// names this a Sturdy+ feature; free users default to Gentle.
+// AsyncStorage-backed because user_preferences table is out of scope.
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type Tone = 'soft' | 'gentle' | 'direct';
+
+export const TONE_DEFAULT: Tone = 'gentle';
+const KEY = '@sturdy/tone-default';
+
+export function isTone(v: unknown): v is Tone {
+  return v === 'soft' || v === 'gentle' || v === 'direct';
+}
+
+export async function getTone(): Promise<Tone> {
+  try {
+    const raw = await AsyncStorage.getItem(KEY);
+    return isTone(raw) ? raw : TONE_DEFAULT;
+  } catch {
+    return TONE_DEFAULT;
+  }
+}
+
+export async function setTone(tone: Tone): Promise<void> {
+  try {
+    await AsyncStorage.setItem(KEY, tone);
+  } catch {
+    // no-op — preference is non-critical, tone falls back to default
+  }
+}


### PR DESCRIPTION
## Summary

Lays the premium-tier scaffolding so the v5 Sturdy+ features can be built and demoed end-to-end ahead of real billing. **When RevenueCat / StoreKit lands, only `useSubscription.ts` changes** — every gated feature unlocks automatically.

## What's in this PR

### `src/hooks/useSubscription.ts` (new)
Mock hook returning `{ isPremium: false, plan: 'free', purchase, restore }`. `purchase()` and `restore()` log a `[BILLING]` line for now. **Single swap-point** — replace this file's body with the live RevenueCat client when ready.

### `src/components/ui/PaywallSheet.tsx` (new)
Reusable bottom-sheet modal shown when a free user taps a Sturdy+ feature. "Start Sturdy+" CTA calls `useSubscription().purchase()`. Single component covers tone + voice + future premium hooks.

### `src/utils/tone.ts` (new)
AsyncStorage-backed tone preference (`Soft` / `Gentle` / `Direct`). Default `'gentle'`. Per-device. The `user_preferences` table is out of scope for now; AsyncStorage is the right shape for the mock-billing era.

### `src/lib/api.ts`
Extended `ParentingScriptRequest` with optional `tone?: 'soft' | 'gentle' | 'direct'`. Sent in the request body as a forward-compat hook — backend's `validateInput` strips unknown fields, so the value is accepted-and-ignored until `buildPrompt` adds a tone block.

### `apps/mobile/app/child/[id].tsx`
Tone selector: 3 chips (Soft / Gentle / Direct) above intensity.
- **Free users:** Soft + Direct render with 🔒 + a `Sturdy+` pill on the section header. Tapping a locked chip opens `PaywallSheet`, doesn't change selection.
- **Premium users:** full access; selection persists via `setTone()`.
- Tone passed in `getParentingScript()` body; free users always send `'gentle'` (matches the locked default).

### `apps/mobile/app/result.tsx`
Voice playback gating: SOS stays free; Reconnect / Understand / Conversation modes show 🔒 + Sturdy+ pill for free users. Tapping locked voice opens `PaywallSheet` (no audio plays).
- **Premium users:** existing voice player works for every mode.

## ⚠️ Backend caveat (non-blocking)

Tone preference is end-to-end on the client (UI → AsyncStorage → request body) but `buildPrompt.ts` doesn't yet read it. That's a separate edit (out of scope per the "don't change `buildPrompt` without asking" rule). When tone-injection lands, the wire is already in place — no client changes needed.

## Verification

- `tsc --noEmit` clean
- Visual smoke-test still required on a device


---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_