### PR TITLE
backend: account deletion + pause + export lifecycle (PR 1 of 2)

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -239,3 +239,62 @@ flow's "shaped to your child, not a category" promise that shipped
 three days ago. The bug fixes ride along because the failing flow
 involves these screens — fixing them in a separate PR would mean two
 device-test cycles instead of one.
+
+### 2026-04-29 — Account deletion + pause + export flow (backend, PR 1 of 2)
+
+**Context:** Sturdy had no account deletion mechanism. Without one, the
+privacy policy could not honestly promise data deletion, and Sturdy
+could not satisfy data-subject rights under PIPEDA, PIPA BC, GDPR, or
+CCPA. The decision was to build the lifecycle backend before the UI so
+the migration and Edge Functions could ship and be smoke-tested in
+production before any client surface depends on them.
+
+**Decision:** Split the work into two PRs. PR 1 (this entry) lands the
+backend: a migration that adds `profiles.paused_at`, switches
+`safety_events.user_id` from `ON DELETE CASCADE` to `ON DELETE SET NULL`,
+defensively re-asserts `ON DELETE CASCADE` on the out-of-band tables
+(`interaction_logs`, `parent_thoughts`, `usage_events`), and creates a
+private `account-exports` Storage bucket with per-user RLS. Plus four
+Edge Functions:
+
+- `account-export` — JSON + Markdown zipped via `npm:fflate@0.8.2`,
+  uploaded to the private bucket, returned as a 24-hour signed URL.
+  Markdown was chosen over PDF deliberately: it opens on every device,
+  in every text app, with no library dependency that would balloon the
+  function bundle. The privacy policy reflects this.
+- `account-pause` — sets `paused_at = now()` and revokes refresh tokens
+  globally. The user is signed out as a side effect.
+- `account-delete` — deletes the auth user via the admin API. Because
+  every public.* table that references `auth.users` is `ON DELETE
+  CASCADE` (via the migration), and `safety_events.user_id` is
+  `ON DELETE SET NULL`, that single call atomically removes user-owned
+  rows and anonymizes safety logs. Two callers are accepted: the user
+  themselves with `confirmationText = "DELETE"`, or the cron with
+  `confirmationText = "PAUSE_EXPIRED"` and a system-caller credential.
+- `scheduled-pause-cleanup` — daily cron. Queries `paused_at < (now() -
+  30 days)` and calls `account-delete` for each. Daily granularity is
+  intentional — the 30-day window is "approximately 30 days" so a missed
+  run is recovered the next day.
+
+Subscription check is a documented stub: `useSubscription` on the client
+always returns `isPremium: false` until RevenueCat lands, so the server
+mirrors that with a `hasActiveSubscription()` helper that returns false.
+The 409 path on the Edge Function is wired but unreachable today — when
+billing arrives, swapping the helper's body is the only change needed.
+
+PR 2 will add the mobile UI (Settings → Account section, pause and
+delete screens, paused-account detection in `auth/index.tsx`, the
+`requestExport` / `pauseAccount` / `deleteAccount` methods in `api.ts`,
+plus the privacy policy text).
+
+**Reasoning:** Sturdy's positioning rests on respecting parents. A
+clean deletion flow that honours the user's choice is part of that. The
+pause option is humane (deletion in a moment of frustration is
+reversible for 30 days). The export-first path is GDPR/CCPA compliant.
+The "type DELETE" friction (PR 2) matches industry standard for
+irreversible operations. Anonymized `safety_events` retention is the
+only exception to "deletion means deletion" — it's documented in
+Product Principle 8 and surfaced in the privacy policy text. Splitting
+into two PRs lets the destructive backend land first, get
+smoke-tested against a real database, and stabilize before the client
+surfaces it.

--- a/docs/PRODUCT_PRINCIPLES.md
+++ b/docs/PRODUCT_PRINCIPLES.md
@@ -118,6 +118,32 @@ inserted to make cancellation harder than subscription.
 
 ---
 
+## 8. Account deletion means deletion
+
+When a user deletes their Sturdy account, their data is gone. We do not
+preserve deleted accounts for re-engagement campaigns. We do not
+anonymize-and-retain for analytics. We do not maintain shadow profiles.
+We offer a 30-day pause for users who might regret a hasty decision, and
+we offer a data export before any deletion. Once a user chooses to delete,
+we honour it fully.
+
+The one exception is `safety_events` — when a safety filter triggers, the
+resulting log row has its `user_id` stripped on account deletion but the
+content is retained anonymously. This is disclosed in the privacy policy.
+The retention serves the safety filter's improvement for all future users,
+including those whose own accounts are later deleted.
+
+**This looks like a violation when:**
+- "Recover deleted account" flows that revive data after the deletion period
+- Analytics or marketing systems retain deleted-user data linked to the user
+- Soft-delete patterns that flag accounts as deleted but keep the rows linked
+- "We may retain certain information for legitimate business purposes"
+  clauses that quietly preserve deleted user data
+- Any path where a user's deletion is reversible by the company (only the
+  user can reverse a pause; only within the 30-day window)
+
+---
+
 ## How to use this file
 
 Every Claude Code brief that touches product UI, AI prompts, or copy must

--- a/docs/SMOKE_TEST_account_lifecycle.md
+++ b/docs/SMOKE_TEST_account_lifecycle.md
@@ -1,0 +1,260 @@
+# Smoke test: account lifecycle backend (PR 1)
+
+This is the manual smoke-test plan for the backend half of the
+account-deletion + pause + export feature. PR 2 (the mobile UI) does
+**not** start until every step here passes against a real Supabase
+project.
+
+The checks are written to be runnable from `psql` + `curl`. They
+exercise the destructive paths end-to-end: pause → cron tick →
+auto-delete → safety_events anonymization. Run against a staging
+project first, never production.
+
+---
+
+## 0. Prerequisites
+
+Apply the migration and deploy the four Edge Functions:
+
+```bash
+# Apply the migration
+npx supabase db push
+
+# Deploy the Edge Functions
+npx supabase functions deploy account-export account-pause account-delete scheduled-pause-cleanup
+
+# Set the system-caller secret for the scheduled function
+# (alternative to passing the service role key)
+npx supabase secrets set CRON_SHARED_SECRET=<random-32-bytes-hex>
+```
+
+Capture for reuse:
+
+```bash
+PROJECT_URL="https://<project-ref>.supabase.co"
+SERVICE_ROLE_KEY="<service_role_key>"
+ANON_KEY="<anon_key>"
+```
+
+## 1. Verify schema state
+
+```sql
+-- profiles.paused_at exists and is nullable
+select column_name, is_nullable, data_type
+  from information_schema.columns
+ where table_schema = 'public'
+   and table_name   = 'profiles'
+   and column_name  = 'paused_at';
+-- expect: paused_at | YES | timestamp with time zone
+
+-- safety_events.user_id is now nullable
+select is_nullable
+  from information_schema.columns
+ where table_schema = 'public'
+   and table_name   = 'safety_events'
+   and column_name  = 'user_id';
+-- expect: YES
+
+-- safety_events FK is SET NULL
+select pg_get_constraintdef(oid)
+  from pg_constraint
+ where conrelid = 'public.safety_events'::regclass
+   and contype  = 'f';
+-- expect: ... ON DELETE SET NULL
+
+-- interaction_logs / parent_thoughts / usage_events FKs are CASCADE
+-- (skip rows where the table doesn't exist on this environment)
+select c.conrelid::regclass::text as table_name,
+       pg_get_constraintdef(c.oid) as definition
+  from pg_constraint c
+ where c.conrelid::regclass::text in (
+         'public.interaction_logs',
+         'public.parent_thoughts',
+         'public.usage_events'
+       )
+   and c.contype = 'f';
+-- expect: every row's definition contains ON DELETE CASCADE
+
+-- Storage bucket exists and is private
+select id, name, public from storage.buckets where id = 'account-exports';
+-- expect: account-exports | account-exports | f
+
+-- Storage RLS policies exist
+select policyname from pg_policies
+ where schemaname = 'storage' and tablename = 'objects'
+   and policyname like 'account_exports_%';
+-- expect: account_exports_read_own / write_own / delete_own
+```
+
+## 2. Pause flow
+
+Sign in as a test user, capture their JWT (`USER_JWT`) and `USER_ID`.
+
+```bash
+curl -X POST "$PROJECT_URL/functions/v1/account-pause" \
+  -H "Authorization: Bearer $USER_JWT" \
+  -H "Content-Type: application/json" -d '{}'
+# expect: 200 { "ok": true, "pausedAt": "..." }
+```
+
+Verify in DB:
+
+```sql
+select id, paused_at from profiles where id = '<USER_ID>';
+-- expect: paused_at non-null, ~now()
+```
+
+Confirm the user is signed out: subsequent calls with the old JWT
+should return 401 (the refresh token was revoked).
+
+## 3. Trigger the cron manually
+
+The cron schedule itself is configured per environment (dashboard or
+pg_cron — see `supabase/config.toml`). For the smoke test we hit the
+function directly with the system-caller credential.
+
+First, simulate that the paused_at is older than 30 days:
+
+```sql
+update profiles
+   set paused_at = now() - interval '31 days'
+ where id = '<USER_ID>';
+```
+
+Then call the cleanup function:
+
+```bash
+curl -X POST "$PROJECT_URL/functions/v1/scheduled-pause-cleanup" \
+  -H "Authorization: Bearer $SERVICE_ROLE_KEY" \
+  -H "Content-Type: application/json" -d '{}'
+# expect: 200
+# {
+#   "ok": true,
+#   "candidates": 1,
+#   "deleted": 1,
+#   "failed": 0,
+#   "details": [{ "userId": "<USER_ID>", "status": "deleted" }]
+# }
+```
+
+## 4. Verify the auto-delete
+
+```sql
+-- The user is gone from auth.users
+select id from auth.users where id = '<USER_ID>';
+-- expect: 0 rows
+
+-- All cascading public.* rows are gone
+select 'profiles'        as t, count(*) from profiles        where id      = '<USER_ID>'
+union all
+select 'child_profiles',         count(*) from child_profiles  where user_id = '<USER_ID>'
+union all
+select 'conversations',          count(*) from conversations   where user_id = '<USER_ID>'
+union all
+select 'usage_events',            count(*) from usage_events    where user_id = '<USER_ID>';
+-- expect: every row count = 0
+
+-- Safety events are NOT deleted — user_id is NULLed instead
+-- (Pre-create at least one safety_events row for this user before pausing
+-- so this assertion has data to check.)
+select count(*) as anonymized
+  from safety_events
+ where user_id is null
+   and created_at > now() - interval '1 hour';
+-- expect: count > 0 (and matches the number of safety rows the test user had)
+```
+
+## 5. Direct delete flow (no pause)
+
+Sign in as a *different* test user with a fresh `USER_JWT2` / `USER_ID2`.
+
+```bash
+# Pre-create one safety_events row for this user (insert directly via SQL
+# or trigger the safety filter in the app).
+```
+
+Delete:
+
+```bash
+curl -X POST "$PROJECT_URL/functions/v1/account-delete" \
+  -H "Authorization: Bearer $USER_JWT2" \
+  -H "Content-Type: application/json" \
+  -d '{"confirmationText":"DELETE"}'
+# expect: 200 { "ok": true, "deletedUserId": "<USER_ID2>", "reason": "DELETE" }
+```
+
+Re-run the assertion queries from step 4 with `<USER_ID2>` substituted.
+Same expectations: cascade deletion of public.* rows, safety_events
+preserved with `user_id = null`.
+
+## 6. Confirmation guard rails
+
+```bash
+# Wrong confirmation string is rejected
+curl -X POST "$PROJECT_URL/functions/v1/account-delete" \
+  -H "Authorization: Bearer $USER_JWT3" \
+  -H "Content-Type: application/json" \
+  -d '{"confirmationText":"delete"}'
+# expect: 400
+
+# PAUSE_EXPIRED requires system caller, not user JWT
+curl -X POST "$PROJECT_URL/functions/v1/account-delete" \
+  -H "Authorization: Bearer $USER_JWT3" \
+  -H "Content-Type: application/json" \
+  -d '{"confirmationText":"PAUSE_EXPIRED","targetUserId":"<some_id>"}'
+# expect: 401
+
+# scheduled-pause-cleanup requires service role / cron secret
+curl -X POST "$PROJECT_URL/functions/v1/scheduled-pause-cleanup" \
+  -H "Authorization: Bearer $ANON_KEY" -d '{}'
+# expect: 401
+```
+
+## 7. Export flow
+
+Sign in as a fresh test user. Pre-create some data: one child profile,
+one conversation, one parent_thought.
+
+```bash
+curl -X POST "$PROJECT_URL/functions/v1/account-export" \
+  -H "Authorization: Bearer $USER_JWT4" \
+  -H "Content-Type: application/json" -d '{}'
+# expect: 200 { "ok": true, "url": "https://...", "expiresInSeconds": 86400 }
+```
+
+Open the signed URL — it should download a ~few-KB zip. Unzip:
+
+```bash
+unzip sturdy-export-*.zip
+# expect two files:
+#   sturdy-export.json  — every row from the user's data
+#   sturdy-export.md    — readable summary with sections for account /
+#                         children / saved scripts / Question conversations
+```
+
+Verify:
+
+- The JSON contains the test user's profile, child_profiles, conversations,
+  messages, parent_thoughts, interaction_logs, usage_events.
+- The JSON does **not** contain `safety_events` or any other user's data.
+- The Markdown opens cleanly in a text editor and includes the test data.
+- The signed URL stops working after 24 hours (or after re-signing fails).
+
+## 8. RLS verification
+
+Try to read another user's export with the wrong JWT:
+
+```bash
+# As USER_JWT4, attempt to read USER_ID2's export folder via the REST API
+curl "$PROJECT_URL/storage/v1/object/list/account-exports?prefix=$USER_ID2/" \
+  -H "Authorization: Bearer $USER_JWT4"
+# expect: empty list (RLS hides other users' folders)
+```
+
+---
+
+## Sign-off
+
+PR 2 (mobile UI) is unblocked once **every** assertion above passes
+against staging. Paste the full test log into the PR 1 review thread
+before merging to main.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -368,6 +368,59 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Account-lifecycle Edge Functions
+# ─────────────────────────────────────────────────────────────────────────────
+# These three handle user-initiated account flows. Each one validates the
+# caller's JWT inside the function (see supabase/functions/_shared/accountAuth.ts),
+# so the runtime's verify_jwt default is fine — leave it on.
+
+[functions.account-export]
+[functions.account-pause]
+[functions.account-delete]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scheduled cleanup
+# ─────────────────────────────────────────────────────────────────────────────
+# Runs daily at 03:00 UTC (low-traffic window). Queries `profiles` for
+# accounts where `paused_at` is older than 30 days and calls account-delete
+# for each, with confirmationText = "PAUSE_EXPIRED".
+#
+# Why daily: the 30-day pause window is intentionally approximate. A daily
+# tick gives the function a chance to recover from a missed run on the next
+# pass, and a 24-hour granularity is plenty given the size of the window.
+#
+# Why not handled by the user-facing functions: a paused user is signed out
+# by definition. Without a scheduled tick, there's no way to deterministically
+# delete an abandoned paused account.
+#
+# This function is destructive — it must NOT be invokable from anonymous
+# clients. `verify_jwt = false` lets the cron infrastructure call it without
+# a user JWT; the function itself enforces system-caller auth via either the
+# service role key or a CRON_SHARED_SECRET header (see _shared/accountAuth.ts).
+#
+# Schedule wiring is environment-specific (Supabase pg_cron, an external
+# scheduler, or the dashboard's "Schedule" tab). The recommended setup is
+# pg_cron in the production database:
+#
+#   select cron.schedule(
+#     'scheduled-pause-cleanup',
+#     '0 3 * * *',
+#     $$
+#     select net.http_post(
+#       url     := '<project-url>/functions/v1/scheduled-pause-cleanup',
+#       headers := jsonb_build_object(
+#         'Authorization', 'Bearer ' || current_setting('app.service_role_key'),
+#         'Content-Type',  'application/json'
+#       ),
+#       body    := '{}'::jsonb
+#     );
+#     $$
+#   );
+
+[functions.scheduled-pause-cleanup]
+verify_jwt = false
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/_shared/accountAuth.ts
+++ b/supabase/functions/_shared/accountAuth.ts
@@ -1,0 +1,103 @@
+// _shared/accountAuth.ts
+//
+// Shared CORS + JWT-validation helpers for the account-lifecycle Edge Functions
+// (account-export, account-pause, account-delete). The existing
+// chat-parenting-assistant function trusts the client and delegates auth to
+// Postgres RLS; for destructive account operations we want explicit JWT
+// validation before doing anything.
+
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+export const SUPABASE_URL =
+  Deno.env.get("SUPABASE_URL") ?? "";
+export const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+export const SUPABASE_ANON_KEY =
+  Deno.env.get("SUPABASE_ANON_KEY") ?? "";
+
+export function cors(): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin":  "*",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+}
+
+export function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...cors(), "Content-Type": "application/json" },
+  });
+}
+
+export function preflight(req: Request): Response | null {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors() });
+  return null;
+}
+
+/**
+ * Service-role client. Bypasses RLS. Use for admin operations
+ * (deleting auth users, querying any user's data, uploading to private buckets).
+ */
+export function adminClient(): SupabaseClient {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set");
+  }
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+/**
+ * Validate the incoming JWT and return the authenticated user id.
+ *
+ * Throws if the Authorization header is missing or the token is invalid /
+ * expired. Callers should catch and return jsonRes({error}, 401).
+ */
+export async function requireUser(req: Request): Promise<{ userId: string; email: string | null }> {
+  const auth = req.headers.get("Authorization") ?? "";
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  if (!match) throw new AuthError("Missing bearer token");
+
+  const jwt = match[1];
+  const admin = adminClient();
+  const { data, error } = await admin.auth.getUser(jwt);
+  if (error || !data?.user) throw new AuthError("Invalid or expired token");
+
+  return { userId: data.user.id, email: data.user.email ?? null };
+}
+
+/**
+ * Verify the request is from the cron / system caller. Two acceptable signals:
+ *   1. A bearer token equal to SUPABASE_SERVICE_ROLE_KEY (used when Supabase
+ *      pg_cron calls the function directly with the service role key).
+ *   2. A custom shared secret in the X-Cron-Secret header, matched against
+ *      CRON_SHARED_SECRET env. Used when an external scheduler hits the URL.
+ *
+ * Both paths must be guarded; the scheduled function is destructive.
+ */
+export function requireSystemCaller(req: Request): void {
+  const auth = req.headers.get("Authorization") ?? "";
+  const tokenMatch = auth.match(/^Bearer\s+(.+)$/i);
+  const cronSecret = req.headers.get("X-Cron-Secret") ?? "";
+  const expectedSecret = Deno.env.get("CRON_SHARED_SECRET") ?? "";
+
+  const tokenOk =
+    tokenMatch !== null &&
+    SUPABASE_SERVICE_ROLE_KEY.length > 0 &&
+    tokenMatch[1] === SUPABASE_SERVICE_ROLE_KEY;
+
+  const secretOk =
+    expectedSecret.length > 0 && cronSecret === expectedSecret;
+
+  if (!tokenOk && !secretOk) {
+    throw new AuthError("System caller authentication required");
+  }
+}
+
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthError";
+  }
+}

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -1,0 +1,120 @@
+// supabase/functions/account-delete/index.ts
+//
+// Permanently deletes a user's account. Two callers:
+//
+//   1. The user themselves, after confirming with the literal string "DELETE".
+//      Auth: bearer JWT for that user.
+//
+//   2. The scheduled-pause-cleanup function, with confirmationText
+//      "PAUSE_EXPIRED" and a target userId in the body.
+//      Auth: service role key (or X-Cron-Secret header).
+//
+// Implementation note (per docs/OPERATIONS.md 2026-04-29 backend):
+// The migration ensures `ON DELETE CASCADE` on every public.* table that
+// references auth.users, except `safety_events` which is `ON DELETE SET NULL`.
+// So a single `auth.admin.deleteUser()` call atomically:
+//   - Deletes profiles, child_profiles, conversations, messages,
+//     interaction_logs, parent_thoughts, usage_events
+//   - Sets safety_events.user_id = NULL (anonymizing them per Principle 8)
+//   - Removes the auth.users row
+//
+// Subscription check is a stub — useSubscription on the client always returns
+// `isPremium: false` until RevenueCat lands. When real billing arrives, the
+// hasActiveSubscription() helper here will be wired to the subscription
+// provider's API. For now it always returns false (no block).
+
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import {
+  adminClient,
+  AuthError,
+  jsonRes,
+  preflight,
+  requireSystemCaller,
+  requireUser,
+} from "../_shared/accountAuth.ts";
+
+type DeleteBody = {
+  confirmationText?: unknown;
+  // Only honored when called by the system (cron). Ignored on user-initiated
+  // calls — a user can only delete their own account.
+  targetUserId?: unknown;
+};
+
+const VALID_CONFIRMATIONS = new Set(["DELETE", "PAUSE_EXPIRED"]);
+
+// Stub. When RevenueCat lands, this calls the provider's "is this user
+// subscribed?" endpoint. Until then, no user is billed, so no block.
+async function hasActiveSubscription(_userId: string): Promise<boolean> {
+  return false;
+}
+
+serve(async (req) => {
+  const pre = preflight(req);
+  if (pre) return pre;
+  if (req.method !== "POST") return jsonRes({ error: "Method not allowed." }, 405);
+
+  let body: DeleteBody;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonRes({ error: "Invalid JSON." }, 400);
+  }
+
+  const confirmation =
+    typeof body.confirmationText === "string" ? body.confirmationText : null;
+  if (!confirmation || !VALID_CONFIRMATIONS.has(confirmation)) {
+    return jsonRes({ error: "Confirmation text required." }, 400);
+  }
+
+  // Resolve the target userId based on the confirmation type.
+  let userId: string;
+  if (confirmation === "PAUSE_EXPIRED") {
+    // System caller. Validate and use the explicit targetUserId.
+    try {
+      requireSystemCaller(req);
+    } catch (e) {
+      if (e instanceof AuthError) return jsonRes({ error: e.message }, 401);
+      return jsonRes({ error: "Authentication failed." }, 401);
+    }
+    if (typeof body.targetUserId !== "string" || !body.targetUserId) {
+      return jsonRes({ error: "targetUserId required for system delete." }, 400);
+    }
+    userId = body.targetUserId;
+  } else {
+    // User caller. Validate JWT and ignore any targetUserId.
+    try {
+      ({ userId } = await requireUser(req));
+    } catch (e) {
+      if (e instanceof AuthError) return jsonRes({ error: e.message }, 401);
+      return jsonRes({ error: "Authentication failed." }, 401);
+    }
+
+    // Subscription check (stub today; real once billing lands).
+    if (await hasActiveSubscription(userId)) {
+      return jsonRes(
+        {
+          error:
+            "Active subscription detected. Cancel subscription before deleting account.",
+        },
+        409,
+      );
+    }
+  }
+
+  const admin = adminClient();
+
+  // The CASCADE FKs in the migration mean we don't need to delete each table
+  // by hand. Deleting the auth.users row removes everything that references
+  // it with ON DELETE CASCADE and NULLs everything that references it with
+  // ON DELETE SET NULL (i.e. safety_events.user_id).
+  const { error: deleteErr } = await admin.auth.admin.deleteUser(userId);
+  if (deleteErr) {
+    console.error("[account-delete] deleteUser failed", { userId, deleteErr });
+    return jsonRes({ error: "Could not delete account." }, 500);
+  }
+
+  return jsonRes(
+    { ok: true, deletedUserId: userId, reason: confirmation },
+    200,
+  );
+});

--- a/supabase/functions/account-export/index.ts
+++ b/supabase/functions/account-export/index.ts
@@ -1,0 +1,249 @@
+// supabase/functions/account-export/index.ts
+//
+// Generates a portable export of everything a parent has saved in Sturdy.
+// Returns a 24-hour signed URL pointing to a zip in the `account-exports`
+// bucket. The zip contains:
+//
+//   - sturdy-export.json  — every row from the user's data, in JSON
+//   - sturdy-export.md    — a human-readable summary in Markdown
+//
+// Markdown was chosen over PDF intentionally. Markdown opens on every device
+// in every text app, with no dependency on a PDF library that would balloon
+// the function bundle. The privacy policy reflects this ("zipped file
+// containing JSON and a readable text version").
+//
+// What the export does NOT include:
+//   - safety_events (operational data, not user content; principle 8)
+//   - data Sturdy doesn't have (Anthropic-side message logs are subject to
+//     Anthropic's retention schedule — disclosed in the export footer)
+
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { zipSync, strToU8 } from "https://esm.sh/fflate@0.8.2";
+import {
+  adminClient,
+  AuthError,
+  jsonRes,
+  preflight,
+  requireUser,
+} from "../_shared/accountAuth.ts";
+
+const SIGNED_URL_TTL_SECONDS = 60 * 60 * 24; // 24 hours
+const BUCKET = "account-exports";
+
+serve(async (req) => {
+  const pre = preflight(req);
+  if (pre) return pre;
+  if (req.method !== "POST") return jsonRes({ error: "Method not allowed." }, 405);
+
+  let userId: string;
+  let email: string | null;
+  try {
+    ({ userId, email } = await requireUser(req));
+  } catch (e) {
+    if (e instanceof AuthError) return jsonRes({ error: e.message }, 401);
+    return jsonRes({ error: "Authentication failed." }, 401);
+  }
+
+  const admin = adminClient();
+
+  try {
+    const data = await collectUserData(admin, userId);
+
+    const json = JSON.stringify({ exportedAt: new Date().toISOString(), email, ...data }, null, 2);
+    const md   = renderMarkdown({ exportedAt: new Date().toISOString(), email, ...data });
+
+    const zip = zipSync({
+      "sturdy-export.json": strToU8(json),
+      "sturdy-export.md":   strToU8(md),
+    });
+
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const path  = `${userId}/sturdy-export-${stamp}.zip`;
+
+    const { error: upErr } = await admin.storage
+      .from(BUCKET)
+      .upload(path, zip, { contentType: "application/zip", upsert: true });
+
+    if (upErr) {
+      console.error("[account-export] upload failed", upErr);
+      return jsonRes({ error: "Could not generate export." }, 500);
+    }
+
+    const { data: signed, error: signErr } = await admin.storage
+      .from(BUCKET)
+      .createSignedUrl(path, SIGNED_URL_TTL_SECONDS);
+
+    if (signErr || !signed?.signedUrl) {
+      console.error("[account-export] signed URL failed", signErr);
+      return jsonRes({ error: "Could not generate export." }, 500);
+    }
+
+    return jsonRes(
+      {
+        ok: true,
+        url: signed.signedUrl,
+        expiresInSeconds: SIGNED_URL_TTL_SECONDS,
+      },
+      200,
+    );
+  } catch (e) {
+    console.error("[account-export] build failed", e);
+    return jsonRes({ error: "Could not generate export." }, 500);
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Data collection
+// ─────────────────────────────────────────────────────────────────────────────
+
+type UserData = {
+  profile:         unknown;
+  childProfiles:   unknown[];
+  conversations:   unknown[];
+  messages:        unknown[];
+  parentThoughts:  unknown[];
+  interactionLogs: unknown[];
+  usageEvents:     unknown[];
+};
+
+async function collectUserData(admin: ReturnType<typeof adminClient>, userId: string): Promise<UserData> {
+  // Each query is independent — run in parallel for a lower wall-clock time.
+  const [
+    profile,
+    childProfiles,
+    conversations,
+    parentThoughts,
+    interactionLogs,
+    usageEvents,
+  ] = await Promise.all([
+    admin.from("profiles").select("*").eq("id", userId).maybeSingle().then(r => r.data),
+    admin.from("child_profiles").select("*").eq("user_id", userId).then(r => r.data ?? []),
+    admin.from("conversations").select("*").eq("user_id", userId).then(r => r.data ?? []),
+    safeSelect(admin, "parent_thoughts", userId),
+    safeSelect(admin, "interaction_logs", userId),
+    admin.from("usage_events").select("*").eq("user_id", userId).then(r => r.data ?? []),
+  ]);
+
+  // Messages live under conversations — fetch in a second pass.
+  const conversationIds = (conversations as Array<{ id: string }> | undefined)
+    ?.map(c => c.id) ?? [];
+  let messages: unknown[] = [];
+  if (conversationIds.length > 0) {
+    const { data } = await admin
+      .from("messages")
+      .select("*")
+      .in("conversation_id", conversationIds);
+    messages = data ?? [];
+  }
+
+  return {
+    profile,
+    childProfiles,
+    conversations,
+    messages,
+    parentThoughts,
+    interactionLogs,
+    usageEvents,
+  };
+}
+
+/**
+ * Defensive select for tables that may not exist on every environment
+ * (parent_thoughts and interaction_logs were created out-of-band via the
+ * SQL Editor). If the table is missing, return an empty array rather than
+ * blowing up the whole export.
+ */
+async function safeSelect(
+  admin: ReturnType<typeof adminClient>,
+  table: string,
+  userId: string,
+): Promise<unknown[]> {
+  try {
+    const { data, error } = await admin
+      .from(table)
+      .select("*")
+      .eq("user_id", userId);
+    if (error) return [];
+    return data ?? [];
+  } catch {
+    return [];
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Markdown rendering
+// ─────────────────────────────────────────────────────────────────────────────
+
+function renderMarkdown(d: UserData & { exportedAt: string; email: string | null }): string {
+  const lines: string[] = [];
+
+  lines.push("# Your Sturdy data");
+  lines.push("");
+  lines.push(`Exported ${d.exportedAt}`);
+  if (d.email) lines.push(`Account: ${d.email}`);
+  lines.push("");
+
+  lines.push("## Your account");
+  lines.push("");
+  lines.push("```json");
+  lines.push(JSON.stringify(d.profile ?? null, null, 2));
+  lines.push("```");
+  lines.push("");
+
+  lines.push(`## Your children (${d.childProfiles.length})`);
+  lines.push("");
+  for (const c of d.childProfiles as Array<Record<string, unknown>>) {
+    lines.push(`- **${String(c.name ?? "(unnamed)")}** — age ${c.child_age ?? c.age_band ?? "?"}`);
+  }
+  if (d.childProfiles.length === 0) lines.push("_None_");
+  lines.push("");
+
+  lines.push(`## Your saved scripts (${d.conversations.length})`);
+  lines.push("");
+  for (const c of d.conversations as Array<Record<string, unknown>>) {
+    const created = String(c.created_at ?? "");
+    const title   = String(c.title   ?? "(untitled)");
+    lines.push(`### ${title}`);
+    lines.push(`_${created}_`);
+    lines.push("");
+    const conversationMessages = (d.messages as Array<Record<string, unknown>>)
+      .filter(m => m.conversation_id === c.id);
+    for (const m of conversationMessages) {
+      lines.push(`**${String(m.role ?? "?")}:** ${String(m.content ?? "")}`);
+      lines.push("");
+    }
+    lines.push("---");
+    lines.push("");
+  }
+  if (d.conversations.length === 0) {
+    lines.push("_None_");
+    lines.push("");
+  }
+
+  lines.push(`## Your Question conversations (${d.parentThoughts.length})`);
+  lines.push("");
+  for (const t of d.parentThoughts as Array<Record<string, unknown>>) {
+    lines.push(`**You asked:** ${String(t.prompt_text ?? "")}`);
+    lines.push("");
+    lines.push(`**Sturdy:** ${String(t.response_text ?? "")}`);
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+  }
+  if (d.parentThoughts.length === 0) {
+    lines.push("_None_");
+    lines.push("");
+  }
+
+  lines.push("## Notes on this export");
+  lines.push("");
+  lines.push(
+    "This file contains everything Sturdy has stored about your account. " +
+    "Messages you sent to Sturdy were processed by Anthropic (the company " +
+    "behind Claude); Anthropic retains those records on their own schedule, " +
+    "independent of Sturdy. See anthropic.com/legal for details.",
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}

--- a/supabase/functions/account-pause/index.ts
+++ b/supabase/functions/account-pause/index.ts
@@ -1,0 +1,55 @@
+// supabase/functions/account-pause/index.ts
+//
+// Pauses the authenticated user's account. Sets profiles.paused_at = now(),
+// then revokes the user's refresh tokens so they're effectively signed out.
+//
+// The scheduled-pause-cleanup function runs daily and deletes any account
+// where paused_at is older than 30 days. The pause window is intentionally
+// generous — a parent who deletes in a moment of frustration can sign back
+// in within 30 days and be restored.
+
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import {
+  adminClient,
+  AuthError,
+  jsonRes,
+  preflight,
+  requireUser,
+} from "../_shared/accountAuth.ts";
+
+serve(async (req) => {
+  const pre = preflight(req);
+  if (pre) return pre;
+  if (req.method !== "POST") return jsonRes({ error: "Method not allowed." }, 405);
+
+  let userId: string;
+  try {
+    ({ userId } = await requireUser(req));
+  } catch (e) {
+    if (e instanceof AuthError) return jsonRes({ error: e.message }, 401);
+    return jsonRes({ error: "Authentication failed." }, 401);
+  }
+
+  const admin = adminClient();
+
+  // 1. Set paused_at
+  const { error: updateErr } = await admin
+    .from("profiles")
+    .update({ paused_at: new Date().toISOString() })
+    .eq("id", userId);
+
+  if (updateErr) {
+    console.error("[account-pause] update failed", updateErr);
+    return jsonRes({ error: "Could not pause account." }, 500);
+  }
+
+  // 2. Revoke session — the user is signed out as a side effect.
+  // 'global' invalidates every refresh token for this user across all devices.
+  const { error: signOutErr } = await admin.auth.admin.signOut(userId, "global");
+  if (signOutErr) {
+    // Pause already succeeded — surface a warning but don't fail the request.
+    console.warn("[account-pause] signOut failed", signOutErr);
+  }
+
+  return jsonRes({ ok: true, pausedAt: new Date().toISOString() }, 200);
+});

--- a/supabase/functions/scheduled-pause-cleanup/index.ts
+++ b/supabase/functions/scheduled-pause-cleanup/index.ts
@@ -1,0 +1,100 @@
+// supabase/functions/scheduled-pause-cleanup/index.ts
+//
+// Daily cron. Finds every account where profiles.paused_at is older than
+// 30 days and calls account-delete with confirmationText = "PAUSE_EXPIRED".
+//
+// Authentication: caller must be the system, not a user. Two acceptable
+// signals (see _shared/accountAuth.ts:requireSystemCaller):
+//   - Bearer token equal to SUPABASE_SERVICE_ROLE_KEY
+//   - X-Cron-Secret header equal to CRON_SHARED_SECRET env
+//
+// The 30-day deadline is approximate. Per docs/PRODUCT_PRINCIPLES.md §8 the
+// commitment is "approximately 30 days" rather than precise to the minute —
+// if a cron run fails, the next day's run picks up the missed accounts.
+
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import {
+  adminClient,
+  AuthError,
+  jsonRes,
+  preflight,
+  requireSystemCaller,
+  SUPABASE_SERVICE_ROLE_KEY,
+  SUPABASE_URL,
+} from "../_shared/accountAuth.ts";
+
+const PAUSE_TTL_DAYS = 30;
+
+serve(async (req) => {
+  const pre = preflight(req);
+  if (pre) return pre;
+  if (req.method !== "POST") return jsonRes({ error: "Method not allowed." }, 405);
+
+  try {
+    requireSystemCaller(req);
+  } catch (e) {
+    if (e instanceof AuthError) return jsonRes({ error: e.message }, 401);
+    return jsonRes({ error: "Authentication failed." }, 401);
+  }
+
+  const admin = adminClient();
+  const cutoff = new Date(Date.now() - PAUSE_TTL_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+  // Find expired pauses.
+  const { data: expired, error: queryErr } = await admin
+    .from("profiles")
+    .select("id, paused_at")
+    .not("paused_at", "is", null)
+    .lt("paused_at", cutoff);
+
+  if (queryErr) {
+    console.error("[scheduled-pause-cleanup] query failed", queryErr);
+    return jsonRes({ error: "Could not list expired pauses." }, 500);
+  }
+
+  const candidates = (expired ?? []) as Array<{ id: string; paused_at: string }>;
+  const results: Array<{ userId: string; status: "deleted" | "failed"; error?: string }> = [];
+
+  for (const row of candidates) {
+    try {
+      const res = await fetch(`${SUPABASE_URL}/functions/v1/account-delete`, {
+        method: "POST",
+        headers: {
+          "Content-Type":  "application/json",
+          "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+        },
+        body: JSON.stringify({
+          confirmationText: "PAUSE_EXPIRED",
+          targetUserId:     row.id,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        results.push({ userId: row.id, status: "failed", error: body.slice(0, 200) });
+      } else {
+        results.push({ userId: row.id, status: "deleted" });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      results.push({ userId: row.id, status: "failed", error: message });
+    }
+  }
+
+  const deleted = results.filter(r => r.status === "deleted").length;
+  const failed  = results.filter(r => r.status === "failed").length;
+
+  console.log("[scheduled-pause-cleanup]", { deleted, failed, candidates: candidates.length });
+
+  return jsonRes(
+    {
+      ok: true,
+      cutoff,
+      candidates: candidates.length,
+      deleted,
+      failed,
+      // Include the full result list so logs (and ad-hoc invocations) are auditable.
+      details: results,
+    },
+    200,
+  );
+});

--- a/supabase/migrations/20260429_003_account_deletion_lifecycle.sql
+++ b/supabase/migrations/20260429_003_account_deletion_lifecycle.sql
@@ -1,0 +1,178 @@
+-- 20260429_003_account_deletion_lifecycle.sql
+--
+-- Adds the schema changes that support the account-deletion + pause + export feature.
+-- All transactional. Rollback documented at the bottom of this file.
+--
+-- What this migration does:
+--   1. Adds `profiles.paused_at` (nullable timestamptz) + partial index
+--   2. Switches `safety_events.user_id` from `ON DELETE CASCADE` to `ON DELETE SET NULL`
+--      so anonymized rows survive account deletion (per docs/PRODUCT_PRINCIPLES.md §8).
+--   3. Defensively ensures `ON DELETE CASCADE` on `interaction_logs.user_id`,
+--      `parent_thoughts.user_id`, and `usage_events.user_id` — these tables (the first
+--      two especially) were created out-of-band via the SQL Editor and may not have
+--      cascade behavior. The DO blocks no-op cleanly if a table doesn't exist.
+--   4. Creates the `account-exports` Storage bucket (private) + RLS so a parent can
+--      only read their own export. Service role uploads; signed URLs expire in 24h.
+
+begin;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. profiles.paused_at
+-- ─────────────────────────────────────────────────────────────────────────────
+
+alter table public.profiles
+  add column if not exists paused_at timestamptz null;
+
+create index if not exists idx_profiles_paused_at
+  on public.profiles (paused_at)
+  where paused_at is not null;
+
+comment on column public.profiles.paused_at is
+  'Timestamp when user paused their account. NULL = active. If non-NULL and older than 30 days, the scheduled-pause-cleanup function deletes the account.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. safety_events.user_id  →  ON DELETE SET NULL (was CASCADE)
+--
+-- Per Product Principle 8 + privacy policy, safety events are retained
+-- anonymously after user deletion. The user_id is NULLed; the content stays.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Drop NOT NULL so the column can be nullified
+alter table public.safety_events
+  alter column user_id drop not null;
+
+-- Drop the existing CASCADE FK and add a SET NULL FK in its place.
+-- Constraint name is the Postgres default; the DO block looks it up dynamically
+-- in case it was renamed.
+do $$
+declare
+  fk_name text;
+begin
+  select conname into fk_name
+    from pg_constraint
+    where conrelid = 'public.safety_events'::regclass
+      and contype  = 'f'
+      and pg_get_constraintdef(oid) like '%REFERENCES auth.users(id)%';
+
+  if fk_name is not null then
+    execute format('alter table public.safety_events drop constraint %I', fk_name);
+  end if;
+end $$;
+
+alter table public.safety_events
+  add constraint safety_events_user_id_fkey
+  foreign key (user_id) references auth.users(id) on delete set null;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. Ensure ON DELETE CASCADE on out-of-band tables
+--
+-- `interaction_logs` and `parent_thoughts` were created via SQL Editor and are
+-- not in the migration history. Their FK behavior is unknown. These DO blocks
+-- inspect each table at runtime and rebuild the FK with CASCADE if it isn't
+-- already CASCADE. Tables that don't exist are skipped silently — operators on
+-- a fresh environment will create them with CASCADE from the start.
+-- `usage_events` is included as belt-and-suspenders (it already CASCADEs in
+-- the MVP migration but we re-assert to keep the policy explicit).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+do $$
+declare
+  t_name text;
+  fk_name text;
+begin
+  foreach t_name in array array['interaction_logs', 'parent_thoughts', 'usage_events']
+  loop
+    if exists (
+      select 1 from information_schema.tables
+       where table_schema = 'public' and table_name = t_name
+    ) then
+      -- Find the FK that points at auth.users
+      select conname into fk_name
+        from pg_constraint
+        where conrelid = ('public.' || t_name)::regclass
+          and contype  = 'f'
+          and pg_get_constraintdef(oid) like '%REFERENCES auth.users(id)%';
+
+      if fk_name is not null then
+        execute format('alter table public.%I drop constraint %I', t_name, fk_name);
+      end if;
+
+      execute format(
+        'alter table public.%I add constraint %I_user_id_fkey foreign key (user_id) references auth.users(id) on delete cascade',
+        t_name, t_name
+      );
+    end if;
+  end loop;
+end $$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. Storage bucket: account-exports
+--
+-- Private bucket. Service role uploads zips. The Edge Function generates 24-hour
+-- signed URLs for the parent to download. The SELECT policy is defense in depth
+-- — even if the bucket were ever made public, the policy would only allow a
+-- user to list/read their own exports (path prefix `<user_id>/`).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+insert into storage.buckets (id, name, public)
+  values ('account-exports', 'account-exports', false)
+  on conflict (id) do nothing;
+
+-- Drop any prior policies (idempotent on re-run)
+drop policy if exists "account_exports_read_own"   on storage.objects;
+drop policy if exists "account_exports_write_own"  on storage.objects;
+drop policy if exists "account_exports_delete_own" on storage.objects;
+
+-- Read: only files inside <auth.uid()>/ folder
+create policy "account_exports_read_own"
+  on storage.objects for select to authenticated
+  using (
+    bucket_id = 'account-exports'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Insert: only into own folder. Service role bypasses RLS so this is for
+-- direct-upload scenarios only; in practice the Edge Function does the upload.
+create policy "account_exports_write_own"
+  on storage.objects for insert to authenticated
+  with check (
+    bucket_id = 'account-exports'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Delete: own folder only
+create policy "account_exports_delete_own"
+  on storage.objects for delete to authenticated
+  using (
+    bucket_id = 'account-exports'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+commit;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- ROLLBACK
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- begin;
+--   -- Reverse storage bucket policies + bucket
+--   drop policy if exists "account_exports_read_own"   on storage.objects;
+--   drop policy if exists "account_exports_write_own"  on storage.objects;
+--   drop policy if exists "account_exports_delete_own" on storage.objects;
+--   delete from storage.buckets where id = 'account-exports';
+--
+--   -- Reverse safety_events FK back to CASCADE + NOT NULL
+--   alter table public.safety_events drop constraint safety_events_user_id_fkey;
+--   -- Note: cannot easily set NOT NULL again if any rows were anonymized post-rollout.
+--   -- Manually delete anonymized rows first or accept that user_id stays nullable.
+--   alter table public.safety_events
+--     add constraint safety_events_user_id_fkey
+--     foreign key (user_id) references auth.users(id) on delete cascade;
+--
+--   -- Reverse paused_at
+--   drop index if exists public.idx_profiles_paused_at;
+--   alter table public.profiles drop column if exists paused_at;
+--
+--   -- The interaction_logs / parent_thoughts / usage_events FK rebuilds are not
+--   -- reversed — they're re-asserting CASCADE which is the desired post-state.
+-- commit;


### PR DESCRIPTION
## Summary

PR 1 of 2 — backend half of the account-deletion + pause + export feature. PR 2 (mobile UI) is gated on this one merging and the smoke test plan passing against staging.

### Migration — `20260429_003_account_deletion_lifecycle.sql`

- `profiles.paused_at` + partial index for the cron query
- `safety_events.user_id` switched from `ON DELETE CASCADE` to `ON DELETE SET NULL` (and the column made nullable) so anonymized rows survive account deletion. This is the only exception to "deletion means deletion" (Principle 8) and is disclosed in the privacy policy update that lands in PR 2.
- Defensive `ON DELETE CASCADE` re-assertion on `interaction_logs`, `parent_thoughts`, `usage_events`. The first two were created out-of-band via the SQL Editor (no migration history) so their FK behavior was unknown — the migration uses a `DO` block that no-ops cleanly if a table doesn't exist on a given environment.
- Private `account-exports` Storage bucket + per-user RLS (`<auth.uid()>/` folder prefix). Service role uploads, signed URLs do the heavy lifting, defense-in-depth RLS prevents cross-user reads even if a URL leaks.
- Transactional with documented rollback at the bottom of the file.

### Edge Functions

- **`_shared/accountAuth.ts`** — `requireUser` (JWT validation via `auth.getUser`), `requireSystemCaller` (service-role bearer or `X-Cron-Secret` header), `adminClient` factory, CORS + JSON helpers.
- **`account-pause`** — sets `paused_at = now()`, revokes refresh tokens globally (`signOut(userId, "global")`).
- **`account-delete`** — two callers: user JWT with `confirmationText = "DELETE"`, or system caller with `confirmationText = "PAUSE_EXPIRED"` and an explicit `targetUserId`. Calls `auth.admin.deleteUser` once; the migration's CASCADE/SET-NULL FKs do the rest atomically. Subscription check is a documented stub returning `false` until RevenueCat lands.
- **`account-export`** — JSON + Markdown zipped via `https://esm.sh/fflate@0.8.2`, uploaded to `account-exports/<user_id>/sturdy-export-<stamp>.zip`, returned as a 24-hour signed URL. Markdown was chosen over PDF deliberately — opens on every device, in every text app, with no library dependency that would balloon the function bundle. Privacy policy text in PR 2 reflects this.
- **`scheduled-pause-cleanup`** — daily cron. Queries `paused_at < (now - 30 days)` and calls `account-delete` for each candidate. Per-row results are returned so an ad-hoc invocation is auditable.

### Config — `supabase/config.toml`

- `[functions.account-export]`, `[functions.account-pause]`, `[functions.account-delete]` declarations (default `verify_jwt = true`; the functions self-validate JWT inside).
- `[functions.scheduled-pause-cleanup]` with `verify_jwt = false` and a long comment block explaining the daily 03:00 UTC schedule, why daily granularity is fine for an "approximately 30 days" window, and the recommended pg_cron wiring snippet.

### Docs

- `docs/PRODUCT_PRINCIPLES.md` — **Principle 8: Account deletion means deletion** (with the `safety_events` exception explicitly carved out and disclosed).
- `docs/OPERATIONS.md` — 2026-04-29 entry with full context, decision, and reasoning.
- `docs/SMOKE_TEST_account_lifecycle.md` — manual smoke-test plan. Walks through schema verification, pause flow, manual cron trigger after stubbing `paused_at` to 31 days ago, post-cleanup assertions (cascade deletion of public.* rows, `safety_events.user_id` NULLed and content retained), direct-delete flow, confirmation guard rails, export flow with bucket inspection, and RLS verification.

## Out of scope (intentionally — coming in PR 2)

- Mobile screens (`account/pause.tsx`, `account/delete.tsx`, `account/_layout.tsx`)
- Settings → Account section
- `auth/index.tsx` paused-account detection + restore prompt
- `apps/mobile/src/lib/api.ts` — `requestExport`, `pauseAccount`, `deleteAccount`
- `apps/mobile/src/hooks/useSubscription.ts` — `hasActiveSubscription` stub
- `docs/legal/PRIVACY_POLICY.md` retention section update

## Test plan

**This PR does not auto-merge.** Run the full plan in `docs/SMOKE_TEST_account_lifecycle.md` against staging and paste the log into this PR's review thread before merging. Highlights:

- [ ] Migration applies cleanly (`npx supabase db push`)
- [ ] All four functions deploy (`npx supabase functions deploy account-export account-pause account-delete scheduled-pause-cleanup`)
- [ ] Schema verification queries (Step 1 in smoke test) all return expected values
- [ ] Pause → manually advance `paused_at` to 31 days ago → invoke `scheduled-pause-cleanup` with service role → response shows `deleted: 1, failed: 0`
- [ ] Post-cleanup: `auth.users` row gone, public.* rows for that user gone, `safety_events.user_id IS NULL` for anonymized rows (content preserved)
- [ ] Direct delete flow works with `confirmationText: "DELETE"` from a user JWT
- [ ] Wrong confirmation strings rejected (400); user JWT cannot use `PAUSE_EXPIRED` (401); anon key cannot call cron (401)
- [ ] Export returns a working signed URL; zip contains `sturdy-export.json` + `sturdy-export.md` with the user's data only; URL expires in 24h
- [ ] Storage RLS: another user's JWT cannot list a different user's export folder

Once green, merge with **standard merge** (no squash, no `--no-ff`). Then PR 2 starts.

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_