### PR TITLE
docs+ui: neurotype invisibility reconciliation + child setup rebuild

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -43,7 +43,7 @@ const HORIZON_PHOTO = require('../../assets/images/welcome/welcome-horizon.jpg')
 // CONSTANTS
 // ═══════════════════════════════════════════════
 
-const GREETINGS = ['Hi', 'Hello', 'Hey', 'Welcome back', 'Good to see you'];
+const GREETINGS = ['Hi', 'Hello', 'Hey'];
 
 // Rotating color palette for child avatars
 const CHILD_COLORS = [

--- a/apps/mobile/app/child-profile/[id].tsx
+++ b/apps/mobile/app/child-profile/[id].tsx
@@ -8,7 +8,7 @@
 //   3. What works — saved scripts for this child (proxy for "what helped")
 //   4. Emerging patterns — placeholder + lock (table not built yet)
 //   5. Weekly insight — locked teaser + Coming-soon pill
-//   6. Profile basics — read-only name / age / neurotype (editing TBD)
+//   6. Profile basics — read-only name / age (editing TBD)
 //
 // Empty states are load-bearing: they tell the parent the profile gets
 // smarter the more they use Sturdy. That IS the conversion hook.
@@ -108,9 +108,6 @@ export default function ChildProfileScreen() {
   const totalInteractions = insights?.totalInteractions ?? 0;
   const topTriggers = insights?.topTriggers ?? [];
   const isNewProfile = totalInteractions < 3 && !isLoading;
-  const neurotypeText = Array.isArray(child?.neurotype) && child.neurotype.length > 0
-    ? child.neurotype.join(', ')
-    : null;
 
   return (
     <View style={s.root}>
@@ -265,15 +262,6 @@ export default function ChildProfileScreen() {
                 <Text style={s.basicLabel}>Age</Text>
                 <Text style={s.basicValue}>{child.childAge}</Text>
               </View>
-              {neurotypeText ? (
-                <>
-                  <View style={s.divider} />
-                  <View style={s.basicRow}>
-                    <Text style={s.basicLabel}>Neurotype</Text>
-                    <Text style={s.basicValue}>{neurotypeText}</Text>
-                  </View>
-                </>
-              ) : null}
               <Text style={s.basicHint}>Editing coming soon.</Text>
             </View>
           </View>

--- a/apps/mobile/app/child-setup.tsx
+++ b/apps/mobile/app/child-setup.tsx
@@ -1,10 +1,10 @@
 // app/child-setup.tsx
-// v8 — Arrow age picker + slider + neurotype carousel
-// Logo palette: Blue #5778A3, Coral #E87461, Sage #8AA060, Amber #D4944A
+// v9 — First-time child setup: name + exact age. No neurotype UI.
+// Per docs/PRODUCT_PRINCIPLES.md §1: neurotype is invisible — detected silently
+// from how parents describe their child, never selected from a UI.
 
 import { useState } from 'react';
 import {
-  Dimensions,
   Image,
   Pressable,
   ScrollView,
@@ -24,21 +24,8 @@ import { useChildProfile } from '../src/context/ChildProfileContext';
 import { supabase }        from '../src/lib/supabase';
 import { colors as C, fonts as F } from '../src/theme/colors';
 
-const { width: W } = Dimensions.get('window');
 const MIN_AGE = 0;
 const MAX_AGE = 17;
-
-// ─── Neurotype data ───
-const NEUROTYPES = [
-  { key: 'ADHD',    icon: '⚡', label: 'ADHD',              desc: 'Moves fast, acts first, hard to wait',   color: C.coral,     bg: 'rgba(232,116,97,0.07)' },
-  { key: 'Autism',  icon: '🧩', label: 'Autistic',          desc: 'Loves routine, notices everything',       color: C.blue,      bg: 'rgba(87,120,163,0.07)' },
-  { key: 'Anxiety', icon: '🌧️', label: 'Anxiety',           desc: 'Worries deeply, needs safety first',      color: C.peach,     bg: 'rgba(247,149,102,0.07)' },
-  { key: 'Sensory', icon: '🎧', label: 'Sensory',           desc: 'Overwhelmed by noise, texture, crowds',   color: C.amber,     bg: 'rgba(212,148,74,0.07)' },
-  { key: 'PDA',     icon: '🛡️', label: 'PDA',               desc: 'Fights any demand, needs autonomy',       color: C.sage,      bg: 'rgba(138,160,96,0.07)' },
-  { key: '2e',      icon: '🌟', label: 'Twice exceptional', desc: 'Brilliant mind, big emotions',            color: C.blueLight, bg: 'rgba(107,141,184,0.07)' },
-] as const;
-
-type NeurotypeKey = typeof NEUROTYPES[number]['key'];
 
 // ─── Age hint ───
 function getAgeHint(age: number): string {
@@ -74,7 +61,6 @@ export default function ChildSetupScreen() {
  const { setActiveChild, reloadChild } = useChildProfile();
   const [name, setName]    = useState('');
   const [age, setAge]      = useState(5);
-  const [neurotypes, setNeurotypes] = useState<NeurotypeKey[]>([]);
   const [error, setError]  = useState('');
   const [saving, setSaving] = useState(false);
   const [nameFocused, setNameFocused] = useState(false);
@@ -87,13 +73,6 @@ export default function ChildSetupScreen() {
     if (next < MIN_AGE || next > MAX_AGE) return;
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     setAge(next);
-  };
-
-  const toggleNeurotype = (key: NeurotypeKey) => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setNeurotypes(prev =>
-      prev.includes(key) ? prev.filter(n => n !== key) : [...prev, key]
-    );
   };
 
   const handleContinue = async () => {
@@ -110,13 +89,12 @@ export default function ChildSetupScreen() {
             name: trimmed || 'My child',
             child_age: age,
             age_band: age <= 4 ? '2-4' : age <= 7 ? '5-7' : '8-12',
-            neurotype: neurotypes,
           });
         if (dbErr) throw dbErr;
       } else {
         await AsyncStorage.setItem(
           'sturdy_guest_child',
-          JSON.stringify({ name: trimmed, childAge: age, neurotype: neurotypes }),
+          JSON.stringify({ name: trimmed, childAge: age }),
         );
       }
       setActiveChild({ name: trimmed || '', childAge: age, neurotype: null });
@@ -244,56 +222,6 @@ router.replace('/(tabs)');
           {error ? <Text style={s.error}>{error}</Text> : null}
         </LinearGradient>
 
-        {/* ── Neurotype Carousel ── */}
-        <View style={s.neuroSection}>
-          <Text style={s.neuroSectionTitle}>Does your child have any of these?</Text>
-          <Text style={s.neuroSectionSub}>Optional · swipe to browse, tap to select</Text>
-
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={s.neuroCarousel}
-            decelerationRate="fast"
-            snapToInterval={W * 0.42 + 10}
-          >
-            {NEUROTYPES.map(n => {
-              const sel = neurotypes.includes(n.key);
-              return (
-                <Pressable
-                  key={n.key}
-                  onPress={() => toggleNeurotype(n.key)}
-                  style={({ pressed }) => [
-                    s.neuroTile,
-                    sel && { borderColor: `${n.color}50`, backgroundColor: n.bg },
-                    pressed && { opacity: 0.8 },
-                  ]}
-                >
-                  <View style={[s.neuroTileIconWrap, { backgroundColor: sel ? `${n.color}20` : 'rgba(255,255,255,0.06)' }]}>
-                    <Text style={s.neuroTileIcon}>{n.icon}</Text>
-                  </View>
-                  <Text style={[s.neuroTileLabel, sel && { color: n.color }]}>{n.label}</Text>
-                  <Text style={[s.neuroTileDesc, sel && { color: 'rgba(255,255,255,0.50)' }]}>{n.desc}</Text>
-                  {sel && (
-                    <View style={[s.neuroTileCheck, { backgroundColor: n.color }]}>
-                      <Text style={s.neuroTileCheckText}>✓</Text>
-                    </View>
-                  )}
-                  <View style={[s.neuroTileBar, { backgroundColor: sel ? n.color : 'rgba(255,255,255,0.06)' }]} />
-                </Pressable>
-              );
-            })}
-          </ScrollView>
-
-          {neurotypes.length > 0 && (
-            <View style={s.neuroNote}>
-              <Text style={s.neuroNoteIcon}>🤫</Text>
-              <Text style={s.neuroNoteText}>
-                Scripts will quietly adapt for {neurotypes.join(' + ')} — your child is never labelled.
-              </Text>
-            </View>
-          )}
-        </View>
-
         {/* ── CTA ── */}
         <Pressable
           onPress={handleContinue}
@@ -312,6 +240,10 @@ router.replace('/(tabs)');
             </Text>
           </LinearGradient>
         </Pressable>
+
+        {!canContinue && name.trim().length === 0 ? (
+          <Text style={s.ctaHint}>Add your child's name to continue</Text>
+        ) : null}
 
         {/* Skip */}
         <Pressable onPress={handleSkip} style={s.skipBtn}>
@@ -367,29 +299,9 @@ const s = StyleSheet.create({
 
   error: { fontFamily: F.body, fontSize: 14, color: C.coral },
 
-  // Neurotype carousel
-  neuroSection: { gap: 12 },
-  neuroSectionTitle: { fontFamily: F.bodyMedium, fontSize: 16, color: C.textBody },
-  neuroSectionSub: { fontFamily: F.body, fontSize: 13, color: C.textMuted, marginTop: -6 },
-  neuroCarousel: { paddingHorizontal: 4, gap: 10 },
-  neuroTile: {
-    width: W * 0.42, borderRadius: 20, padding: 16,
-    backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.07)',
-    gap: 10, alignItems: 'center', overflow: 'hidden',
-  },
-  neuroTileIconWrap: { width: 48, height: 48, borderRadius: 24, alignItems: 'center', justifyContent: 'center' },
-  neuroTileIcon: { fontSize: 24 },
-  neuroTileLabel: { fontFamily: F.bodySemi, fontSize: 14, color: C.textSub, textAlign: 'center' },
-  neuroTileDesc: { fontFamily: F.body, fontSize: 12, color: C.textMuted, textAlign: 'center', lineHeight: 17 },
-  neuroTileCheck: { position: 'absolute', top: 10, right: 10, width: 22, height: 22, borderRadius: 11, alignItems: 'center', justifyContent: 'center' },
-  neuroTileCheckText: { fontSize: 12, color: '#FFFFFF', fontWeight: '700' },
-  neuroTileBar: { position: 'absolute', bottom: 0, left: 0, right: 0, height: 3, borderBottomLeftRadius: 20, borderBottomRightRadius: 20 },
-  neuroNote: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, backgroundColor: 'rgba(87,120,163,0.08)', borderRadius: 14, padding: 14, borderWidth: 1, borderColor: 'rgba(87,120,163,0.15)' },
-  neuroNoteIcon: { fontSize: 18, marginTop: 1 },
-  neuroNoteText: { fontFamily: F.body, fontSize: 13, color: C.textSub, flex: 1, lineHeight: 20 },
-
   ctaBtn: { borderRadius: 18, minHeight: 56, alignItems: 'center', justifyContent: 'center' },
   ctaText: { fontFamily: F.subheading, fontSize: 17, color: '#FFFFFF', letterSpacing: 0.3 },
+  ctaHint: { fontFamily: F.body, fontSize: 13, color: C.textMuted, textAlign: 'center', marginTop: -12 },
 
   skipBtn: { alignItems: 'center', paddingVertical: 4 },
   skipText: { fontFamily: F.body, fontSize: 14, color: C.textMuted },

--- a/apps/mobile/app/child/new.tsx
+++ b/apps/mobile/app/child/new.tsx
@@ -1,8 +1,7 @@
 // app/child/new.tsx
-// v7 — Add child profile
-// Arrow age picker + slider + contextual hint
-// Neurotype: illustrated cards with icons + colored accent bars
-// Logo palette throughout
+// v8 — Add child profile
+// Arrow age picker + slider + contextual hint + optional personality notes.
+// Per docs/PRODUCT_PRINCIPLES.md §1: no neurotype selection UI.
 
 import { useState } from 'react';
 import {
@@ -30,18 +29,6 @@ import { colors as C, fonts as F } from '../../src/theme/colors';
 const { width: W } = Dimensions.get('window');
 const MIN_AGE = 0;
 const MAX_AGE = 17;
-
-// ─── Neurotype data with icons + unique colors ───
-const NEUROTYPES = [
-  { key: 'ADHD',    icon: '⚡', label: 'ADHD',              desc: 'Moves fast, acts first, hard to wait',          color: C.coral,  bg: 'rgba(232,116,97,0.07)' },
-  { key: 'Autism',  icon: '🧩', label: 'Autistic',          desc: 'Loves routine, notices everything',              color: C.blue,   bg: 'rgba(87,120,163,0.07)' },
-  { key: 'Anxiety', icon: '🌧️', label: 'Anxiety',           desc: "Worries deeply, needs safety first",             color: C.peach,  bg: 'rgba(247,149,102,0.07)' },
-  { key: 'Sensory', icon: '🎧', label: 'Sensory',           desc: 'Overwhelmed by noise, texture, crowds',          color: C.amber,  bg: 'rgba(212,148,74,0.07)' },
-  { key: 'PDA',     icon: '🛡️', label: 'PDA',               desc: 'Fights any demand, needs autonomy',              color: C.sage,   bg: 'rgba(138,160,96,0.07)' },
-  { key: '2e',      icon: '🌟', label: 'Twice exceptional', desc: 'Brilliant mind, big emotions',                   color: C.blueLight, bg: 'rgba(107,141,184,0.07)' },
-] as const;
-
-type NeurotypeKey = typeof NEUROTYPES[number]['key'];
 
 // ─── Age hint ───
 function getAgeHint(age: number): string {
@@ -77,7 +64,6 @@ export default function NewChildScreen() {
   const { reloadChild }    = useChildProfile();
   const [name, setName]    = useState('');
   const [age, setAge]      = useState(5);
-  const [neurotypes, setNeurotypes] = useState<NeurotypeKey[]>([]);
   const [notes, setNotes]  = useState('');
   const [error, setError]  = useState('');
   const [saving, setSaving] = useState(false);
@@ -94,13 +80,6 @@ export default function NewChildScreen() {
     setAge(next);
   };
 
-  const toggleNeurotype = (key: NeurotypeKey) => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setNeurotypes(prev =>
-      prev.includes(key) ? prev.filter(n => n !== key) : [...prev, key]
-    );
-  };
-
   const handleSave = async () => {
     if (!canSave || saving || !session) return;
     setSaving(true); setError('');
@@ -115,7 +94,6 @@ export default function NewChildScreen() {
           name: name.trim(),
           child_age: age,
           age_band: age <= 4 ? '2-4' : age <= 7 ? '5-7' : '8-12',
-          neurotype: neurotypes,
           preferences,
         });
       if (dbErr) throw dbErr;
@@ -242,65 +220,6 @@ export default function NewChildScreen() {
             </View>
           </LinearGradient>
 
-        {/* ── Neurotype Section ── */}
-          <View style={st.neuroSection}>
-            <Text style={st.neuroSectionTitle}>Does your child have any of these?</Text>
-            <Text style={st.neuroSectionSub}>Optional · swipe to browse, tap to select</Text>
-
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              contentContainerStyle={st.neuroCarousel}
-              decelerationRate="fast"
-              snapToInterval={W * 0.42 + 10}
-            >
-              {NEUROTYPES.map(n => {
-                const sel = neurotypes.includes(n.key);
-                return (
-                  <Pressable
-                    key={n.key}
-                    onPress={() => toggleNeurotype(n.key)}
-                    style={({ pressed }) => [
-                      st.neuroTile,
-                      sel && { borderColor: `${n.color}50`, backgroundColor: n.bg },
-                      pressed && { opacity: 0.8 },
-                    ]}
-                  >
-                    {/* Top icon */}
-                    <View style={[st.neuroTileIconWrap, { backgroundColor: sel ? `${n.color}20` : 'rgba(255,255,255,0.06)' }]}>
-                      <Text style={st.neuroTileIcon}>{n.icon}</Text>
-                    </View>
-
-                    {/* Label */}
-                    <Text style={[st.neuroTileLabel, sel && { color: n.color }]}>{n.label}</Text>
-
-                    {/* Description */}
-                    <Text style={[st.neuroTileDesc, sel && { color: 'rgba(255,255,255,0.50)' }]}>{n.desc}</Text>
-
-                    {/* Selected indicator */}
-                    {sel && (
-                      <View style={[st.neuroTileCheck, { backgroundColor: n.color }]}>
-                        <Text style={st.neuroTileCheckText}>✓</Text>
-                      </View>
-                    )}
-
-                    {/* Bottom color bar */}
-                    <View style={[st.neuroTileBar, { backgroundColor: sel ? n.color : 'rgba(255,255,255,0.06)' }]} />
-                  </Pressable>
-                );
-              })}
-            </ScrollView>
-
-            {neurotypes.length > 0 && (
-              <View style={st.neuroNote}>
-                <Text style={st.neuroNoteIcon}>🤫</Text>
-                <Text style={st.neuroNoteText}>
-                  Scripts will quietly adapt for {neurotypes.join(' + ')} — your child is never labelled.
-                </Text>
-              </View>
-            )}
-          </View>
-
           {/* ── Personality Notes ── */}
           <Pressable onPress={() => setShowNotes(v => !v)} style={st.notesToggle}>
             <Text style={st.notesToggleText}>
@@ -408,24 +327,6 @@ const st = StyleSheet.create({
   hintCard: { flexDirection: 'row', alignItems: 'center', gap: 8, backgroundColor: 'rgba(138,160,96,0.08)', borderRadius: 12, borderWidth: 1, borderColor: 'rgba(138,160,96,0.15)', paddingHorizontal: 14, paddingVertical: 10 },
   hintIcon: { fontSize: 18 },
   hintText: { fontFamily: F.body, fontSize: 13, color: C.sage, flex: 1, lineHeight: 19 },
-
-  // ── Neurotype carousel (these 5 were missing) ──
-  neuroSection: { gap: 12 },
-  neuroSectionTitle: { fontFamily: F.bodyMedium, fontSize: 16, color: C.textBody },
-  neuroSectionSub: { fontFamily: F.body, fontSize: 13, color: C.textMuted, marginTop: -6 },
-  neuroNote: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, backgroundColor: 'rgba(87,120,163,0.08)', borderRadius: 14, padding: 14, borderWidth: 1, borderColor: 'rgba(87,120,163,0.15)' },
-  neuroNoteIcon: { fontSize: 18, marginTop: 1 },
-  neuroNoteText: { fontFamily: F.body, fontSize: 13, color: C.textSub, flex: 1, lineHeight: 20 },
-
-  neuroCarousel: { paddingHorizontal: 4, gap: 10 },
-  neuroTile: { width: W * 0.42, borderRadius: 20, padding: 16, backgroundColor: 'rgba(255,255,255,0.04)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.07)', gap: 10, alignItems: 'center', overflow: 'hidden' },
-  neuroTileIconWrap: { width: 48, height: 48, borderRadius: 24, alignItems: 'center', justifyContent: 'center' },
-  neuroTileIcon: { fontSize: 24 },
-  neuroTileLabel: { fontFamily: F.bodySemi, fontSize: 14, color: C.textSub, textAlign: 'center' },
-  neuroTileDesc: { fontFamily: F.body, fontSize: 12, color: C.textMuted, textAlign: 'center', lineHeight: 17 },
-  neuroTileCheck: { position: 'absolute', top: 10, right: 10, width: 22, height: 22, borderRadius: 11, alignItems: 'center', justifyContent: 'center' },
-  neuroTileCheckText: { fontSize: 12, color: '#FFFFFF', fontWeight: '700' },
-  neuroTileBar: { position: 'absolute', bottom: 0, left: 0, right: 0, height: 3, borderBottomLeftRadius: 20, borderBottomRightRadius: 20 },
 
   notesToggle: { paddingVertical: 4 },
   notesToggleText: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textMuted },

--- a/apps/mobile/app/welcome/index.tsx
+++ b/apps/mobile/app/welcome/index.tsx
@@ -37,6 +37,7 @@ import { BlurView }        from 'expo-blur';
 import * as Haptics        from 'expo-haptics';
 import AsyncStorage        from '@react-native-async-storage/async-storage';
 import { useAuth }         from '../../src/context/AuthContext';
+import { markOnboardingComplete } from '../../src/utils/onboarding';
 import { colors as C, fonts as F } from '../../src/theme/colors';
 
 const { width: W, height: H } = Dimensions.get('window');
@@ -170,17 +171,19 @@ export default function WelcomeScreen() {
   const handleSkip = async () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     await AsyncStorage.setItem(GUEST_SEEN_KEY, 'true');
+    await markOnboardingComplete();
     router.replace('/(tabs)');
   };
 
- const handleGetStarted = () => {
+  const handleGetStarted = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-    router.push('/auth/sign-up');
+    router.push('/auth?mode=signup');
   };
 
   const handleTryWithout = async () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     await AsyncStorage.setItem(GUEST_SEEN_KEY, 'true');
+    await markOnboardingComplete();
     router.replace('/(tabs)');
   };
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -179,3 +179,63 @@ than to defend a Soft tone that drifts in the wild. The hero rewrite
 live or die by: paid Sturdy gets sharper about your child over time.
 Everything else on the page now supports that one promise instead of
 itemizing parallel claims.
+
+### 2026-04-29 — Neurotype invisibility reconciliation + child profile rebuild
+
+**Context:** Doc audit revealed the neurotype-invisibility principle was
+documented in CLAUDE.md and PROMPT_SYSTEM.md but contradicted by
+DATABASE_SCHEMA.md, which described an "optional parent-set premium" path
+that no other doc supported. The child profile setup screen was built
+consistent with the schema doc — exposing ADHD/Autistic/Anxiety/Sensory/
+PDA/2e selection cards — and the per-child profile screen displayed the
+stored neurotype back to the parent as a labeled row. Both violated the
+locked principle stated in CLAUDE.md and PROMPT_SYSTEM.md. The Master
+Blueprint deferred to PROMPT_SYSTEM.md without restating the principle
+in its own canonical text. Three flow bugs surfaced in the same path:
+the welcome "Get started" button pushed `/auth/sign-up` (a route that
+no longer exists since auth was unified to `/auth?mode=signup`), the
+guest skip path could land on Home with greeting "Welcome back, there",
+and the "Continue" button on child setup was invisibly disabled when
+the name field was empty with no hint to the parent.
+
+**Decision:** Reconciled all docs to the strict-invisibility principle.
+Removed the "set by parent (premium)" line from DATABASE_SCHEMA.md and
+replaced the column comment with "AI auto-detection only — never user-
+set, never displayed." Restated the principle directly in
+STURDY_MASTER_BLUEPRINT.md so the canonical product spec carries it,
+not just CLAUDE.md and PROMPT_SYSTEM.md. Created new canonical
+docs/PRODUCT_PRINCIPLES.md as the single source of truth for product
+principles, with a violation checklist for each of the seven principles
+and an explicit usage protocol for future briefs. Rebuilt the child
+profile setup screen to remove neurotype selection cards entirely; the
+screen is now name + exact-age slider + Continue + Skip. Stripped the
+"Neurotype" row from the per-child profile screen. Fixed the three
+flow bugs in the same PR: welcome's "Get started" now pushes
+`/auth?mode=signup`; both guest skip handlers now also call
+`markOnboardingComplete()` so the AuthGate routes returning guests to
+`/auth?mode=signin` instead of looping back to `/welcome`; the Home
+greeting rotation no longer includes "Welcome back" or "Good to see
+you" (so guests with no name get "Hi, there." rather than "Welcome
+back, there."); child setup now shows a visible "Add your child's
+name to continue" hint under the disabled Continue button when the
+name field is empty.
+
+Notes / "What makes them them?" field deferred to a follow-up brief
+that ships notes UI + detection wiring together. A notes field that
+doesn't feed detection would break the "shaped to your child" promise
+the welcome flow makes — better to ship the experience whole than the
+input alone.
+
+**Reasoning:** The principle is the most defensible product position
+Sturdy has — parents do not need to diagnose their child to get help,
+because Sturdy reads it from how they describe behaviour. Doc
+inconsistency is what caused the original child-setup screen to ship
+with the carousel in the first place; if the schema doc and the master
+blueprint had agreed with CLAUDE.md, that drift would not have
+happened. Adding PRODUCT_PRINCIPLES.md as a canonical reference
+prevents the same drift class from recurring — every future brief
+references it. The screen rebuild aligns the UI with the welcome
+flow's "shaped to your child, not a category" promise that shipped
+three days ago. The bug fixes ride along because the failing flow
+involves these screens — fixing them in a separate PR would mean two
+device-test cycles instead of one.

--- a/docs/PRODUCT_PRINCIPLES.md
+++ b/docs/PRODUCT_PRINCIPLES.md
@@ -1,0 +1,134 @@
+# Sturdy Product Principles
+
+These are the locked principles that govern every product decision in Sturdy.
+Before building any feature, screen, prompt, or copy, this file must be read
+and the work must be verified against these principles.
+
+If a principle is violated, the work does not ship — even if it works
+technically, even if it tests well, even if it would convert better.
+
+When principles conflict with marketing intuition, conversion best practice,
+or "what every other parenting app does" — the principles win.
+
+---
+
+## 1. Neurotype invisibility
+
+Sturdy detects neurotype (ADHD, Autism, Anxiety, Sensory, PDA, 2e) silently
+from how parents describe their child. The detection adapts AI output but is
+never named, displayed, or set by the user.
+
+**Why it matters:** Sturdy's differentiation is that parents do not need to
+diagnose their child to get help. Every other parenting app asks parents to
+declare their child's traits. Sturdy reads it from how they describe behaviour.
+This is the single most defensible product position Sturdy has.
+
+**This looks like a violation when:**
+- A UI screen asks the parent to select their child's neurotype
+- A paywall offers neurotype-related features
+- AI output names a neurotype ("Children with ADHD often...")
+- Marketing copy mentions specific neurotype names ("Aware of ADHD, autism")
+- Settings expose neurotype as user-editable
+- Database queries that surface neurotype to a non-AI client
+
+**The DB column `child_profiles.neurotype` exists for AI use only.**
+
+---
+
+## 2. Scripts as examples, not instructions
+
+Sturdy's SOS scripts are example phrasings. The parent adapts them. They are
+not verbatim commands.
+
+**This looks like a violation when:**
+- UI implies the script must be said exactly as written
+- "Copy" buttons that suggest verbatim use without adaptation
+- Language that says "tell your child:" instead of "you might say something like:"
+
+---
+
+## 3. Exact age, never age-bands
+
+Sturdy uses integer ages 2-17. A 4-year-old and a 5-year-old are different
+products. Never reintroduce age bands like 2-4, 5-7, 8-12.
+
+**This looks like a violation when:**
+- Any UI offers age range selection
+- Any prompt logic groups ages into buckets
+- Any documentation references age bands as a current feature (legacy mentions OK)
+
+---
+
+## 4. Crisis is never paywalled
+
+If the safety filter detects a crisis, the resulting flow is always free.
+Crisis routing, the crisis screen, and any safety-related guidance must work
+for users with no subscription.
+
+**This looks like a violation when:**
+- Any paywall sits between a crisis-classified message and its resources
+- Premium features ride alongside crisis content (degrading the experience for free users)
+- Free-tier rate limits apply to crisis paths
+
+---
+
+## 5. Long-walk register
+
+Sturdy's voice is "a wise friend on a long walk." Plain words, no preamble,
+no therapy speak, no parenting-blog tone. The first sentence stands alone as
+a complete answer. Every sentence earns its place.
+
+See `docs/QUESTION_MODE_QUALITY_STANDARDS.md` for the canonical voice
+references and `docs/SCRIPT QUALITY STANDARDS.md` for SOS register.
+
+**This looks like a violation when:**
+- Copy opens with "It's so common!" or "Great question!"
+- Phrases like "your feelings are valid" appear
+- Framework names (theory of mind, secure attachment, executive function)
+  show up in user-facing text
+- Endearments ("honey," "mama," "sweetheart")
+- Social-media voice ("power move," "living their best life")
+- Validation by disparaging other parents
+
+---
+
+## 6. Free-tier honesty
+
+The free tier of Sturdy is a real product, not a trial. Unlimited SOS scripts.
+Question mode. Crisis support. These never become paid.
+
+**This looks like a violation when:**
+- Free-tier features get rate-limited beyond reasonable abuse prevention
+- Free-tier features get degraded over time to push subscription
+- Marketing implies the free tier is a teaser
+
+---
+
+## 7. Trust over conversion
+
+Sturdy does not use dark patterns to drive subscription. No fake higher prices
+discounted back. No urgency manufactured by countdown timers. No friction
+inserted to make cancellation harder than subscription.
+
+**This looks like a violation when:**
+- Pricing anchors that don't reflect real prices
+- "Limited time" claims that aren't limited
+- Multi-step cancellation flows
+- Loss-aversion language in the paywall ("don't miss out")
+
+---
+
+## How to use this file
+
+Every Claude Code brief that touches product UI, AI prompts, or copy must
+reference this file. The brief should explicitly state which principles are
+relevant and verify the work does not violate them.
+
+When a principle conflicts with a request:
+1. Surface the conflict to the human (Thai)
+2. Quote the relevant principle and explain why the work as proposed
+   would violate it
+3. Wait for explicit override or for the request to be revised
+
+This file is updated only with explicit human decisions. New principles
+require an OPERATIONS.md entry explaining the addition.

--- a/docs/backend/DATABASE_SCHEMA.md
+++ b/docs/backend/DATABASE_SCHEMA.md
@@ -31,7 +31,7 @@ user_id     uuid references auth.users(id)
 name        text nullable
 child_age   integer check (child_age between 2 and 17)  -- exact age, required
 age_band    text check (age_band in ('2-4', '5-7', '8-12'))  -- legacy, kept for compat
-neurotype   text[] default '{}'  -- detected or set: ADHD, Autism, Anxiety, Sensory, PDA, 2e
+neurotype   text[] default '{}'  -- AI auto-detection only — never user-set, never displayed
 preferences jsonb default '{}'
 created_at  timestamptz
 updated_at  timestamptz
@@ -40,7 +40,10 @@ updated_at  timestamptz
 **Key design decisions:**
 - `child_age` is exact integer — not a band. A 4-year-old and 2-year-old are completely different.
 - `neurotype` is an array — future support for multiple. Currently uses first element.
-- Neurotype is set by auto-detection from message or optionally by parent (premium).
+- Neurotype is set ONLY by silent auto-detection from parent messages (see PROMPT_SYSTEM.md).
+- The column is invisible AI infrastructure. It is never exposed in UI, never set by parent,
+  and never named in output. Any future code that exposes this field to the user is a
+  product principle violation — see PRODUCT_PRINCIPLES.md.
 
 ---
 

--- a/docs/master/STURDY_MASTER_BLUEPRINT.md
+++ b/docs/master/STURDY_MASTER_BLUEPRINT.md
@@ -189,7 +189,14 @@ All AI/prompt/safety changes are deferred to a future phase after the UI rebuild
 Unchanged — 12 foundational parenting books. See PROMPT_SYSTEM.md.
 
 ### Neurotype Detection
-Unchanged — detects from message content. See PROMPT_SYSTEM.md.
+
+**Principle: Neurotype is invisible.** Sturdy detects neurotype silently from
+how parents describe their child. The detection adapts AI output but is never
+named, displayed, or set by the user. There is no UI for neurotype selection.
+There is no premium feature for neurotype labelling. The column exists in the
+database for AI use only.
+
+Detection logic unchanged — detects from message content. See PROMPT_SYSTEM.md.
 
 ---
 


### PR DESCRIPTION
## Summary

Reconciles every doc to the locked **"neurotype is invisible"** principle (already in CLAUDE.md and PROMPT_SYSTEM.md, but contradicted by DATABASE_SCHEMA.md and the shipped child-setup screens). Strips the matching UI violations from the mobile app and folds in three flow bugs that surfaced in the same path.

### Docs
- `docs/backend/DATABASE_SCHEMA.md` — column comment is now `AI auto-detection only — never user-set, never displayed`. The "set by parent (premium)" line is replaced with an explicit "never exposed in UI / never set by parent / never named in output" note that points to PRODUCT_PRINCIPLES.md.
- `docs/master/STURDY_MASTER_BLUEPRINT.md` — restated the principle directly in the Neurotype Detection section so the canonical product spec carries it, not just CLAUDE.md and PROMPT_SYSTEM.md.
- `docs/PRODUCT_PRINCIPLES.md` (**new**) — single source of truth for the seven locked principles (neurotype invisibility / scripts as examples / exact age / crisis never paywalled / long-walk register / free-tier honesty / trust over conversion). Each has a violation checklist and a usage protocol for future briefs.

### Mobile UI
- `apps/mobile/app/child-setup.tsx` — removed the 6-tile neurotype carousel + `NEUROTYPES` data + `neurotypes` state + `toggleNeurotype` handler. Screen is now: name input + exact-age slider + Continue + Skip.
- `apps/mobile/app/child/new.tsx` — same carousel removal (the second screen with the same violation, surfaced during the mobile-side audit).
- `apps/mobile/app/child-profile/[id].tsx` — removed the "Neurotype" row from the Profile section + its derivation.

### Bug fixes
- **6a — Get started loop:** `welcome/index.tsx` was pushing the dead `/auth/sign-up` route. Now pushes `/auth?mode=signup` to match the unified auth screen.
- **6b — Greeting + onboarding flag:** removed `Welcome back` and `Good to see you` from the `GREETINGS` rotation in `(tabs)/index.tsx` (so guests with no name land on `Hi, there.`, not `Welcome back, there.`). Both guest skip handlers in welcome now also call `markOnboardingComplete()` so the AuthGate routes returning guests to `/auth?mode=signin` rather than looping back to `/welcome`.
- **6c — Add child button dead:** added a visible `Add your child's name to continue` hint under the disabled Continue button in `child-setup.tsx`. The button was correctly gated by `name.trim().length > 0` — the bug was that the disabled state was invisible to the parent.

### Deferred (intentionally)
Notes / "What makes them them?" field deferred to a follow-up brief that ships notes UI + detection wiring together. A notes field that doesn't feed `detectNeurotype` (which currently reads only the live parent message at `supabase/functions/_shared/buildPrompt.ts:113`) would break the "shaped to your child" promise the welcome flow makes.

### Untouched
- `supabase/functions/_shared/buildPrompt.ts` — detection engine
- `supabase/functions/_shared/prompts/categories/` — neurotype adaptations
- `child_profiles.neurotype` DB column — persists for AI use only
- `ChildProfileContext` — keeps reading `neurotype` from the DB; no UI consumer

## Verification

- [x] `apps/mobile && npx tsc --noEmit` clean
- [x] `grep -rn "neurotype\|Neurotype" docs/` — every match is silent-detection / AI-only-DB / the principle / the log entry. No "set by parent", no "premium", no UI references.
- [x] `grep -rn "neurotype\|Neurotype" apps/mobile/` — all remaining matches are internal carriers (context type, DB select, guest data migration plumbing). No UI strings expose clinical labels.
- [ ] Manual device walkthrough (cannot run in CI):
  - Welcome → Get started → reaches `/auth?mode=signup` (no loop)
  - Welcome → Try without account → Home greeting reads e.g. `Hi, there.` (never `Welcome back, there.`)
  - Relaunch as guest → AuthGate routes to `/auth?mode=signin` (not `/welcome`)
  - Home → Add a child → child-setup shows: name + exact-age slider, no neurotype carousel, no notes
  - Empty name → Continue disabled with `Add your child's name to continue` hint
  - Filled name + age → Continue creates the profile, lands on Home
  - Open per-child profile → no `Neurotype` row

See `docs/OPERATIONS.md` (2026-04-29 entry) for full context, decision, and reasoning.

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_