### PR TITLE
Add "Add another child" link to single-child home screen view

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -442,24 +442,37 @@ export default function HomeScreen() {
 
             {/* ─── 1 child: lite view shows quick link to their hub ─── */}
             {isSingleChild && onlyChild ? (
-              <Pressable
-                onPress={() => handleOpenChild(onlyChild.id)}
-                style={({ pressed }) => [
-                  s.singleChildCard,
-                  pressed && { opacity: 0.92, transform: [{ scale: 0.99 }] },
-                ]}
-              >
-                <View style={[s.singleChildAvatar, { backgroundColor: CHILD_COLORS[0] }]}>
-                  <Text style={s.singleChildAvatarText}>
-                    {(onlyChild.name?.trim()?.[0] ?? '?').toUpperCase()}
-                  </Text>
-                </View>
-                <View style={{ flex: 1 }}>
-                  <Text style={s.singleChildName}>Open {onlyChild.name}'s hub</Text>
-                  <Text style={s.singleChildSub}>Saved scripts, history, and SOS</Text>
-                </View>
-                <Text style={s.singleChildArrow}>→</Text>
-              </Pressable>
+              <>
+                <Pressable
+                  onPress={() => handleOpenChild(onlyChild.id)}
+                  style={({ pressed }) => [
+                    s.singleChildCard,
+                    pressed && { opacity: 0.92, transform: [{ scale: 0.99 }] },
+                  ]}
+                >
+                  <View style={[s.singleChildAvatar, { backgroundColor: CHILD_COLORS[0] }]}>
+                    <Text style={s.singleChildAvatarText}>
+                      {(onlyChild.name?.trim()?.[0] ?? '?').toUpperCase()}
+                    </Text>
+                  </View>
+                  <View style={{ flex: 1 }}>
+                    <Text style={s.singleChildName}>Open {onlyChild.name}'s hub</Text>
+                    <Text style={s.singleChildSub}>Saved scripts, history, and SOS</Text>
+                  </View>
+                  <Text style={s.singleChildArrow}>→</Text>
+                </Pressable>
+                <Pressable
+                  onPress={handleAddChild}
+                  style={({ pressed }) => [
+                    s.addChildLink,
+                    pressed && { opacity: 0.7 },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Add another child"
+                >
+                  <Text style={s.addChildLinkText}>+ Add another child</Text>
+                </Pressable>
+              </>
             ) : null}
 
             {/* ─── 2+ children: child selector ─── */}
@@ -651,6 +664,18 @@ const s = StyleSheet.create({
   },
   singleChildArrow: {
     fontFamily: F.bodySemi, fontSize: 20, color: C.rose,
+  },
+
+  // Add-another-child link (single-child view only)
+  addChildLink: {
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  addChildLinkText: {
+    fontFamily: F.bodyMedium,
+    fontSize: 13,
+    color: '#D4944A',
+    letterSpacing: 0.3,
   },
 
   // Multi-child selector


### PR DESCRIPTION
## Summary
Added an "Add another child" quick action link to the home screen when a user has only one child, improving discoverability and accessibility for adding additional children to their account.

## Key Changes
- Wrapped the single-child card in a Fragment to accommodate the new action link
- Added a new `Pressable` component below the single-child card that triggers `handleAddChild`
- Implemented new styles for the add-child link:
  - `addChildLink`: Container styling with vertical padding and centered alignment
  - `addChildLinkText`: Text styling with custom font, size, and warm gold color (#D4944A)
- Included proper accessibility attributes (`accessibilityRole` and `accessibilityLabel`) for the new button

## Implementation Details
- The new link appears only in the single-child view (when `isSingleChild && onlyChild` is true)
- Uses consistent press feedback pattern with opacity change (0.7 on press)
- Styled with a warm gold color to visually distinguish it from the main child card
- Maintains the existing layout structure and spacing conventions

https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj