### PR TITLE
copy: upgrade screen rewrite + tone selector deferred

### DIFF
--- a/apps/mobile/app/upgrade.tsx
+++ b/apps/mobile/app/upgrade.tsx
@@ -41,18 +41,17 @@ const SAGE        = '#8DB89A';                       // checkmarks + savings bad
 const SAGE_BG     = 'rgba(141,184,154,0.12)';
 
 const FEATURES = [
-  { icon: '🧒', label: 'Child profile & insights', desc: 'See what triggers your child and what works' },
-  { icon: '💡', label: 'Weekly insight',           desc: 'Patterns Sturdy spots across your interactions' },
-  { icon: '🎯', label: 'Follow-up coaching',       desc: '"What if they refuse?" — a second script, tailored' },
-  { icon: '🎨', label: 'Tone selector',            desc: 'Soft, gentle, direct — match your parenting style' },
-  { icon: '📚', label: 'Full interaction history', desc: 'Every script, searchable and saved' },
-  { icon: '🔊', label: 'Voice on all modes',       desc: 'Listen to scripts hands-free, anytime' },
+  { icon: '🧒', label: 'A Sturdy that knows your child', desc: 'Patterns Sturdy notices about what sets them off — and what helps' },
+  { icon: '💡', label: 'Weekly reflection',              desc: 'What Sturdy noticed across your weeks together' },
+  { icon: '🎯', label: 'Follow-up scripts',              desc: 'A second script for when the first one didn\'t land — tailored to what happened' },
+  { icon: '📚', label: 'Everything you\'ve saved, kept', desc: 'Every script, every answer — searchable, yours' },
+  { icon: '🔊', label: 'Voice on every mode',            desc: 'Hear the response read aloud — for the moments your hands are full' },
 ];
 
 const FREE_FEATURES = [
   'Unlimited SOS scripts',
-  'Voice on SOS',
-  'Regulate → Connect → Guide',
+  'Question mode',
+  'Crisis support',
 ];
 
 
@@ -104,14 +103,14 @@ export default function UpgradeScreen() {
             <Text style={s.heroTitle}>Sturdy+</Text>
             <Text style={s.heroSub}>
               {childName
-                ? `Unlock the full picture of how ${childName} responds — and grow as a parent.`
-                : 'Unlock the full picture of how your child responds — and grow as a parent.'}
+                ? `The version that remembers. So Sturdy gets sharper about ${childName}, week by week.`
+                : 'The version that remembers. So Sturdy gets sharper about your child, week by week.'}
             </Text>
           </View>
 
           {/* ─── Features ─── */}
           <View style={s.featuresCard}>
-            <Text style={s.featuresTitle}>EVERYTHING IN STURDY+</Text>
+            <Text style={s.featuresTitle}>WHAT STURDY+ ADDS</Text>
             {FEATURES.map((f, i) => (
               <View key={i} style={s.featureRow}>
                 <Text style={s.featureIcon}>{f.icon}</Text>
@@ -144,11 +143,6 @@ export default function UpgradeScreen() {
               style={({ pressed }) => [pressed && { opacity: 0.92 }]}
             >
               <View style={[s.planCard, isYearly && s.planCardActive]}>
-                {isYearly ? (
-                  <View style={s.bestBadge}>
-                    <View style={s.bestBadgeInner}><Text style={s.bestBadgeText}>BEST VALUE</Text></View>
-                  </View>
-                ) : null}
                 <View style={s.planRow}>
                   <View style={[s.radio, isYearly && s.radioActive]}>
                     {isYearly ? <View style={s.radioDot} /> : null}
@@ -206,7 +200,7 @@ export default function UpgradeScreen() {
                 {purchasing ? 'Starting trial…' : `Start ${isYearly ? '7' : '3'}-day free trial`}
               </Text>
               <Text style={s.ctaSub}>
-                {isYearly ? 'Then $69.99/year' : 'Then $9.99/month'} · Cancel anytime
+                {isYearly ? 'Then $69.99/year — that\'s $5.83/month' : 'Then $9.99/month'} · Cancel anytime
               </Text>
             </LinearGradient>
           </Pressable>
@@ -304,11 +298,6 @@ const s = StyleSheet.create({
   },
   radioActive: { borderColor: AMBER },
   radioDot:    { width: 10, height: 10, borderRadius: 5, backgroundColor: AMBER },
-
-  // BEST VALUE badge (active yearly)
-  bestBadge:      { position: 'absolute', top: -10, right: 16, zIndex: 5 },
-  bestBadgeInner: { backgroundColor: AMBER, paddingHorizontal: 10, paddingVertical: 3, borderRadius: 8 },
-  bestBadgeText:  { fontFamily: F.label, fontSize: 9, letterSpacing: 0.8, color: '#0e0a10' },
 
   // Trial / savings badges
   trialBadge: {

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -132,3 +132,50 @@ in particular makes the long-walk register more accessible to scanning
 parents without requiring shorter responses overall — preserving the
 breathing room that makes Sturdy feel like Sturdy while serving the
 cohort that wants the answer in seconds.
+
+### 2026-04-28 — Upgrade screen copy rewrite + tone selector deferred
+
+**Context:** The upgrade screen feature list was a six-row inventory
+that read like a pricing-page checklist (Child profile & insights /
+Weekly insight / Follow-up coaching / Tone selector / Full interaction
+history / Voice on all modes). The hero ("Unlock the full picture") and
+the ALWAYS FREE row ("Voice on SOS / Regulate → Connect → Guide") were
+written for an audience that already knows what Sturdy is — feature
+names instead of what those features feel like. The BEST VALUE badge on
+yearly was selling the plan against itself rather than the product.
+Tone selector was listed as a paid feature but the voice quality bar
+that makes Soft and Direct safe to ship has not yet been validated
+against the same eval rigor as the gentle default.
+
+**Decision:** Rewrote the FEATURES list to five emotional descriptions
+("A Sturdy that knows your child" / "Weekly reflection" / "Follow-up
+scripts" / "Everything you've saved, kept" / "Voice on every mode"),
+each paired with a what-it-feels-like subhead instead of a what-it-is
+label. Removed the tone selector from the paid list entirely until its
+voice block has its own eval pass. Replaced the hero subhead with "The
+version that remembers. So Sturdy gets sharper about [child], week by
+week." — naming the felt promise (memory + sharpening) rather than the
+abstract claim (full picture). Replaced FREE_FEATURES with the three
+that actually matter to a free-tier parent ("Unlimited SOS scripts /
+Question mode / Crisis support") so the divide reads as "free covers
+the moment, paid covers the relationship." Renamed the section header
+from EVERYTHING IN STURDY+ to WHAT STURDY+ ADDS to remove the
+inventory-listing register. Removed the BEST VALUE badge and its three
+supporting styles — the savings-row "5 months free" badge already
+carries that signal. Tightened the annual CTA subtext to "Then
+$69.99/year — that's $5.83/month" so the per-month frame appears at
+the moment of commitment, not just on the plan card.
+
+**Reasoning:** The upgrade screen is the only paid surface Sturdy has
+until billing wires up — every word on it is doing the job of the
+entire pricing strategy. Feature names market features; emotional
+descriptions market outcomes, and outcomes are what parents are
+actually deciding between. Removing tone selector from the paid pitch
+trades one bullet point for the integrity of not selling something
+whose voice quality has not been verified to the same standard as the
+default — better to add it back later from a position of confidence
+than to defend a Soft tone that drifts in the wild. The hero rewrite
+("the version that remembers") gives the screen a single thesis to
+live or die by: paid Sturdy gets sharper about your child over time.
+Everything else on the page now supports that one promise instead of
+itemizing parallel claims.


### PR DESCRIPTION
## Summary

- Rewrites the upgrade screen FEATURES list from six feature-name rows to five outcome-framed rows; drops the tone selector from the paid pitch until its voice block has its own eval pass.
- Replaces the hero subhead with the "version that remembers" thesis, swaps FREE_FEATURES to the three that actually matter for the free tier (unlimited SOS / Question mode / Crisis support), and renames the section header to `WHAT STURDY+ ADDS`.
- Removes the BEST VALUE badge (the savings-row "5 months free" already signals it) and tightens the annual CTA subtext to `Then $69.99/year — that's $5.83/month` so the per-month frame appears at commitment.

## Out of scope (untouched)

- Pricing constants ($9.99/month, $69.99/year, 3-day / 7-day trials)
- `useSubscription` mock + gating logic
- Dark identity tokens (BG / SURFACE / BORDER / TEXT / SAGE)
- LinearGradient CTA colors (AMBER_DEEP → AMBER_LIGHT)
- Animations (`fadeAnim`, `slideAnim`)
- Fine-print legal copy + Restore / Terms / Privacy links

## Test plan

- [x] `npx tsc --noEmit` clean from `apps/mobile/`
- [ ] Visual check on device: hero subhead reads "version that remembers", section header reads `WHAT STURDY+ ADDS`, no BEST VALUE badge on yearly card, annual CTA shows `Then $69.99/year — that's $5.83/month`
- [ ] FEATURES list renders 5 rows in order (no tone selector row)
- [ ] FREE_FEATURES row reads "Unlimited SOS scripts · Question mode · Crisis support"

See `docs/OPERATIONS.md` (2026-04-28 entry) for the reasoning behind the cuts.

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_