### PR TITLE
feat: wire tone param into buildPrompt — soft/gentle/direct

### DIFF
--- a/supabase/functions/_shared/buildPrompt.ts
+++ b/supabase/functions/_shared/buildPrompt.ts
@@ -11,12 +11,14 @@
 // 4. Follow-up mode — "What happened next?" context carries forward
 
 import { buildCategorySection } from './prompts/categories/index.ts';
+import { getToneBlock, type ToneLabel } from './prompts/tones/index.ts';
 export type BuildPromptInput = {
   childName:     string;
   childAge:      number;
   message:       string;
   intensity?:    number | null;
   mode?:         string | null; // 'sos' | 'reconnect' | 'understand' | 'conversation'
+  tone?:         ToneLabel | string | null; // 'soft' | 'gentle' | 'direct' (default = gentle = no-op)
   isFollowUp?:   boolean;
   followUpType?: string | null;
   originalScript?: {
@@ -273,10 +275,12 @@ function getSOSPrompt(
   neurotypePart: string[],
   intensityPart: string[],
   lengthRule: string,
+  tonePart: string[],
 ): string {
   return [
     ...neurotypePart,
     ...intensityPart,
+    ...tonePart,
     'You are Sturdy — a calm parenting guide.',
     'Write three things a parent can say OUT LOUD in a hard moment.',
     'Not advice. Not coaching. Actual words to say.',
@@ -337,7 +341,7 @@ function getSOSPrompt(
   ].filter(Boolean).join('\n');
 }
 
-function getReconnectPrompt(childName: string, childAge: number, message: string): string {
+function getReconnectPrompt(childName: string, childAge: number, message: string, toneBlock: string): string {
   return `You are Sturdy — a calm parenting guide.
 The parent is not in a crisis. They need help reconnecting after a rupture.
 
@@ -347,6 +351,7 @@ Situation: ${message.trim()}
 ${getAgeContext(childAge)}
 ${getMessageLengthRule(message)}
 ${GLOBAL_NEGATIVE_CONSTRAINTS}
+${toneBlock ? '\n' + toneBlock : ''}
 
 RECONNECT MODE CONSTRAINTS:
 - BANNED: Any form of correction, boundary-setting, or "I'm sorry but..."
@@ -369,7 +374,7 @@ ${JSON_ENFORCEMENT}
 }`;
 }
 
-function getUnderstandPrompt(childName: string, childAge: number, message: string): string {
+function getUnderstandPrompt(childName: string, childAge: number, message: string, toneBlock: string): string {
   return `You are Sturdy — a developmental expert. Explain the "WHY" behind behavior.
 
 Child: ${childName}, age ${childAge}
@@ -378,6 +383,7 @@ Observation: ${message.trim()}
 ${getAgeContext(childAge)}
 ${getMessageLengthRule(message)}
 ${GLOBAL_NEGATIVE_CONSTRAINTS}
+${toneBlock ? '\n' + toneBlock : ''}
 
 UNDERSTAND MODE CONSTRAINTS:
 - BANNED: Clinical/Academic jargon (e.g., "executive dysfunction", "amygdala hijack").
@@ -400,7 +406,7 @@ ${JSON_ENFORCEMENT}
 }`;
 }
 
-function getConversationPrompt(childName: string, childAge: number, message: string): string {
+function getConversationPrompt(childName: string, childAge: number, message: string, toneBlock: string): string {
   return `You are Sturdy. Help a parent plan a calm, non-crisis conversation.
 
 Child: ${childName}, age ${childAge}
@@ -409,6 +415,7 @@ Topic: ${message.trim()}
 ${getAgeContext(childAge)}
 ${getMessageLengthRule(message)}
 ${GLOBAL_NEGATIVE_CONSTRAINTS}
+${toneBlock ? '\n' + toneBlock : ''}
 
 CONVERSATION MODE CONSTRAINTS:
 - BANNED: Lecturing or "I-messages" that sound robotic.
@@ -438,11 +445,13 @@ function getFollowUpCoachingPrompt(
   childAge: number,
   message: string,
   intensity: number | null,
+  toneBlock: string,
 ): string {
   const neurotype = detectNeurotype(message);
   const neurotypePart = neurotype && NEUROTYPE_BLOCKS[neurotype]
     ? NEUROTYPE_BLOCKS[neurotype] + '\n'
     : '';
+  const tonePart = toneBlock ? toneBlock + '\n' : '';
 
   const titles: Record<string, string> = {
     refused:   "They won't budge — that's normal",
@@ -484,7 +493,7 @@ Read what the parent described. Respond to where the child is NOW, not where the
 The goal is: orient the parent, one clear next step.`,
   };
 
-  return `${neurotypePart}You are Sturdy — a calm parenting guide.
+  return `${neurotypePart}${tonePart}You are Sturdy — a calm parenting guide.
 
 The parent already received a 3-part script (Regulate, Connect, Guide) and tried it. Now they are telling you what happened next.
 CRITICAL RULE: DO NOT generate another 3-step script. DO NOT use the Regulate/Connect/Guide format. 
@@ -543,6 +552,7 @@ export function buildPrompt({
   message,
   intensity,
   mode,
+  tone,
   isFollowUp,
   followUpType,
   originalScript,
@@ -551,6 +561,11 @@ export function buildPrompt({
   // Resolve neurotype as an array of keys to pass into getSOSPrompt
   const detectedNeurotype = detectNeurotype(message);
   const activeNeurotypes = detectedNeurotype ? [detectedNeurotype] : [];
+
+  // Resolve tone block once — empty string for 'gentle' / null / unknown
+  // (no-op, mirrors pre-tone behaviour). 'soft' / 'direct' inject a
+  // short voice-modulation block.
+  const toneBlock = getToneBlock(tone ?? null);
 
   // Follow-up mode — warm guidance instead of full script
   if (isFollowUp && followUpType) {
@@ -561,6 +576,7 @@ export function buildPrompt({
       childAge,
       message,
       intensity ?? null,
+      toneBlock,
     );
   }
 
@@ -568,15 +584,15 @@ export function buildPrompt({
   const resolvedMode = mode ?? 'sos';
 
   if (resolvedMode === 'reconnect') {
-    return getReconnectPrompt(childName, childAge, message);
+    return getReconnectPrompt(childName, childAge, message, toneBlock);
   }
 
   if (resolvedMode === 'understand') {
-    return getUnderstandPrompt(childName, childAge, message);
+    return getUnderstandPrompt(childName, childAge, message, toneBlock);
   }
 
   if (resolvedMode === 'conversation') {
-    return getConversationPrompt(childName, childAge, message);
+    return getConversationPrompt(childName, childAge, message, toneBlock);
   }
 
   // Default — SOS mode
@@ -584,20 +600,23 @@ export function buildPrompt({
   const neurotypePart = detectedNeurotype && NEUROTYPE_BLOCKS[detectedNeurotype]
     ? [NEUROTYPE_BLOCKS[detectedNeurotype]]
     : [];
-  
+
   const intensityPart = intensity !== null && intensity !== undefined
     ? [getIntensityGuidance(intensity)]
     : [];
-  
+
+  const tonePart = toneBlock ? [toneBlock] : [];
+
   const lengthRule = getMessageLengthRule(message);
 
   return getSOSPrompt(
-    childName, 
-    childAge, 
-    message, 
-    intensity ?? null, 
+    childName,
+    childAge,
+    message,
+    intensity ?? null,
     neurotypePart,
     intensityPart,
-    lengthRule
+    lengthRule,
+    tonePart,
   );
 }

--- a/supabase/functions/_shared/prompts/tones/direct.ts
+++ b/supabase/functions/_shared/prompts/tones/direct.ts
@@ -1,0 +1,26 @@
+// supabase/functions/_shared/prompts/tones/direct.ts
+// Tone: DIRECT — confident, action-first, no sugarcoating.
+// Selected by Sturdy+ parents; default is GENTLE (no override).
+// Voice rules below mirror Script Quality Standards — direct is a
+// *modulation* of the existing voice, not a different voice.
+
+export const DIRECT_TONE_GUIDANCE = `
+== TONE: DIRECT ==
+
+The parent has chosen a DIRECT tone. Cut to the action. This is a modulation of the standard Sturdy voice — every existing voice rule still applies.
+
+What this CHANGES:
+— Skip warm-up phrases. Lead with what to say.
+— REGULATE may be a single short sentence — naming the situation, not soothing it.
+— CONNECT: feeling AND limit, but the limit is up front. "I won't let you hit. You're angry — I get it." not "I get it. You're angry. I won't let you hit."
+— GUIDE: one decisive next step. No softeners. Avoid "let's", "maybe", "would you", "if you can".
+— parent_action steps lean confident-physical — stand up, take their hand, set the timer, walk first, get low and still.
+
+What this does NOT change:
+— Direct is not harsh. Not commanding. Not yelling. Not threatening.
+— CONNECT must still name the feeling. Direct doesn't skip empathy — it just front-loads action.
+— No "because I said so". No threats ("or else…"). No shaming.
+— Age calibration still rules. Direct tone for a 2-year-old is still 3–4 words and still warm.
+
+VOICE CHECK: Would a calm, confident, trusted friend say this on a busy day? If yes, it passes.
+`.trim();

--- a/supabase/functions/_shared/prompts/tones/index.ts
+++ b/supabase/functions/_shared/prompts/tones/index.ts
@@ -1,0 +1,32 @@
+// supabase/functions/_shared/prompts/tones/index.ts
+// Tone dispatcher — maps a tone string to its guidance block.
+// Mirrors the categories/ pattern.
+//
+// 'gentle' is the canonical Sturdy voice; it returns an empty block so
+// nothing changes in the prompt. Anything unknown / missing also falls
+// back to gentle (no-op).
+
+import { SOFT_TONE_GUIDANCE }   from './soft.ts';
+import { DIRECT_TONE_GUIDANCE } from './direct.ts';
+
+export const TONE_LABELS = ['soft', 'gentle', 'direct'] as const;
+export type ToneLabel = typeof TONE_LABELS[number];
+
+export function isToneLabel(v: unknown): v is ToneLabel {
+  return v === 'soft' || v === 'gentle' || v === 'direct';
+}
+
+/**
+ * Returns the prompt block for a given tone, or empty string for the
+ * default ('gentle' / null / unknown). Empty strings are dropped from
+ * the prompt by .filter(Boolean) so a default-tone request produces
+ * the same prompt as before this feature shipped.
+ */
+export function getToneBlock(tone: ToneLabel | string | null | undefined): string {
+  switch (tone) {
+    case 'soft':   return SOFT_TONE_GUIDANCE;
+    case 'direct': return DIRECT_TONE_GUIDANCE;
+    case 'gentle':
+    default:       return '';
+  }
+}

--- a/supabase/functions/_shared/prompts/tones/soft.ts
+++ b/supabase/functions/_shared/prompts/tones/soft.ts
@@ -1,0 +1,27 @@
+// supabase/functions/_shared/prompts/tones/soft.ts
+// Tone: SOFT — extra gentle, validating, slower pacing.
+// Selected by Sturdy+ parents; default is GENTLE (no override).
+// Voice rules below mirror Script Quality Standards — soft is a
+// *modulation* of the existing voice, not a different voice.
+
+export const SOFT_TONE_GUIDANCE = `
+== TONE: SOFT ==
+
+The parent has chosen a SOFT tone. Lean warm, validating, slower-paced. This is a modulation of the standard Sturdy voice — every existing voice rule still applies.
+
+What this CHANGES:
+— Add small reassurances where they fit naturally inside the script lines: "It's okay." "I'm right here." "You're doing great." Use sparingly — one per script field, max.
+— Use shorter sentences with breath between them. A full stop in the middle of a script line is welcome.
+— Validate the feeling more than once if appropriate ("That felt unfair. That really hurt.").
+— parent_action steps lean physical-soothing — hand on back, kneel down, lower voice, soft eye contact.
+— REGULATE leans warmest. CONNECT names the feeling tenderly before holding the limit.
+
+What this does NOT change:
+— CONNECT must still hold the limit. Soft tone ≠ no boundary. The limit just lands wrapped in warmth.
+— Scripts still stay short. Soft is "warmer per word", not "more words".
+— No therapy speak. No "big feelings". No "I hear you that…". A soft real parent, not a soft therapist.
+— Banned phrases are still banned (see global negative constraints).
+— Age calibration still rules. Soft tone for a 2-year-old is still 3–4 words.
+
+VOICE CHECK: Would a tired parent rocking a sad child say this? If yes, it passes.
+`.trim();

--- a/supabase/functions/_shared/requestHelpers.ts
+++ b/supabase/functions/_shared/requestHelpers.ts
@@ -21,10 +21,13 @@ export type RequestBody = {
   childProfileId?: unknown;
   intensity?:      unknown;
   mode?:           unknown;
+  tone?:           unknown;
   isFollowUp?:     unknown;
   followUpType?:   unknown;
   originalScript?: unknown;
 };
+
+export type Tone = 'soft' | 'gentle' | 'direct';
 
 export type ValidatedInput = {
   childName:      string;
@@ -34,6 +37,7 @@ export type ValidatedInput = {
   childProfileId: string | null;
   intensity:      number | null;
   mode:           string | null;
+  tone:           Tone | null;
   isFollowUp:     boolean;
   followUpType:   string | null;
   originalScript: {
@@ -53,6 +57,9 @@ export function validateInput(body: RequestBody): ValidatedInput {
   const intensity      = typeof body.intensity === "number" && body.intensity >= 1 && body.intensity <= 5
                            ? Math.round(body.intensity) : null;
   const mode           = typeof body.mode === "string" ? body.mode : null;
+  const tone           = (body.tone === 'soft' || body.tone === 'gentle' || body.tone === 'direct')
+                           ? body.tone as Tone
+                           : null;
   const isFollowUp     = body.isFollowUp === true;
   const followUpType   = typeof body.followUpType === "string" ? body.followUpType : null;
   const originalScript = body.originalScript && typeof body.originalScript === "object"
@@ -70,7 +77,7 @@ export function validateInput(body: RequestBody): ValidatedInput {
 
   return {
     childName, childAge, message, userId, childProfileId,
-    intensity, mode, isFollowUp, followUpType, originalScript,
+    intensity, mode, tone, isFollowUp, followUpType, originalScript,
   };
 }
 

--- a/supabase/functions/_tests/buildPrompt.test.ts
+++ b/supabase/functions/_tests/buildPrompt.test.ts
@@ -277,3 +277,46 @@ Deno.test("buildPrompt — follow-up mode uses follow-up output schema, not 3-st
   assertStringIncludes(out, "what_to_do");
   assertEquals(out.includes("REGULATE — Stabilise the moment"), false);
 });
+
+// ─── tone injection ──────────────────────────────
+
+Deno.test("buildPrompt — tone 'soft' injects SOFT block in SOS", () => {
+  const out = buildPrompt({ childName: "Maya", childAge: 5, message: "She hit", tone: "soft" });
+  assertStringIncludes(out, "TONE: SOFT");
+});
+
+Deno.test("buildPrompt — tone 'direct' injects DIRECT block in SOS", () => {
+  const out = buildPrompt({ childName: "Maya", childAge: 5, message: "She hit", tone: "direct" });
+  assertStringIncludes(out, "TONE: DIRECT");
+});
+
+Deno.test("buildPrompt — tone 'gentle' injects nothing (default voice)", () => {
+  const out = buildPrompt({ childName: "Maya", childAge: 5, message: "She hit", tone: "gentle" });
+  assertEquals(out.includes("TONE: SOFT"), false);
+  assertEquals(out.includes("TONE: DIRECT"), false);
+});
+
+Deno.test("buildPrompt — tone missing injects nothing (back-compat)", () => {
+  const out = buildPrompt({ childName: "Maya", childAge: 5, message: "She hit" });
+  assertEquals(out.includes("TONE:"), false);
+});
+
+Deno.test("buildPrompt — tone applies to all 4 modes", () => {
+  for (const mode of ['sos', 'reconnect', 'understand', 'conversation'] as const) {
+    const out = buildPrompt({
+      childName: "Maya", childAge: 5, message: "x", mode, tone: 'soft',
+    });
+    assertStringIncludes(out, "TONE: SOFT", `mode ${mode} should inject tone block`);
+  }
+});
+
+Deno.test("buildPrompt — tone applies to follow-up mode too", () => {
+  const out = buildPrompt({
+    childName: "Maya", childAge: 5, message: "x",
+    tone: 'direct',
+    isFollowUp: true,
+    followUpType: "refused",
+    originalScript: { situation_summary: "x", regulate: "x", connect: "x", guide: "x" },
+  });
+  assertStringIncludes(out, "TONE: DIRECT");
+});

--- a/supabase/functions/_tests/validateInput.test.ts
+++ b/supabase/functions/_tests/validateInput.test.ts
@@ -219,3 +219,24 @@ Deno.test("validateInput — userId + childProfileId default to null when missin
   assertEquals(r.userId,         null);
   assertEquals(r.childProfileId, null);
 });
+
+// ─── tone ───────────────────────────────────────
+
+Deno.test("validateInput — tone passes through for soft/gentle/direct", () => {
+  for (const t of ['soft', 'gentle', 'direct'] as const) {
+    const r = validateInput({ childName: "X", childAge: 5, message: "x", tone: t });
+    assertEquals(r.tone, t, `tone ${t} should pass through`);
+  }
+});
+
+Deno.test("validateInput — tone unknown / wrong type → null", () => {
+  const a = validateInput({ childName: "X", childAge: 5, message: "x", tone: 'sassy' as unknown });
+  assertEquals(a.tone, null);
+  const b = validateInput({ childName: "X", childAge: 5, message: "x", tone: 42 as unknown });
+  assertEquals(b.tone, null);
+});
+
+Deno.test("validateInput — tone missing → null (default 'gentle' is resolved downstream)", () => {
+  const r = validateInput({ childName: "X", childAge: 5, message: "x" });
+  assertEquals(r.tone, null);
+});

--- a/supabase/functions/chat-parenting-assistant/index.ts
+++ b/supabase/functions/chat-parenting-assistant/index.ts
@@ -282,6 +282,7 @@ serve(async (req) => {
       message:        input.message,
       intensity:      input.intensity,
       mode:           input.mode,
+      tone:           input.tone,
       isFollowUp:     input.isFollowUp,
       followUpType:   input.followUpType,
       originalScript: input.originalScript,


### PR DESCRIPTION
## Summary

Picks up the `tone` param the mobile UI has been sending and threads it end-to-end into the prompt. `'gentle'` is a no-op (current voice preserved); `'soft'` and `'direct'` inject a short voice-modulation block that mirrors the existing prompt-pattern conventions in `_shared/prompts/categories/`.

## What's in this PR

### New files (mirror the `categories/` pattern)

- `supabase/functions/_shared/prompts/tones/soft.ts` — `SOFT_TONE_GUIDANCE`
- `supabase/functions/_shared/prompts/tones/direct.ts` — `DIRECT_TONE_GUIDANCE`
- `supabase/functions/_shared/prompts/tones/index.ts` — `getToneBlock(tone)` dispatcher

Both tone blocks read as a **modulation** of the standard Sturdy voice. Every existing voice rule (banned phrases, age calibration, neurotype stealth, Connect = feeling + limit) still applies. Aligned with `Sturdy_Script_Quality_Standards`.

### `buildPrompt.ts`
- `BuildPromptInput` gains `tone?: ToneLabel | string | null`
- Resolved once via `getToneBlock()` — returns empty string for `gentle` / `null` / unknown so default-tone requests produce the same prompt as before this PR
- Injected high in every mode prompt (mirrors neurotype injection):
  - **SOS:** `...neurotypePart, ...intensityPart, ...tonePart`
  - **Reconnect / Understand / Conversation:** after `GLOBAL_NEGATIVE_CONSTRAINTS`, above mode-specific constraints
  - **Follow-up:** at top of prompt next to `neurotypePart`

### `requestHelpers.ts`
- `RequestBody.tone?: unknown`
- `ValidatedInput.tone: Tone | null`
- `validateInput` accepts only `'soft' | 'gentle' | 'direct'`; anything else → `null`. Mirrors the existing intensity / mode validation pattern.

### `chat-parenting-assistant/index.ts`
- Passes `input.tone` to `buildPrompt()`

### Tests (+9, total 111 passing)
- `validateInput` (3 new): pass-through for valid tones, unknown/wrong-type → null, missing → null
- `buildPrompt` (6 new): soft injects `SOFT`, direct injects `DIRECT`, gentle is no-op, missing is no-op, all 4 modes inject tone, follow-up injects tone

`deno test supabase/functions/_tests/` — 111 ok | 0 failed.

## Out of scope

No mobile / UI / database / safety-system changes. Surface is contained to `supabase/functions/_shared/` + the edge function — exactly what the brief allowed.

The mobile UI has been wiring `tone` into the request body since the previous PR; this commit completes the loop.


---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_