### PR TITLE
feat: upgrade screen v3 dark identity — $9.99/mo, $69.99/yr

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -243,11 +243,11 @@ const s = StyleSheet.create({
   accountPlan: { fontFamily: F.body, fontSize: 12, color: C.textMuted },
 
   upgradeRow: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingHorizontal: 16, paddingVertical: 14 },
-  upgradeLabel: { fontFamily: F.bodySemi, fontSize: 15, color: C.rose },
+  upgradeLabel: { fontFamily: F.bodySemi, fontSize: 15, color: '#D4944A' },
   upgradeSub: { fontFamily: F.body, fontSize: 12, color: C.textMuted },
   upgradeBtn: {
     width: 36, height: 36, borderRadius: 12,
-    backgroundColor: C.rose,
+    backgroundColor: '#C8883A',
     alignItems: 'center', justifyContent: 'center',
   },
   upgradeBtnText: { fontSize: 16, color: '#FFFFFF', fontFamily: F.bodySemi },

--- a/apps/mobile/app/upgrade.tsx
+++ b/apps/mobile/app/upgrade.tsx
@@ -1,41 +1,53 @@
 // app/upgrade.tsx
-// v2 — Journal identity: pastel gradient, frosted glass, rose CTA
-// Soft, warm conversion — not aggressive
-// Monthly $9.99 (3-day trial) / Yearly $79.99 (7-day trial)
+// v3 — Dark identity: solid #0e0a10 base, glass cards, amber gradient CTA.
+// Replaces the v2 Journal pastel-gradient + rose-coral accents.
+//
+// Pricing (locked):
+//   Monthly  $9.99/month   · 3-day free trial
+//   Annual   $69.99/year   · 7-day free trial · 5 months free vs monthly
 
-
-import { useRef, useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Animated,
-  Dimensions,
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
-import { router }         from 'expo-router';
-import { StatusBar }       from 'expo-status-bar';
-import { SafeAreaView }    from 'react-native-safe-area-context';
-import { LinearGradient }  from 'expo-linear-gradient';
-import * as Haptics        from 'expo-haptics';
-import { useAuth }         from '../src/context/AuthContext';
+import { router }        from 'expo-router';
+import { StatusBar }     from 'expo-status-bar';
+import { SafeAreaView }  from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics      from 'expo-haptics';
 import { useChildProfile } from '../src/context/ChildProfileContext';
-import { colors as C, fonts as F } from '../src/theme';
+import { fonts as F } from '../src/theme';
 
+// ═══════════════════════════════════════════════
+// V3 DARK IDENTITY TOKENS (hardcoded per spec)
+// ═══════════════════════════════════════════════
 
-const { width: W } = Dimensions.get('window');
-
+const BG          = '#0e0a10';
+const SURFACE     = 'rgba(255,255,255,0.055)';
+const BORDER      = 'rgba(255,255,255,0.07)';
+const BORDER_HI   = 'rgba(255,255,255,0.13)';
+const TEXT        = 'rgba(255,255,255,0.92)';
+const TEXT_SEC    = 'rgba(255,255,255,0.52)';
+const TEXT_MUTED  = 'rgba(255,255,255,0.28)';
+const AMBER       = '#D4944A';                       // selected-plan accents
+const AMBER_DEEP  = '#C8883A';                       // CTA gradient start
+const AMBER_LIGHT = '#E8A855';                       // CTA gradient end
+const SAGE        = '#8DB89A';                       // checkmarks + savings badge
+const SAGE_BG     = 'rgba(141,184,154,0.12)';
 
 const FEATURES = [
   { icon: '🧒', label: 'Child profile & insights', desc: 'See what triggers your child and what works' },
-  { icon: '💡', label: 'Weekly insight', desc: 'Patterns Sturdy spots across your interactions' },
-  { icon: '🎯', label: 'Follow-up coaching', desc: '"What if they refuse?" — a second script, tailored' },
-  { icon: '🎨', label: 'Tone selector', desc: 'Firm, gentle, playful — match your parenting style' },
+  { icon: '💡', label: 'Weekly insight',           desc: 'Patterns Sturdy spots across your interactions' },
+  { icon: '🎯', label: 'Follow-up coaching',       desc: '"What if they refuse?" — a second script, tailored' },
+  { icon: '🎨', label: 'Tone selector',            desc: 'Soft, gentle, direct — match your parenting style' },
   { icon: '📚', label: 'Full interaction history', desc: 'Every script, searchable and saved' },
-  { icon: '🔊', label: 'Voice on all modes', desc: 'Listen to scripts hands-free, anytime' },
+  { icon: '🔊', label: 'Voice on all modes',       desc: 'Listen to scripts hands-free, anytime' },
 ];
-
 
 const FREE_FEATURES = [
   'Unlimited SOS scripts',
@@ -44,48 +56,22 @@ const FREE_FEATURES = [
 ];
 
 
-function BreathingGlow() {
-  const opacity = useRef(new Animated.Value(0.3)).current;
-  useEffect(() => {
-    Animated.loop(Animated.sequence([
-      Animated.timing(opacity, { toValue: 0.7, duration: 2000, useNativeDriver: true }),
-      Animated.timing(opacity, { toValue: 0.3, duration: 2000, useNativeDriver: true }),
-    ])).start();
-  }, [opacity]);
-  return (
-    <Animated.View
-      style={[StyleSheet.absoluteFill, {
-        opacity, backgroundColor: 'transparent',
-        shadowColor: C.rose, shadowOffset: { width: 0, height: 0 },
-        shadowOpacity: 0.3, shadowRadius: 30, elevation: 0,
-      }]}
-      pointerEvents="none"
-    />
-  );
-}
-
-
 export default function UpgradeScreen() {
-  const { session } = useAuth();
   const { activeChild } = useChildProfile();
   const childName = activeChild?.name?.trim() || '';
 
-
   const [selectedPlan, setSelectedPlan] = useState<'yearly' | 'monthly'>('yearly');
-  const [purchasing, setPurchasing] = useState(false);
+  const [purchasing, setPurchasing]     = useState(false);
 
-
-  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const fadeAnim  = useRef(new Animated.Value(0)).current;
   const slideAnim = useRef(new Animated.Value(24)).current;
-
 
   useEffect(() => {
     Animated.parallel([
-      Animated.timing(fadeAnim, { toValue: 1, duration: 500, useNativeDriver: true }),
+      Animated.timing(fadeAnim,  { toValue: 1, duration: 500, useNativeDriver: true }),
       Animated.timing(slideAnim, { toValue: 0, duration: 500, useNativeDriver: true }),
     ]).start();
   }, []);
-
 
   const handlePurchase = async () => {
     setPurchasing(true);
@@ -94,33 +80,25 @@ export default function UpgradeScreen() {
     setTimeout(() => { setPurchasing(false); }, 2000);
   };
 
-
-  const handleRestore = () => { Haptics.selectionAsync(); /* TODO: Wire to RevenueCat restore */ };
-
+  const handleRestore = () => {
+    Haptics.selectionAsync();
+    // TODO: Wire to RevenueCat restore
+  };
 
   const isYearly = selectedPlan === 'yearly';
 
-
   return (
     <SafeAreaView style={s.root} edges={['top', 'bottom']}>
-      <StatusBar style="dark" />
-      <LinearGradient
-        colors={[C.gradStart, C.gradMid1, C.gradMid2, C.gradEnd]}
-        start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
-        style={StyleSheet.absoluteFill}
-      />
-
+      <StatusBar style="light" />
 
       <ScrollView contentContainerStyle={s.scroll} showsVerticalScrollIndicator={false}>
         <Pressable onPress={() => router.back()} style={s.closeBtn} hitSlop={16}>
           <Text style={s.closeText}>✕</Text>
         </Pressable>
 
-
         <Animated.View style={{ opacity: fadeAnim, transform: [{ translateY: slideAnim }], gap: 20 }}>
 
-
-          {/* Hero */}
+          {/* ─── Hero ─── */}
           <View style={s.hero}>
             <Text style={s.heroIcon}>✦</Text>
             <Text style={s.heroTitle}>Sturdy+</Text>
@@ -131,10 +109,9 @@ export default function UpgradeScreen() {
             </Text>
           </View>
 
-
-          {/* Features */}
+          {/* ─── Features ─── */}
           <View style={s.featuresCard}>
-            <Text style={s.featuresTitle}>Everything in Sturdy+</Text>
+            <Text style={s.featuresTitle}>EVERYTHING IN STURDY+</Text>
             {FEATURES.map((f, i) => (
               <View key={i} style={s.featureRow}>
                 <Text style={s.featureIcon}>{f.icon}</Text>
@@ -146,10 +123,9 @@ export default function UpgradeScreen() {
             ))}
           </View>
 
-
-          {/* Free forever */}
+          {/* ─── Always free ─── */}
           <View style={s.freeSection}>
-            <Text style={s.freeTitle}>Always free</Text>
+            <Text style={s.freeTitle}>ALWAYS FREE</Text>
             <View style={s.freeList}>
               {FREE_FEATURES.map((f, i) => (
                 <View key={i} style={s.freeRow}>
@@ -160,76 +136,90 @@ export default function UpgradeScreen() {
             </View>
           </View>
 
-
-          {/* Plan selector */}
+          {/* ─── Plans ─── */}
           <View style={s.plans}>
             {/* Yearly */}
-            <Pressable onPress={() => { Haptics.selectionAsync(); setSelectedPlan('yearly'); }}
-              style={({ pressed }) => [pressed && { opacity: 0.9 }]}>
+            <Pressable
+              onPress={() => { Haptics.selectionAsync(); setSelectedPlan('yearly'); }}
+              style={({ pressed }) => [pressed && { opacity: 0.92 }]}
+            >
               <View style={[s.planCard, isYearly && s.planCardActive]}>
-                {isYearly && (
+                {isYearly ? (
                   <View style={s.bestBadge}>
                     <View style={s.bestBadgeInner}><Text style={s.bestBadgeText}>BEST VALUE</Text></View>
                   </View>
-                )}
+                ) : null}
                 <View style={s.planRow}>
                   <View style={[s.radio, isYearly && s.radioActive]}>
-                    {isYearly && <View style={s.radioDot} />}
+                    {isYearly ? <View style={s.radioDot} /> : null}
                   </View>
                   <View style={{ flex: 1, gap: 2 }}>
-                    <Text style={[s.planName, isYearly && { color: C.rose }]}>Yearly</Text>
-                    <Text style={s.planPrice}>$79.99/year · $6.67/mo</Text>
+                    <Text style={[s.planName, isYearly && { color: AMBER }]}>Yearly</Text>
+                    <Text style={s.planPrice}>$69.99/year · $5.83/mo</Text>
                   </View>
-                  <View style={s.trialBadge}><Text style={s.trialBadgeText}>7-day free trial</Text></View>
+                  <View style={s.trialBadge}>
+                    <Text style={s.trialBadgeText}>7-day free trial</Text>
+                  </View>
                 </View>
-                <Text style={s.planSave}>Save 33% vs monthly</Text>
+                <View style={s.savingsRow}>
+                  <View style={s.savingsBadge}>
+                    <Text style={s.savingsBadgeText}>5 months free</Text>
+                  </View>
+                </View>
               </View>
             </Pressable>
 
-
             {/* Monthly */}
-            <Pressable onPress={() => { Haptics.selectionAsync(); setSelectedPlan('monthly'); }}
-              style={({ pressed }) => [pressed && { opacity: 0.9 }]}>
+            <Pressable
+              onPress={() => { Haptics.selectionAsync(); setSelectedPlan('monthly'); }}
+              style={({ pressed }) => [pressed && { opacity: 0.92 }]}
+            >
               <View style={[s.planCard, !isYearly && s.planCardActive]}>
                 <View style={s.planRow}>
                   <View style={[s.radio, !isYearly && s.radioActive]}>
-                    {!isYearly && <View style={s.radioDot} />}
+                    {!isYearly ? <View style={s.radioDot} /> : null}
                   </View>
                   <View style={{ flex: 1, gap: 2 }}>
-                    <Text style={[s.planName, !isYearly && { color: C.rose }]}>Monthly</Text>
+                    <Text style={[s.planName, !isYearly && { color: AMBER }]}>Monthly</Text>
                     <Text style={s.planPrice}>$9.99/month</Text>
                   </View>
-                  <View style={s.trialBadge}><Text style={s.trialBadgeText}>3-day free trial</Text></View>
+                  <View style={s.trialBadge}>
+                    <Text style={s.trialBadgeText}>3-day free trial</Text>
+                  </View>
                 </View>
               </View>
             </Pressable>
           </View>
 
+          {/* ─── CTA ─── */}
+          <Pressable
+            onPress={handlePurchase}
+            disabled={purchasing}
+            style={({ pressed }) => [pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] }]}
+          >
+            <LinearGradient
+              colors={[AMBER_DEEP, AMBER_LIGHT]}
+              start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
+              style={s.ctaBtn}
+            >
+              <Text style={s.ctaText}>
+                {purchasing ? 'Starting trial…' : `Start ${isYearly ? '7' : '3'}-day free trial`}
+              </Text>
+              <Text style={s.ctaSub}>
+                {isYearly ? 'Then $69.99/year' : 'Then $9.99/month'} · Cancel anytime
+              </Text>
+            </LinearGradient>
+          </Pressable>
 
-          {/* CTA */}
-          <View style={s.ctaWrap}>
-            <BreathingGlow />
-            <Pressable onPress={handlePurchase} disabled={purchasing}
-              style={({ pressed }) => [pressed && { opacity: 0.9, transform: [{ scale: 0.98 }] }]}>
-              <View style={s.ctaBtn}>
-                <Text style={s.ctaText}>
-                  {purchasing ? 'Starting trial…' : `Start ${isYearly ? '7' : '3'}-day free trial`}
-                </Text>
-                <Text style={s.ctaSub}>
-                  {isYearly ? 'Then $79.99/year' : 'Then $9.99/month'} · Cancel anytime
-                </Text>
-              </View>
-            </Pressable>
-          </View>
-
-
-          {/* Fine print */}
+          {/* ─── Fine print ─── */}
           <View style={s.fine}>
-            <Pressable onPress={handleRestore}>
-              <Text style={s.fineLink}>Restore purchase</Text>
+            <Pressable onPress={handleRestore} style={s.restoreBtn}>
+              <Text style={s.restoreLink}>Restore purchase</Text>
             </Pressable>
             <Text style={s.fineText}>
-              Payment will be charged to your App Store account at the end of the trial period. Subscription automatically renews unless cancelled at least 24 hours before the end of the current period.
+              Payment will be charged to your App Store account at the end of the trial period.
+              Subscription automatically renews unless cancelled at least 24 hours before the end
+              of the current period.
             </Text>
             <View style={s.fineLinks}>
               <Pressable onPress={() => router.push('/legal/terms-of-service')}>
@@ -242,7 +232,6 @@ export default function UpgradeScreen() {
             </View>
           </View>
 
-
           <View style={{ height: 30 }} />
         </Animated.View>
       </ScrollView>
@@ -252,82 +241,107 @@ export default function UpgradeScreen() {
 
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.base },
+  root:   { flex: 1, backgroundColor: BG },
   scroll: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 60 },
 
-
+  // Close button
   closeBtn: {
-    alignSelf: 'flex-end', width: 36, height: 36, borderRadius: 18,
-    backgroundColor: C.cardGlass, borderWidth: 1, borderColor: C.border,
-    alignItems: 'center', justifyContent: 'center', marginBottom: 8,
+    alignSelf: 'flex-end',
+    width: 36, height: 36, borderRadius: 18,
+    backgroundColor: SURFACE,
+    borderWidth: 1, borderColor: BORDER_HI,
+    alignItems: 'center', justifyContent: 'center',
+    marginBottom: 8,
   },
-  closeText: { fontSize: 16, color: C.textMuted },
+  closeText: { fontSize: 16, color: TEXT_MUTED },
 
+  // Hero
+  hero:      { alignItems: 'center', gap: 8, paddingVertical: 16 },
+  heroIcon:  { fontSize: 32, color: AMBER, marginBottom: 4 },
+  heroTitle: { fontFamily: F.heading, fontSize: 36, color: TEXT, letterSpacing: -0.5 },
+  heroSub:   { fontFamily: F.body, fontSize: 16, color: TEXT_SEC, textAlign: 'center', lineHeight: 24, maxWidth: 320 },
 
-  hero: { alignItems: 'center', gap: 8, paddingVertical: 16 },
-  heroIcon: { fontSize: 32, color: C.rose, marginBottom: 4 },
-  heroTitle: { fontFamily: F.heading, fontSize: 36, color: C.text, letterSpacing: -0.5 },
-  heroSub: { fontFamily: F.body, fontSize: 16, color: C.textSub, textAlign: 'center', lineHeight: 24, maxWidth: 300 },
-
-
+  // Features card
   featuresCard: {
-    borderRadius: 18, padding: 18, gap: 14,
-    backgroundColor: 'rgba(201,123,99,0.05)', borderWidth: 1, borderColor: 'rgba(201,123,99,0.12)',
+    borderRadius: 20, padding: 18, gap: 14,
+    backgroundColor: SURFACE,
+    borderWidth: 1, borderColor: BORDER,
   },
-  featuresTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.rose, letterSpacing: 0.3 },
-  featureRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
-  featureIcon: { fontSize: 18, marginTop: 1 },
-  featureLabel: { fontFamily: F.bodySemi, fontSize: 15, color: C.text },
-  featureDesc: { fontFamily: F.body, fontSize: 13, color: C.textMuted },
+  featuresTitle: { fontFamily: F.label, fontSize: 11, letterSpacing: 0.8, color: AMBER },
+  featureRow:    { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
+  featureIcon:   { fontSize: 18, marginTop: 1 },
+  featureLabel:  { fontFamily: F.bodySemi, fontSize: 15, color: TEXT },
+  featureDesc:   { fontFamily: F.body, fontSize: 13, color: TEXT_SEC, lineHeight: 18 },
 
+  // Always-free
+  freeSection: { alignItems: 'center', gap: 10, paddingTop: 4 },
+  freeTitle:   { fontFamily: F.label, fontSize: 11, letterSpacing: 0.8, color: TEXT_MUTED },
+  freeList:    { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', gap: 14 },
+  freeRow:     { flexDirection: 'row', alignItems: 'center', gap: 5 },
+  freeCheck:   { fontFamily: F.bodySemi, fontSize: 13, color: SAGE },
+  freeLabel:   { fontFamily: F.body, fontSize: 13, color: TEXT_SEC },
 
-  freeSection: { alignItems: 'center', gap: 8 },
-  freeTitle: { fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted },
-  freeList: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', gap: 12 },
-  freeRow: { flexDirection: 'row', alignItems: 'center', gap: 4 },
-  freeCheck: { fontFamily: F.bodySemi, fontSize: 12, color: C.sage },
-  freeLabel: { fontFamily: F.body, fontSize: 13, color: C.textSub },
-
-
-  plans: { gap: 10 },
+  // Plans
+  plans:    { gap: 10 },
   planCard: {
-    borderRadius: 18, padding: 16, gap: 6,
-    backgroundColor: C.cardGlass, borderWidth: 1, borderColor: C.border,
+    borderRadius: 20, padding: 16, gap: 8,
+    backgroundColor: SURFACE,
+    borderWidth: 1, borderColor: BORDER,
   },
-  planCardActive: { borderColor: 'rgba(201,123,99,0.25)', backgroundColor: 'rgba(201,123,99,0.05)' },
-  planRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
-  planName: { fontFamily: F.bodySemi, fontSize: 16, color: C.text },
-  planPrice: { fontFamily: F.body, fontSize: 13, color: C.textMuted },
-  planSave: { fontFamily: F.bodyMedium, fontSize: 12, color: C.sage, marginLeft: 34 },
+  planCardActive: {
+    borderColor: 'rgba(212,148,74,0.45)',
+    backgroundColor: 'rgba(212,148,74,0.06)',
+  },
+  planRow:   { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  planName:  { fontFamily: F.bodySemi, fontSize: 16, color: TEXT },
+  planPrice: { fontFamily: F.body, fontSize: 13, color: TEXT_SEC },
 
+  // Radio
+  radio: {
+    width: 22, height: 22, borderRadius: 11,
+    borderWidth: 2, borderColor: BORDER_HI,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  radioActive: { borderColor: AMBER },
+  radioDot:    { width: 10, height: 10, borderRadius: 5, backgroundColor: AMBER },
 
-  radio: { width: 22, height: 22, borderRadius: 11, borderWidth: 2, borderColor: 'rgba(42,37,32,0.15)', alignItems: 'center', justifyContent: 'center' },
-  radioActive: { borderColor: C.rose },
-  radioDot: { width: 12, height: 12, borderRadius: 6, backgroundColor: C.rose },
+  // BEST VALUE badge (active yearly)
+  bestBadge:      { position: 'absolute', top: -10, right: 16, zIndex: 5 },
+  bestBadgeInner: { backgroundColor: AMBER, paddingHorizontal: 10, paddingVertical: 3, borderRadius: 8 },
+  bestBadgeText:  { fontFamily: F.label, fontSize: 9, letterSpacing: 0.8, color: '#0e0a10' },
 
+  // Trial / savings badges
+  trialBadge: {
+    backgroundColor: SAGE_BG,
+    paddingHorizontal: 8, paddingVertical: 4,
+    borderRadius: 8,
+  },
+  trialBadgeText: { fontFamily: F.bodyMedium, fontSize: 11, color: SAGE },
+  savingsRow:     { paddingLeft: 34 },
+  savingsBadge: {
+    alignSelf: 'flex-start',
+    backgroundColor: SAGE_BG,
+    paddingHorizontal: 8, paddingVertical: 3,
+    borderRadius: 8,
+  },
+  savingsBadgeText: { fontFamily: F.bodyMedium, fontSize: 11, color: SAGE, letterSpacing: 0.2 },
 
-  bestBadge: { position: 'absolute', top: -10, right: 16, zIndex: 5 },
-  bestBadgeInner: { backgroundColor: C.rose, paddingHorizontal: 10, paddingVertical: 3, borderRadius: 8 },
-  bestBadgeText: { fontFamily: F.label, fontSize: 9, letterSpacing: 0.8, color: '#FFFFFF' },
-
-
-  trialBadge: { backgroundColor: 'rgba(129,178,154,0.10)', borderWidth: 1, borderColor: 'rgba(129,178,154,0.18)', paddingHorizontal: 8, paddingVertical: 3, borderRadius: 8 },
-  trialBadgeText: { fontFamily: F.bodyMedium, fontSize: 11, color: C.sage },
-
-
-  ctaWrap: { position: 'relative' },
-  ctaBtn: { borderRadius: 20, paddingVertical: 18, alignItems: 'center', gap: 3, backgroundColor: C.rose },
+  // CTA
+  ctaBtn: {
+    borderRadius: 20,
+    paddingVertical: 18,
+    alignItems: 'center',
+    gap: 3,
+  },
   ctaText: { fontFamily: F.subheading, fontSize: 17, color: '#FFFFFF', letterSpacing: 0.3 },
-  ctaSub: { fontFamily: F.body, fontSize: 12, color: 'rgba(255,255,255,0.70)' },
+  ctaSub:  { fontFamily: F.body, fontSize: 12, color: 'rgba(255,255,255,0.78)' },
 
-
-  fine: { alignItems: 'center', gap: 10, paddingTop: 4 },
-  fineLink: { fontFamily: F.bodySemi, fontSize: 13, color: C.rose, textDecorationLine: 'underline' },
-  fineText: { fontFamily: F.body, fontSize: 11, color: C.textMuted, textAlign: 'center', lineHeight: 16, maxWidth: 300 },
-  fineLinks: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  fineLinkSmall: { fontFamily: F.bodyMedium, fontSize: 12, color: C.textMuted },
-  fineDot: { fontSize: 10, color: 'rgba(42,37,32,0.15)' },
+  // Fine print
+  fine:        { alignItems: 'center', gap: 10, paddingTop: 4 },
+  restoreBtn:  { paddingVertical: 4 },
+  restoreLink: { fontFamily: F.bodyMedium, fontSize: 13, color: TEXT_MUTED, textDecorationLine: 'underline' },
+  fineText:    { fontFamily: F.body, fontSize: 11, color: TEXT_MUTED, textAlign: 'center', lineHeight: 16, maxWidth: 320 },
+  fineLinks:   { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  fineLinkSmall: { fontFamily: F.bodyMedium, fontSize: 12, color: TEXT_MUTED },
+  fineDot:     { fontSize: 10, color: TEXT_MUTED },
 });
-
-
-


### PR DESCRIPTION
## Summary

Brings the paywall + the Settings upgrade row in line with the v3 dark identity (solid `#0e0a10`, glass surfaces, amber gradient CTAs). Replaces the v2 Journal pastel-gradient + rose-coral palette.

## `apps/mobile/app/upgrade.tsx` — full rewrite

- **Background:** solid `#0e0a10` (dropped `LinearGradient` + photo + blobs + the `BreathingGlow` halo). `StatusBar` style="light".
- **Cards:** `rgba(255,255,255,0.055)` bg, `rgba(255,255,255,0.07)` border, 20px radius. Active plan card: amber tint + amber border.
- **Primary CTA:** `LinearGradient` `#C8883A` → `#E8A855` (left-to-right). No rose/coral.
- **Secondary surfaces:** `rgba(255,255,255,0.13)` borders.
- **Text ladder:** 0.92 / 0.52 / 0.28 white opacities.
- **Pricing updated:** Monthly stays $9.99/mo (3-day trial); Annual drops **$79.99 → $69.99/yr** (7-day trial).
- **"5 months free"** savings badge under the yearly card — `rgba(141,184,154,0.12)` bg + `#8DB89A` text. Math: $9.99 × 12 = $119.88; $119.88 − $69.99 = **$49.89 ≈ 9.99 × 5 months**.
- **BEST VALUE** pill on yearly: amber fill, `#0e0a10` text.
- **Free-features checkmarks:** `#8DB89A` (sage).
- **Restore purchase + Terms / Privacy:** muted white (`rgba 0.28`), no longer rose-coral underlined link.
- v3 dark tokens hardcoded at the top of the file (`BG`, `SURFACE`, `BORDER`, `AMBER`, `SAGE`, etc.) so the screen owns its identity even when the global theme is cream elsewhere in the app.

## `apps/mobile/app/(tabs)/settings.tsx` — upgrade row only

- `upgradeLabel` color: `C.rose` → `'#D4944A'`
- `upgradeBtn` backgroundColor: `C.rose` → `'#C8883A'`
- All other settings styles untouched per brief.

## `apps/mobile/app/child/[id].tsx` — no change

The brief was **conditional** ("only update if `tonePremiumPill` uses `C.rose`"); it uses `C.amber`, which already aligns with the v3 amber identity. Skipped per spec.

## Out of scope (per brief)

- `apps/mobile/app/welcome/index.tsx` — locked
- `apps/mobile/app/(tabs)/index.tsx` — locked
- Backend / navigation / subscription-logic — untouched

`tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_