### PR TITLE
fix: guest account loop + sign-out routing (AuthGate as single source of truth)

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -98,7 +98,9 @@ export default function SettingsScreen() {
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     try {
       await signOut();
-      router.replace('/auth?mode=signin');
+      // AuthGate in _layout.tsx handles post-signout routing (returning users
+      // → /auth?mode=signin). Do NOT router.replace here — bypassing AuthGate
+      // leaves /welcome in the back stack and creates the guest re-entry loop.
     } catch {
       setSigningOut(false);
     }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,7 +1,7 @@
 // app/_layout.tsx
 // v5 — Logo-derived premium dark theme; Fraunces (serif) + DM Sans (sans).
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Platform, Text, TextInput } from 'react-native';
 import { Stack, router } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
@@ -50,12 +50,24 @@ if (Platform.OS !== 'web') {
 function AuthGate() {
   const { session, isLoading } = useAuth();
   const [routed, setRouted] = useState(false);
+  const prevSessionRef = useRef(session);
 
   useEffect(() => {
     if (!isLoading) {
       SplashScreen.hideAsync();
     }
   }, [isLoading]);
+
+  // Reset the routed flag when the session drops (sign-out, pause, delete,
+  // session timeout). Without this, AuthGate would never re-evaluate after
+  // the initial route — sign-out flows could leak the welcome stack frame
+  // because no AuthGate redirect ever fires.
+  useEffect(() => {
+    if (prevSessionRef.current && !session) {
+      setRouted(false);
+    }
+    prevSessionRef.current = session;
+  }, [session]);
 
   useEffect(() => {
     if (isLoading || routed) return;

--- a/apps/mobile/app/account/delete.tsx
+++ b/apps/mobile/app/account/delete.tsx
@@ -58,15 +58,16 @@ export default function DeleteAccountScreen() {
       return;
     }
 
-    // Deleted account → device should feel like a fresh install. Clear
-    // the onboarding-complete flag and the guest-seen flag so AuthGate
-    // routes to /welcome and keeps them there. Then clear Supabase tokens
-    // and fire-and-forget signOut (server-side session is already gone).
+    // Deleted account → device should feel like a fresh install. Reset the
+    // onboarding-complete flag and the guest-seen flag so when AuthGate
+    // re-evaluates after the session drops, it sees done=false and routes
+    // to /welcome (instead of /auth?mode=signin). Then clear Supabase
+    // tokens and fire signOut to trigger AuthGate. No explicit router
+    // call — AuthGate is the single source of truth for auth-based routing.
     await resetOnboarding();
     await AsyncStorage.removeItem(GUEST_SEEN_KEY).catch(() => {});
     await clearAuthStorage();
-    supabase.auth.signOut().catch(() => {});
-    router.replace('/welcome');
+    await supabase.auth.signOut().catch(() => {});
   };
 
   return (

--- a/apps/mobile/app/account/pause.tsx
+++ b/apps/mobile/app/account/pause.tsx
@@ -52,12 +52,11 @@ export default function PauseAccountScreen() {
 
     // Clear local tokens immediately (don't wait for server-side teardown).
     await clearAuthStorage();
-    // Fire-and-forget; the session may already be invalid server-side.
-    supabase.auth.signOut().catch(() => {});
-    // Paused user is "returning" — sign-in screen is the right destination.
-    // Routing through /welcome would race AuthGate (onboarding-complete=true
-    // would bounce them to sign-in anyway, leaving welcome in the back stack).
-    router.replace('/auth?mode=signin');
+    // signOut emits the auth event AuthGate listens for. AuthGate then sees
+    // session=null + onboarding-complete=true and routes to /auth?mode=signin,
+    // which is the right destination for a paused user (they can sign back in
+    // within 30 days to restore). No explicit router.replace needed.
+    await supabase.auth.signOut().catch(() => {});
   };
 
   const onConfirm = () => {

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -15,12 +15,18 @@ type AuthContextValue = {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function normalizeAuthError(message: string) {
-  if (message.toLowerCase().includes('invalid login credentials')) {
+  const lower = message.toLowerCase();
+
+  if (lower.includes('invalid login credentials')) {
     return 'That email or password did not match. Please try again.';
   }
 
-  if (message.toLowerCase().includes('email not confirmed')) {
+  if (lower.includes('email not confirmed')) {
     return 'Check your email to confirm your account, then sign in.';
+  }
+
+  if (lower.includes('user already registered')) {
+    return 'An account with this email already exists. Try signing in instead.';
   }
 
   return message;

--- a/apps/mobile/src/lib/sessionTimeout.ts
+++ b/apps/mobile/src/lib/sessionTimeout.ts
@@ -1,9 +1,9 @@
 // apps/mobile/src/lib/sessionTimeout.ts
 // Global 20-minute inactivity timeout.
 // Import resetSessionTimeout() in any screen and call on user interaction.
-// When timer fires, calls signOut and routes to /welcome.
+// When timer fires, calls signOut. AuthGate in app/_layout.tsx handles the
+// post-signout redirect (returning user → /auth?mode=signin).
 
-import { router } from 'expo-router';
 import { supabase } from './supabase';
 
 const TIMEOUT_MS = 20 * 60 * 1000; // 20 minutes
@@ -32,6 +32,6 @@ export function resetSessionTimeout() {
     try {
       await supabase.auth.signOut();
     } catch { /* non-fatal */ }
-    router.replace('/welcome');
+    // AuthGate handles the redirect once the session drops.
   }, TIMEOUT_MS);
 }


### PR DESCRIPTION
## Summary

Fixes the guest-account loop and "user already registered" error message. The loop wasn't a destination problem — it was an architecture problem. Multiple sign-out flows called `router.replace` explicitly, which raced AuthGate's own routing decision. AuthGate also had a `routed` flag that latched `true` on first route and never reset, so when the session dropped on sign-out, AuthGate didn't re-evaluate at all. The explicit `router.replace` calls covered for that bug, but they left the prior route (`/welcome`) in the back stack — pressing Back surfaced it for re-entry as guest, looping indefinitely.

The fix makes **AuthGate the single source of truth** for auth-based routing.

## Changes

| File | Change |
|---|---|
| `app/_layout.tsx` | AuthGate now tracks the previous session via `prevSessionRef`. When session transitions non-null → null (sign-out / pause / delete / timeout), an effect calls `setRouted(false)` so AuthGate re-evaluates. Routing destinations unchanged. |
| `app/(tabs)/settings.tsx` | `handleSignOut` no longer calls `router.replace`. `signOut()` only — AuthGate routes returning user → `/auth?mode=signin`. |
| `app/account/pause.tsx` | Awaited `signOut`; removed explicit `router.replace`. AuthGate routes paused user → `/auth?mode=signin`. |
| `app/account/delete.tsx` | `resetOnboarding()` + clear guest flag + `clearAuthStorage()` + awaited `signOut()`; removed explicit `router.replace`. With onboarding-complete = false, AuthGate routes → `/welcome` (fresh-install feel). |
| `src/lib/sessionTimeout.ts` | Removed unused `router` import and the `router.replace('/welcome')`. AuthGate routes when timer fires and `signOut` completes. |
| `src/context/AuthContext.tsx` | `normalizeAuthError` now handles `"user already registered"` → "An account with this email already exists. Try signing in instead." |

## Out of scope (flagged for follow-up)

- **`apps/mobile/app/child/[id].tsx`** has an inline 20-minute session timeout that duplicates `sessionTimeout.ts` *and* explicitly routes to `/welcome`. Same anti-pattern, but not in the brief's file list. Worth consolidating onto the global `sessionTimeout.ts` in a separate PR.
- `auth/index.tsx` line 128 has `router.replace('/welcome')` in `handleBack` — that's a back-button fallback when there's no history, not a sign-out path. Correct as-is.

## Test plan

After clearing app data / reinstall to wipe stale AsyncStorage:

- [ ] Fresh launch → lands on `/welcome`
- [ ] Get Started → `/auth?mode=signup` → create account → `/(tabs)`
- [ ] Settings → Sign out → `/auth?mode=signin` (NOT `/welcome`)
- [ ] Press Back from `/auth?mode=signin` → does NOT reveal `/welcome`
- [ ] Sign back in → `/(tabs)`
- [ ] From welcome, Skip → `/(tabs)` as guest → Sign out → `/auth?mode=signin`
- [ ] Settings → Pause account → confirm → `/auth?mode=signin`. Sign back in within 30 days → restored.
- [ ] Settings → Delete account → type `DELETE` → confirm → `/welcome`. Skip from welcome → behaves like first-time guest. Force-quit + relaunch → `/welcome` (not `/auth?mode=signin`) because onboarding flag was reset.
- [ ] Sign-up with an existing email → "An account with this email already exists. Try signing in instead." (instead of raw Supabase string)
- [x] `npx tsc --noEmit` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_