### PR TITLE
fix: auth flow loop after sign-out

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -98,7 +98,7 @@ export default function SettingsScreen() {
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     try {
       await signOut();
-      router.replace('/welcome');
+      router.replace('/auth?mode=signin');
     } catch {
       setSigningOut(false);
     }

--- a/apps/mobile/app/account/delete.tsx
+++ b/apps/mobile/app/account/delete.tsx
@@ -15,6 +15,9 @@ import * as Haptics from 'expo-haptics';
 import { fonts as F } from '../../src/theme';
 import { supabase } from '../../src/lib/supabase';
 import { deleteAccount } from '../../src/lib/accountApi';
+import { resetOnboarding } from '../../src/utils/onboarding';
+
+const GUEST_SEEN_KEY = 'sturdy_guest_seen_v1';
 
 const BG         = '#0e0a10';
 const TEXT       = 'rgba(255,255,255,0.92)';
@@ -55,8 +58,12 @@ export default function DeleteAccountScreen() {
       return;
     }
 
-    // Clear local tokens immediately. The server-side session is gone with
-    // the user, so signOut is fire-and-forget.
+    // Deleted account → device should feel like a fresh install. Clear
+    // the onboarding-complete flag and the guest-seen flag so AuthGate
+    // routes to /welcome and keeps them there. Then clear Supabase tokens
+    // and fire-and-forget signOut (server-side session is already gone).
+    await resetOnboarding();
+    await AsyncStorage.removeItem(GUEST_SEEN_KEY).catch(() => {});
     await clearAuthStorage();
     supabase.auth.signOut().catch(() => {});
     router.replace('/welcome');

--- a/apps/mobile/app/account/pause.tsx
+++ b/apps/mobile/app/account/pause.tsx
@@ -54,7 +54,10 @@ export default function PauseAccountScreen() {
     await clearAuthStorage();
     // Fire-and-forget; the session may already be invalid server-side.
     supabase.auth.signOut().catch(() => {});
-    router.replace('/welcome');
+    // Paused user is "returning" — sign-in screen is the right destination.
+    // Routing through /welcome would race AuthGate (onboarding-complete=true
+    // would bounce them to sign-in anyway, leaving welcome in the back stack).
+    router.replace('/auth?mode=signin');
   };
 
   const onConfirm = () => {


### PR DESCRIPTION
## Summary

Fixes the auth-flow loop where after sign-out (Settings) or pause (account/pause), the back button revealed `/welcome` and the user could re-enter as guest.

**Root cause:** three sign-out flows called `router.replace('/welcome')`, but `AuthGate` saw `session=null + onboarding-complete=true` and immediately re-routed to `/auth?mode=signin`. The race left `/welcome` in the back stack — pressing Back surfaced it, the user tapped Skip, loop restarted.

## Changes

- **`apps/mobile/app/(tabs)/settings.tsx`** — sign-out routes to `/auth?mode=signin`. Returning users land directly where AuthGate would send them anyway; no `/welcome` stack frame to leak.
- **`apps/mobile/app/account/pause.tsx`** — same change. A paused user is "returning" by definition (they can come back within 30 days by signing in).
- **`apps/mobile/app/account/delete.tsx`** — keeps `router.replace('/welcome')` because a deleted account *should* feel like a fresh install. To make `/welcome` actually stick (instead of bouncing through AuthGate to sign-in), the handler now calls `resetOnboarding()` and clears `sturdy_guest_seen_v1` from AsyncStorage **before** the redirect. AuthGate then sees `done = false` on relaunch and keeps the user on `/welcome`.

`resetOnboarding` is imported from `../../src/utils/onboarding`. AuthGate logic in `_layout.tsx` is unchanged — it was correct as-is.

## Test plan

- [ ] **Sign out (Settings):** sign in → Settings → Sign out → confirm landing on `/auth?mode=signin`. Press Back → must NOT reveal `/welcome`.
- [ ] **Pause:** sign in → Settings → Pause account → confirm Alert → confirm landing on `/auth?mode=signin`. Press Back → must NOT reveal `/welcome`. Sign in again with same credentials → restored (server-side `paused_at` clears via app logic when wired).
- [ ] **Delete:** sign in → Settings → Delete account → type `DELETE` → confirm landing on `/welcome`. Tap "Try without account" → behaves like first-time guest. Force-quit + relaunch → AuthGate routes to `/welcome` (not `/auth?mode=signin`) because onboarding flag was reset.
- [x] `npx tsc --noEmit` clean.

## Files NOT touched

- `_layout.tsx` (AuthGate is correct)
- `welcome/index.tsx` (`markOnboardingComplete()` calls there are correct)
- Backend / Edge Functions
- Any other navigation

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_