### PR TITLE
feat: account lifecycle mobile UI — pause, delete, export screens

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -190,14 +190,22 @@ export default function SettingsScreen() {
           <SettingRow label="Contact us" onPress={() => {}} />
         </SettingGroup>
 
-        {/* ACCOUNT ACTIONS */}
+        {/* ACCOUNT MANAGEMENT */}
+        <SectionLabel label="ACCOUNT" />
+        <SettingGroup>
+          <SettingRow label="Export my data" onPress={() => router.push('/account/export')} />
+          <Divider />
+          <SettingRow label="Pause account"  onPress={() => router.push('/account/pause')} />
+          <Divider />
+          <SettingRow label="Delete account" danger onPress={() => router.push('/account/delete')} />
+        </SettingGroup>
+
+        {/* SIGN OUT */}
         <SettingGroup>
           <SettingRow
             label={signingOut ? 'Signing out…' : 'Sign out'}
             onPress={handleSignOut}
           />
-          <Divider />
-          <SettingRow label="Delete account" danger onPress={() => {}} />
         </SettingGroup>
 
         <Text style={s.version}>Sturdy v6.0 · Made with ♥</Text>

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -190,8 +190,8 @@ export default function SettingsScreen() {
           <SettingRow label="Contact us" onPress={() => {}} />
         </SettingGroup>
 
-        {/* ACCOUNT MANAGEMENT */}
-        <SectionLabel label="ACCOUNT" />
+        {/* MANAGE ACCOUNT */}
+        <SectionLabel label="MANAGE ACCOUNT" />
         <SettingGroup>
           <SettingRow label="Export my data" onPress={() => router.push('/account/export')} />
           <Divider />

--- a/apps/mobile/app/account/_layout.tsx
+++ b/apps/mobile/app/account/_layout.tsx
@@ -1,0 +1,16 @@
+// app/account/_layout.tsx
+// Stack layout for the account-lifecycle screens (pause, delete, export).
+// Headers are hidden — each screen renders its own back button.
+
+import { Stack } from 'expo-router';
+
+export default function AccountLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: '#0e0a10' },
+      }}
+    />
+  );
+}

--- a/apps/mobile/app/account/delete.tsx
+++ b/apps/mobile/app/account/delete.tsx
@@ -1,0 +1,168 @@
+// app/account/delete.tsx
+//
+// Permanent account deletion. Requires the parent to type the literal
+// string "DELETE" (exact, case-sensitive) into the input — this is the
+// only way to enable the CTA. On success, local tokens are cleared,
+// signOut is fired-and-forgotten, and we route to welcome.
+
+import { useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { router }   from 'expo-router';
+import { StatusBar }   from 'expo-status-bar';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import * as Haptics from 'expo-haptics';
+import { fonts as F } from '../../src/theme';
+import { supabase } from '../../src/lib/supabase';
+import { deleteAccount } from '../../src/lib/accountApi';
+
+const BG         = '#0e0a10';
+const TEXT       = 'rgba(255,255,255,0.92)';
+const TEXT_SEC   = 'rgba(255,255,255,0.52)';
+const TEXT_MUTED = 'rgba(255,255,255,0.28)';
+const CORAL      = '#E87461';
+
+const CONFIRMATION = 'DELETE';
+
+async function clearAuthStorage() {
+  try {
+    const keys = await AsyncStorage.getAllKeys();
+    const supabaseKeys = keys.filter(k => k.startsWith('sb-') || k.includes('supabase'));
+    if (supabaseKeys.length > 0) await AsyncStorage.multiRemove(supabaseKeys);
+  } catch {
+    // best-effort
+  }
+}
+
+export default function DeleteAccountScreen() {
+  const [confirmText, setConfirmText] = useState('');
+  const [submitting,  setSubmitting]  = useState(false);
+  const [error,       setError]       = useState<string | null>(null);
+
+  // Exact-match, case-sensitive — Delete / delete / DELETED all stay disabled.
+  const canSubmit = confirmText === CONFIRMATION && !submitting;
+
+  const onSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+
+    const result = await deleteAccount(CONFIRMATION);
+    if (!result.ok) {
+      setError(result.error);
+      setSubmitting(false);
+      return;
+    }
+
+    // Clear local tokens immediately. The server-side session is gone with
+    // the user, so signOut is fire-and-forget.
+    await clearAuthStorage();
+    supabase.auth.signOut().catch(() => {});
+    router.replace('/welcome');
+  };
+
+  return (
+    <SafeAreaView style={s.root} edges={['top', 'bottom']}>
+      <StatusBar style="light" />
+      <ScrollView contentContainerStyle={s.scroll} keyboardShouldPersistTaps="handled">
+        <Pressable onPress={() => router.back()} style={s.closeBtn} hitSlop={16}>
+          <Text style={s.closeText}>‹ Back</Text>
+        </Pressable>
+
+        <View style={s.body}>
+          <Text style={s.heading}>Delete your account</Text>
+          <Text style={s.bodyText}>
+            This will permanently delete your account and all your data. This cannot be undone.
+          </Text>
+          <Text style={s.subText}>
+            To confirm, type <Text style={s.subTextBold}>DELETE</Text> below.
+          </Text>
+
+          <TextInput
+            value={confirmText}
+            onChangeText={setConfirmText}
+            autoCapitalize="characters"
+            autoCorrect={false}
+            spellCheck={false}
+            textContentType="none"
+            importantForAutofill="no"
+            placeholder="DELETE"
+            placeholderTextColor={TEXT_MUTED}
+            style={[
+              s.input,
+              { borderColor: confirmText ? 'rgba(232,116,97,0.40)' : 'rgba(255,255,255,0.07)' },
+            ]}
+          />
+        </View>
+
+        <View style={s.actions}>
+          <Pressable
+            onPress={onSubmit}
+            disabled={!canSubmit}
+            style={({ pressed }) => [
+              s.cta,
+              !canSubmit && s.ctaDisabled,
+              canSubmit && pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] },
+            ]}
+          >
+            <Text style={[s.ctaText, !canSubmit && s.ctaTextDisabled]}>
+              {submitting ? 'Deleting…' : 'Delete my account'}
+            </Text>
+          </Pressable>
+
+          {error ? <Text style={s.errorText}>{error}</Text> : null}
+
+          <Pressable onPress={() => router.back()} style={s.secondaryBtn} hitSlop={8}>
+            <Text style={s.secondaryText}>Cancel</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const s = StyleSheet.create({
+  root:   { flex: 1, backgroundColor: BG },
+  scroll: { padding: 24, paddingBottom: 40, gap: 24 },
+
+  closeBtn:  { alignSelf: 'flex-start', paddingVertical: 8 },
+  closeText: { fontFamily: F.bodyMedium, fontSize: 15, color: TEXT_MUTED },
+
+  body:        { gap: 14, paddingTop: 12 },
+  heading:     { fontFamily: F.heading, fontSize: 28, color: TEXT, letterSpacing: -0.4, lineHeight: 34 },
+  bodyText:    { fontFamily: F.body, fontSize: 16, color: TEXT_SEC, lineHeight: 24 },
+  subText:     { fontFamily: F.body, fontSize: 14, color: TEXT_SEC, lineHeight: 20, marginTop: 4 },
+  subTextBold: { fontFamily: F.bodySemi, color: TEXT },
+
+  input: {
+    backgroundColor: 'rgba(255,255,255,0.06)',
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    color: TEXT,
+    fontFamily: F.bodySemi,
+    fontSize: 16,
+    letterSpacing: 1.2,
+    marginTop: 8,
+  },
+
+  actions: { gap: 12, marginTop: 12 },
+
+  cta: {
+    backgroundColor: CORAL,
+    borderRadius: 18,
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  ctaDisabled: {
+    backgroundColor: 'rgba(255,255,255,0.06)',
+  },
+  ctaText:         { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
+  ctaTextDisabled: { color: 'rgba(255,255,255,0.20)' },
+
+  errorText: { fontFamily: F.body, fontSize: 14, color: CORAL, textAlign: 'center' },
+
+  secondaryBtn:  { paddingVertical: 14, alignItems: 'center' },
+  secondaryText: { fontFamily: F.bodyMedium, fontSize: 14, color: TEXT_MUTED },
+});

--- a/apps/mobile/app/account/export.tsx
+++ b/apps/mobile/app/account/export.tsx
@@ -41,13 +41,15 @@ export default function ExportAccountScreen() {
       return;
     }
 
-    // Hand off to the system browser — it will start the download.
-    Linking.openURL(result.url).catch(() => {
-      // If the system can't open the URL, surface that as an error.
+    // Hand off to the system browser — it will start the download. Await
+    // so a failure flips to the error branch instead of racing with the
+    // synchronous success state.
+    try {
+      await Linking.openURL(result.url);
+      setSuccess(true);
+    } catch {
       setError("Couldn't open the download link. Please try again.");
-      return;
-    });
-    setSuccess(true);
+    }
   };
 
   return (

--- a/apps/mobile/app/account/export.tsx
+++ b/apps/mobile/app/account/export.tsx
@@ -1,0 +1,124 @@
+// app/account/export.tsx
+//
+// Generates a 24-hour signed URL for the parent's data export and opens
+// it in the system browser. Empty exports (brand-new accounts) are fine —
+// the backend returns the same shape with a near-empty zip.
+
+import { useState } from 'react';
+import { Linking, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { router }   from 'expo-router';
+import { StatusBar }   from 'expo-status-bar';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics from 'expo-haptics';
+import { fonts as F } from '../../src/theme';
+import { requestExport } from '../../src/lib/accountApi';
+
+const BG          = '#0e0a10';
+const TEXT        = 'rgba(255,255,255,0.92)';
+const TEXT_SEC    = 'rgba(255,255,255,0.52)';
+const TEXT_MUTED  = 'rgba(255,255,255,0.28)';
+const CORAL       = '#E87461';
+const AMBER_DEEP  = '#C8883A';
+const AMBER_LIGHT = '#E8A855';
+
+export default function ExportAccountScreen() {
+  const [loading, setLoading] = useState(false);
+  const [error,   setError]   = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const onDownload = async () => {
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+    Haptics.selectionAsync();
+
+    const result = await requestExport();
+    setLoading(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    // Hand off to the system browser — it will start the download.
+    Linking.openURL(result.url).catch(() => {
+      // If the system can't open the URL, surface that as an error.
+      setError("Couldn't open the download link. Please try again.");
+      return;
+    });
+    setSuccess(true);
+  };
+
+  return (
+    <SafeAreaView style={s.root} edges={['top', 'bottom']}>
+      <StatusBar style="light" />
+      <ScrollView contentContainerStyle={s.scroll}>
+        <Pressable onPress={() => router.back()} style={s.closeBtn} hitSlop={16}>
+          <Text style={s.closeText}>‹ Back</Text>
+        </Pressable>
+
+        <View style={s.body}>
+          <Text style={s.heading}>Download your data</Text>
+          <Text style={s.bodyText}>
+            Get a copy of everything Sturdy has stored about your account —
+            child profiles, saved scripts, Question responses, and more. The
+            download link expires in 24 hours.
+          </Text>
+        </View>
+
+        <View style={s.actions}>
+          <Pressable
+            onPress={onDownload}
+            disabled={loading}
+            style={({ pressed }) => [pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] }]}
+          >
+            <LinearGradient
+              colors={[AMBER_DEEP, AMBER_LIGHT]}
+              start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
+              style={s.cta}
+            >
+              <Text style={s.ctaText}>
+                {loading ? 'Preparing…' : 'Download my data'}
+              </Text>
+            </LinearGradient>
+          </Pressable>
+
+          {error   ? <Text style={s.errorText}>{error}</Text> : null}
+          {success ? (
+            <Text style={s.successText}>
+              Download started. The link expires in 24 hours.
+            </Text>
+          ) : null}
+
+          <Pressable onPress={() => router.back()} style={s.secondaryBtn} hitSlop={8}>
+            <Text style={s.secondaryText}>Back</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const s = StyleSheet.create({
+  root:   { flex: 1, backgroundColor: BG },
+  scroll: { padding: 24, paddingBottom: 40, gap: 24 },
+
+  closeBtn:  { alignSelf: 'flex-start', paddingVertical: 8 },
+  closeText: { fontFamily: F.bodyMedium, fontSize: 15, color: TEXT_MUTED },
+
+  body:     { gap: 14, paddingTop: 12 },
+  heading:  { fontFamily: F.heading, fontSize: 28, color: TEXT, letterSpacing: -0.4, lineHeight: 34 },
+  bodyText: { fontFamily: F.body, fontSize: 16, color: TEXT_SEC, lineHeight: 24 },
+
+  actions: { gap: 12, marginTop: 12 },
+
+  cta:     { borderRadius: 18, paddingVertical: 16, alignItems: 'center' },
+  ctaText: { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
+
+  errorText:   { fontFamily: F.body, fontSize: 14, color: CORAL,    textAlign: 'center' },
+  successText: { fontFamily: F.body, fontSize: 14, color: TEXT_SEC, textAlign: 'center' },
+
+  secondaryBtn:  { paddingVertical: 14, alignItems: 'center' },
+  secondaryText: { fontFamily: F.bodyMedium, fontSize: 14, color: TEXT_MUTED },
+});

--- a/apps/mobile/app/account/pause.tsx
+++ b/apps/mobile/app/account/pause.tsx
@@ -1,0 +1,136 @@
+// app/account/pause.tsx
+//
+// Pause account screen. 30-day reversible suspension; auto-deleted at expiry
+// by the scheduled-pause-cleanup Edge Function. The pause confirmation is
+// the only Alert — every other failure surfaces inline below the CTA.
+
+import { useState } from 'react';
+import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { router }   from 'expo-router';
+import { StatusBar }   from 'expo-status-bar';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics from 'expo-haptics';
+import { fonts as F } from '../../src/theme';
+import { supabase } from '../../src/lib/supabase';
+import { pauseAccount } from '../../src/lib/accountApi';
+
+const BG          = '#0e0a10';
+const TEXT        = 'rgba(255,255,255,0.92)';
+const TEXT_SEC    = 'rgba(255,255,255,0.52)';
+const TEXT_MUTED  = 'rgba(255,255,255,0.28)';
+const CORAL       = '#E87461';
+const AMBER_DEEP  = '#C8883A';
+const AMBER_LIGHT = '#E8A855';
+
+async function clearAuthStorage() {
+  try {
+    const keys = await AsyncStorage.getAllKeys();
+    const supabaseKeys = keys.filter(k => k.startsWith('sb-') || k.includes('supabase'));
+    if (supabaseKeys.length > 0) await AsyncStorage.multiRemove(supabaseKeys);
+  } catch {
+    // best-effort; sign-out fallback below
+  }
+}
+
+export default function PauseAccountScreen() {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError]           = useState<string | null>(null);
+
+  const doPause = async () => {
+    setSubmitting(true);
+    setError(null);
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+
+    const result = await pauseAccount();
+    if (!result.ok) {
+      setError(result.error);
+      setSubmitting(false);
+      return;
+    }
+
+    // Clear local tokens immediately (don't wait for server-side teardown).
+    await clearAuthStorage();
+    // Fire-and-forget; the session may already be invalid server-side.
+    supabase.auth.signOut().catch(() => {});
+    router.replace('/welcome');
+  };
+
+  const onConfirm = () => {
+    Alert.alert(
+      'Pause your account?',
+      'Your account will be paused for 30 days, then permanently deleted unless you sign back in.',
+      [
+        { text: 'Pause',  style: 'destructive', onPress: doPause },
+        { text: 'Cancel', style: 'cancel' },
+      ],
+    );
+  };
+
+  return (
+    <SafeAreaView style={s.root} edges={['top', 'bottom']}>
+      <StatusBar style="light" />
+      <ScrollView contentContainerStyle={s.scroll}>
+        <Pressable onPress={() => router.back()} style={s.closeBtn} hitSlop={16}>
+          <Text style={s.closeText}>‹ Back</Text>
+        </Pressable>
+
+        <View style={s.body}>
+          <Text style={s.heading}>Pause your account</Text>
+          <Text style={s.bodyText}>
+            Your account will be paused for 30 days. After that, it will be
+            permanently deleted. If you sign back in within 30 days, you can
+            restore everything.
+          </Text>
+        </View>
+
+        <View style={s.actions}>
+          <Pressable
+            onPress={onConfirm}
+            disabled={submitting}
+            style={({ pressed }) => [pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] }]}
+          >
+            <LinearGradient
+              colors={[AMBER_DEEP, AMBER_LIGHT]}
+              start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
+              style={s.cta}
+            >
+              <Text style={s.ctaText}>
+                {submitting ? 'Pausing…' : 'Pause my account'}
+              </Text>
+            </LinearGradient>
+          </Pressable>
+
+          {error ? <Text style={s.errorText}>{error}</Text> : null}
+
+          <Pressable onPress={() => router.back()} style={s.secondaryBtn} hitSlop={8}>
+            <Text style={s.secondaryText}>Not yet</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const s = StyleSheet.create({
+  root:   { flex: 1, backgroundColor: BG },
+  scroll: { padding: 24, paddingBottom: 40, gap: 24 },
+
+  closeBtn:  { alignSelf: 'flex-start', paddingVertical: 8 },
+  closeText: { fontFamily: F.bodyMedium, fontSize: 15, color: TEXT_MUTED },
+
+  body:     { gap: 14, paddingTop: 12 },
+  heading:  { fontFamily: F.heading, fontSize: 28, color: TEXT, letterSpacing: -0.4, lineHeight: 34 },
+  bodyText: { fontFamily: F.body, fontSize: 16, color: TEXT_SEC, lineHeight: 24 },
+
+  actions: { gap: 12, marginTop: 12 },
+
+  cta:     { borderRadius: 18, paddingVertical: 16, alignItems: 'center' },
+  ctaText: { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
+
+  errorText: { fontFamily: F.body, fontSize: 14, color: CORAL, textAlign: 'center' },
+
+  secondaryBtn:  { paddingVertical: 14, alignItems: 'center' },
+  secondaryText: { fontFamily: F.bodyMedium, fontSize: 14, color: TEXT_MUTED },
+});

--- a/apps/mobile/src/lib/accountApi.ts
+++ b/apps/mobile/src/lib/accountApi.ts
@@ -1,0 +1,113 @@
+// apps/mobile/src/lib/accountApi.ts
+//
+// Client for the account-lifecycle Edge Functions (account-pause,
+// account-delete, account-export). Each function pulls the current
+// session JWT and POSTs to the matching endpoint with that bearer.
+//
+// All three return a discriminated union — never throw. Callers branch
+// on `ok` and surface the error string inline. See Edge Function
+// implementations in supabase/functions/account-{pause,delete,export}.
+
+import { supabase } from './supabase';
+
+// @ts-ignore
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
+if (!SUPABASE_URL) throw new Error('Missing EXPO_PUBLIC_SUPABASE_URL.');
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export type PauseResult =
+  | { ok: true;  pausedAt: string }
+  | { ok: false; error: string };
+
+export type DeleteResult =
+  | { ok: true;  deletedUserId: string }
+  | { ok: false; error: string };
+
+export type ExportResult =
+  | { ok: true;  url: string; expiresInSeconds: number }
+  | { ok: false; error: string };
+
+// ─── Error message resolution ────────────────────────────────────────────────
+
+const SESSION_EXPIRED   = 'Session expired, please sign in again.';
+const NETWORK_OR_SERVER = "Couldn't reach Sturdy. Please check your connection and try again.";
+const GENERIC           = 'Something went wrong. Please try again.';
+
+function errorForStatus(status: number): string {
+  if (status === 401) return SESSION_EXPIRED;
+  if (status >= 500)  return NETWORK_OR_SERVER;
+  return GENERIC;
+}
+
+// ─── Internal: fetch with auth ───────────────────────────────────────────────
+
+type CallResult =
+  | { ok: true;  data: unknown }
+  | { ok: false; error: string };
+
+async function callFunction(name: string, body: Record<string, unknown>): Promise<CallResult> {
+  let jwt: string | null;
+  try {
+    const { data } = await supabase.auth.getSession();
+    jwt = data?.session?.access_token ?? null;
+  } catch {
+    return { ok: false, error: SESSION_EXPIRED };
+  }
+  if (!jwt) return { ok: false, error: SESSION_EXPIRED };
+
+  let res: Response;
+  try {
+    res = await fetch(`${SUPABASE_URL}/functions/v1/${name}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        Authorization:   `Bearer ${jwt}`,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return { ok: false, error: NETWORK_OR_SERVER };
+  }
+
+  if (!res.ok) return { ok: false, error: errorForStatus(res.status) };
+
+  try {
+    const data = await res.json();
+    return { ok: true, data };
+  } catch {
+    return { ok: false, error: GENERIC };
+  }
+}
+
+// ─── Public functions ────────────────────────────────────────────────────────
+
+export async function pauseAccount(): Promise<PauseResult> {
+  const result = await callFunction('account-pause', {});
+  if (!result.ok) return result;
+  const data = result.data as { ok?: boolean; pausedAt?: unknown };
+  if (data?.ok === true && typeof data.pausedAt === 'string') {
+    return { ok: true, pausedAt: data.pausedAt };
+  }
+  return { ok: false, error: GENERIC };
+}
+
+export async function deleteAccount(confirmationText: string): Promise<DeleteResult> {
+  const result = await callFunction('account-delete', { confirmationText });
+  if (!result.ok) return result;
+  const data = result.data as { ok?: boolean; deletedUserId?: unknown };
+  if (data?.ok === true && typeof data.deletedUserId === 'string') {
+    return { ok: true, deletedUserId: data.deletedUserId };
+  }
+  return { ok: false, error: GENERIC };
+}
+
+export async function requestExport(): Promise<ExportResult> {
+  const result = await callFunction('account-export', {});
+  if (!result.ok) return result;
+  const data = result.data as { ok?: boolean; url?: unknown; expiresInSeconds?: unknown };
+  if (data?.ok === true && typeof data.url === 'string' && typeof data.expiresInSeconds === 'number') {
+    return { ok: true, url: data.url, expiresInSeconds: data.expiresInSeconds };
+  }
+  return { ok: false, error: GENERIC };
+}


### PR DESCRIPTION
## Summary

Wires PR 18's backend (account-pause, account-delete, account-export Edge Functions) to the mobile app. Reachable from Settings → Account.

### Files added

- **`apps/mobile/src/lib/accountApi.ts`** — `pauseAccount` / `deleteAccount` / `requestExport`. Each pulls the JWT via `supabase.auth.getSession()` and POSTs to the matching `/functions/v1/<name>` endpoint. Returns a discriminated union (`{ ok: true, ... } | { ok: false, error: string }`) — never throws. Error mapping per the brief: 401 → "Session expired, please sign in again." / 5xx or network → "Couldn't reach Sturdy. Please check your connection and try again." / other → generic.
- **`apps/mobile/app/account/_layout.tsx`** — Stack with `headerShown: false`, dark `contentStyle`.
- **`apps/mobile/app/account/pause.tsx`** — Heading + body + amber-gradient CTA + "Not yet" secondary. Tap opens `Alert.alert` (destructive Pause + Cancel). On success: clears AsyncStorage `sb-*` keys, fires `supabase.auth.signOut().catch()`, `router.replace('/welcome')`. Failures inline-coral, retryable.
- **`apps/mobile/app/account/delete.tsx`** — TextInput with the brief's exact-match props (`autoCapitalize: 'characters'`, `autoCorrect: false`, `textContentType: 'none'`, etc). CTA gated on `confirmText === 'DELETE'` exactly — case-sensitive, so `Delete` / `delete` / `DELETED` stay disabled. Coral solid CTA. Same teardown sequence as pause on success. Failures inline-coral, the typed "DELETE" preserved in the input.
- **`apps/mobile/app/account/export.tsx`** — Amber-gradient CTA. On success, `Linking.openURL` hands the signed URL to the system browser, and an inline tertiary message ("Download started. The link expires in 24 hours.") confirms. Stays on screen, retryable.

### Files modified

- **`apps/mobile/app/(tabs)/settings.tsx`** — New `ACCOUNT` section with Export / Pause / Delete rows (Delete uses the existing `danger` prop). Below the existing sections so destructive actions stay at the bottom by convention. Removed the empty-onPress "Delete account" placeholder. Sign-out moved to its own group below the new ACCOUNT section.

### Untouched (per brief)

- `welcome/index.tsx` (LOCKED)
- Anything under `supabase/`
- `auth/index.tsx`
- `CLAUDE.md`, `docs/PRODUCT_PRINCIPLES.md`

## Test plan

- [x] `cd apps/mobile && npx tsc --noEmit` clean
- [x] `ls apps/mobile/app/account/` returns `_layout.tsx delete.tsx export.tsx pause.tsx`
- [x] `grep -c "accountApi"` returns ≥1 for each of pause / delete / export
- [x] `grep -c "router.push('/account/"` against settings returns 3
- [ ] Manual device walkthrough (cannot run in sandbox):
  - Settings → ACCOUNT section visible with 3 rows + a separate Sign out group
  - Export → Download my data → system browser opens the signed URL → "Download started" message under the CTA
  - Pause → Pause my account → Alert.alert (Pause/Cancel) → confirm → routed to /welcome → token cleared
  - Delete → typing `delete` / `Delete` / `DELETED` keeps the CTA disabled; only literal `DELETE` enables it → tap → routed to /welcome → token cleared
  - Force a 401 (e.g. expired session) → inline coral "Session expired" appears; page state preserved; user can retry

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_