### PR TITLE
feat: welcome polish + Home Deep Warm migration

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 // app/(tabs)/_layout.tsx
-// v5 — Premium dark tab bar; amber active, muted inactive.
+// v6 — Deep Warm v5.2 tab bar; amber active, muted inactive, shadow separator.
 // Two tabs (post-Phase-1 architecture): Home · Settings.
 
 import { Text } from 'react-native';
@@ -12,16 +12,19 @@ export default function TabLayout() {
       screenOptions={{
         headerShown: false,
         tabBarStyle: {
-          backgroundColor: 'rgba(20,17,14,0.92)',   // warm dark, near-opaque
-          borderTopWidth: 1,
-          borderTopColor: C.border,
-          paddingBottom: 24,
-          paddingTop: 8,
-          height: 80,
-          position: 'absolute',
-          elevation: 0,
+          backgroundColor: 'rgba(10,10,10,0.97)',    // deeper, near-opaque
+          borderTopWidth:  0,                         // shadow does the separator
+          paddingBottom:   24,
+          paddingTop:      8,
+          height:          80,
+          position:        'absolute',
+          shadowColor:     '#000000',
+          shadowOffset:    { width: 0, height: -4 },
+          shadowOpacity:   0.30,
+          shadowRadius:    12,
+          elevation:       8,
         },
-        tabBarActiveTintColor:   C.tabActive,        // amber #F79566
+        tabBarActiveTintColor:   C.tabActive,         // amber #C8883A
         tabBarInactiveTintColor: C.tabInactive,
         tabBarLabelStyle: {
           fontFamily: F.bodySemi,

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -1,19 +1,24 @@
 // app/(tabs)/index.tsx
-// v4 — New Home (Parent Hub) with Question mode
-// - Rotating greeting (re-rolls each focus)
-// - 0 children → empty state
-// - 1 child → lite view: greeting + input + Open hub link
-// - 2+ children → full selector + input
-// - "What's on your mind?" input wired to getQuestionResponse
-// - Skeleton-while-loading via navigation to /thought/[id]
-// Journal identity: pastel gradient, frosted glass, rose accents.
+// v5 — Deep Warm v5.2 home (Parent Hub)
+//
+// Visual identity:
+//   - C-2 fast-fade gradient (warm parchment top → near-black bottom)
+//   - Greeting in dark text (sits on warm zone)
+//   - Dark glass cards (3D floating: transparent fill + bright top edge + strong shadow)
+//   - Icon-badge outcome grid: 46x46 gradient square + title/subtitle, horizontal layout
+//   - Amber CTA + amber empty-state button (no more pink)
+//
+// Behavior preserved verbatim from v4:
+//   - Rotating greeting (re-rolls each focus)
+//   - 0 children → empty state with "Add a child" CTA (no auto-redirect)
+//   - 1 child → lite view: greeting + input + Open hub link
+//   - 2+ children → full selector + outcome → child picker modal
+//   - "What's on your mind?" input wired to getQuestionResponse
+//   - detectChildFromMessage scans the message for an exact name match
 
-
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   ActivityIndicator,
-  Animated,
-  Image,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -37,83 +42,69 @@ import { supabase } from '../../src/lib/supabase';
 import { getQuestionResponse, CrisisDetectedError } from '../../src/lib/api';
 import { colors as C, fonts as F } from '../../src/theme';
 
-const HORIZON_PHOTO = require('../../assets/images/welcome/welcome-horizon.jpg');
-
 // ═══════════════════════════════════════════════
 // CONSTANTS
 // ═══════════════════════════════════════════════
 
 const GREETINGS = ['Hi', 'Hello', 'Hey'];
 
-// Rotating color palette for child avatars
-const CHILD_COLORS = [
-  C.sage,
-  C.rose,
-  '#5778A3',
-  '#F79566',
-  '#C4A46C',
-  '#8B7AA8',
+// Rotating gradient pairs for child avatars (Deep Warm icon palette).
+const CHILD_GRADIENTS: Array<[string, string]> = [
+  [C.iconTalkStart,       C.iconTalkEnd],        // sage
+  [C.iconSosStart,        C.iconSosEnd],         // coral
+  [C.iconUnderstandStart, C.iconUnderstandEnd],  // steel
+  [C.iconRepairStart,     C.iconRepairEnd],      // amber
 ];
 
 // ═══════════════════════════════════════════════
 // OUTCOME MODES
-// 4 internal modes, surfaced as tap cards below the Question input.
+// 4 internal modes, surfaced as icon-badge cards below the Question input.
 // Routes to /child/[id]?mode=<key>; the per-child hub reads the mode
-// param and adapts its prompt + UI. Backend prompts already exist
-// (getSOSPrompt / getReconnectPrompt / getUnderstandPrompt /
-// getConversationPrompt) — this is purely a UI surface.
+// param and adapts its prompt + UI.
 // ═══════════════════════════════════════════════
 
 type OutcomeMode = 'sos' | 'reconnect' | 'understand' | 'conversation';
 
 type Outcome = {
-  mode:        OutcomeMode;
-  emoji:       string;
-  title:       string;
-  subtitle:    string;
-  accentColor: string;
+  mode:           OutcomeMode;
+  emoji:          string;
+  title:          string;
+  subtitle:       string;
+  iconGradient:   [string, string];
 };
 
 const OUTCOMES: Outcome[] = [
-  { mode: 'sos',          emoji: '🆘', title: 'Right now',         subtitle: 'They\'re melting down',   accentColor: '#E87461' },
-  { mode: 'reconnect',    emoji: '🤝', title: 'Repair',            subtitle: 'After it went sideways',  accentColor: '#C4A46C' },
-  { mode: 'understand',   emoji: '💡', title: 'Understand',        subtitle: 'Why do they do this?',    accentColor: '#5778A3' },
-  { mode: 'conversation', emoji: '💬', title: 'Plan a talk',       subtitle: 'A hard conversation',     accentColor: '#8AA060' },
+  { mode: 'sos',          emoji: '🆘', title: 'Right now',   subtitle: "They're melting down",   iconGradient: [C.iconSosStart,        C.iconSosEnd] },
+  { mode: 'reconnect',    emoji: '🤝', title: 'Repair',      subtitle: 'After it went sideways', iconGradient: [C.iconRepairStart,     C.iconRepairEnd] },
+  { mode: 'understand',   emoji: '💡', title: 'Understand',  subtitle: 'Why do they do this?',   iconGradient: [C.iconUnderstandStart, C.iconUnderstandEnd] },
+  { mode: 'conversation', emoji: '💬', title: 'Plan a talk', subtitle: 'A hard conversation',    iconGradient: [C.iconTalkStart,       C.iconTalkEnd] },
 ];
 
- // ═══════════════════════════════════════════════
-  // CHILD AUTO-DETECTION
-  // Returns the child id if exactly ONE child name appears in the
-  // message. Returns null otherwise (no match, multiple matches,
-  // or empty input).
-  // ═══════════════════════════════════════════════
+// ═══════════════════════════════════════════════
+// CHILD AUTO-DETECTION
+// Returns a child id if exactly ONE child name appears in the message.
+// ═══════════════════════════════════════════════
 
-  function detectChildFromMessage(
-    message: string,
-    children: Array<{ id: string; name?: string }>,
-  ): string | null {
-    if (!message || !Array.isArray(children) || children.length === 0) {
-      return null;
-    }
+function detectChildFromMessage(
+  message: string,
+  children: Array<{ id: string; name?: string }>,
+): string | null {
+  if (!message || !Array.isArray(children) || children.length === 0) return null;
 
-    const lower = message.toLowerCase();
-    const matches: string[] = [];
+  const lower = message.toLowerCase();
+  const matches: string[] = [];
 
-    for (const child of children) {
-      const name = (child?.name ?? '').trim().toLowerCase();
-      if (!name || name.length < 2) continue;
+  for (const child of children) {
+    const name = (child?.name ?? '').trim().toLowerCase();
+    if (!name || name.length < 2) continue;
 
-      // Word-boundary match — name surrounded by non-letters or string edges
-      const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const pattern = new RegExp(`(^|[^a-z])${escaped}([^a-z]|$)`, 'i');
-      if (pattern.test(lower)) {
-        matches.push(child.id);
-      }
-    }
-
-    // Only return a single match — never guess if 2+ kids referenced
-    return matches.length === 1 ? matches[0] : null;
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`(^|[^a-z])${escaped}([^a-z]|$)`, 'i');
+    if (pattern.test(lower)) matches.push(child.id);
   }
+
+  return matches.length === 1 ? matches[0] : null;
+}
 
 
 // ═══════════════════════════════════════════════
@@ -127,14 +118,11 @@ export default function HomeScreen() {
   const [firstName, setFirstName] = useState<string | null>(null);
   const [greeting, setGreeting]   = useState<string>(GREETINGS[0]);
 
-  // Question input state
-  const [question, setQuestion]       = useState('');
+  const [question, setQuestion]         = useState('');
   const [inputFocused, setInputFocused] = useState(false);
-  const [sending, setSending]         = useState(false);
-  const [error, setError]             = useState('');
+  const [sending, setSending]           = useState(false);
+  const [error, setError]               = useState('');
 
-  // Outcome-selector picker state (shown when 2+ children exist and
-  // the parent taps an outcome card — picks WHICH child the mode is for).
   const [pickerMode, setPickerMode] = useState<OutcomeMode | null>(null);
 
   // ─── Fetch parent's name ───
@@ -162,16 +150,15 @@ export default function HomeScreen() {
         setFirstName(cleaned.charAt(0).toUpperCase() + cleaned.slice(1));
       }
     } catch {
-      // Non-blocking — fall through to generic greeting
+      // non-blocking
     }
   }, [session?.user?.id, session?.user?.email]);
 
-  // ─── Re-roll greeting + refetch name on each focus ───
   useFocusEffect(
     useCallback(() => {
       setGreeting(GREETINGS[Math.floor(Math.random() * GREETINGS.length)]);
       fetchName();
-    }, [fetchName])
+    }, [fetchName]),
   );
 
   // ─── Handlers ───
@@ -185,11 +172,6 @@ export default function HomeScreen() {
     router.push('/child/new');
   };
 
-  // Outcome card tapped — route to a child's hub with the selected mode.
-  // 0 children: bounce to /child/new (parent adds a child first).
-  // 1 child:    auto-route, no picker.
-  // 2+ children: open picker modal so the parent picks which child this
-  //              outcome applies to.
   const handleSelectOutcome = (mode: OutcomeMode) => {
     Haptics.selectionAsync();
     if (kidList.length === 0) {
@@ -212,9 +194,7 @@ export default function HomeScreen() {
     router.push({ pathname: `/child/${childId}` as any, params: { mode } });
   };
 
-  const handlePickerCancel = () => {
-    setPickerMode(null);
-  };
+  const handlePickerCancel = () => setPickerMode(null);
 
   const handleSend = async () => {
     const msg = question.trim();
@@ -235,11 +215,8 @@ export default function HomeScreen() {
         childProfileId: detectedChildId,
       } as any);
 
-      // Clear input before navigating so coming back to Home is fresh
       setQuestion('');
 
-      // Navigate to thought screen — pass response inline as fallback if
-      // thought_id is null (unauthenticated edge case)
       const responsePayload = (result as any).response ?? '';
       const thoughtId = (result as any).thought_id ?? null;
 
@@ -249,7 +226,6 @@ export default function HomeScreen() {
           params: { fallbackResponse: responsePayload, prompt: msg },
         });
       } else {
-        // No id — pass response inline. Result screen will use params.
         router.push({
           pathname: '/thought/inline' as any,
           params: { fallbackResponse: responsePayload, prompt: msg },
@@ -270,34 +246,41 @@ export default function HomeScreen() {
   };
 
   // ─── Helpers ───
-  const displayName = firstName ?? 'there';
-  const kidList = Array.isArray(children) ? children : [];
-  const canSend = question.trim().length > 0 && !sending;
+  const displayName  = firstName ?? 'there';
+  const kidList      = Array.isArray(children) ? children : [];
+  const canSend      = question.trim().length > 0 && !sending;
   const isSingleChild = kidList.length === 1;
-  const isMultiChild = kidList.length > 1;
-  const onlyChild = isSingleChild ? kidList[0] : null;
+  const isMultiChild  = kidList.length > 1;
+  const onlyChild     = isSingleChild ? kidList[0] : null;
 
+  // ─── Shared background — single C-2 gradient (no photos) ───
+  const Background = () => (
+    <>
+      <LinearGradient
+        colors={[
+          C.gradientTop,
+          C.gradientMid1,
+          C.gradientMid2,
+          C.gradientMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      {/* Atmospheric amber glow behind the greeting zone */}
+      <View pointerEvents="none" style={s.amberGlow} />
+    </>
+  );
 
   // ─── Loading gate ───
   if (isLoadingChild) {
     return (
       <View style={s.root}>
         <StatusBar style="light" />
-        <Image
-          source={HORIZON_PHOTO}
-          style={StyleSheet.absoluteFill}
-          resizeMode="cover"
-        />
-        <LinearGradient
-          colors={[
-            'rgba(15,10,18,0.45)',
-            'rgba(15,10,18,0.65)',
-            'rgba(15,10,18,0.82)',
-          ]}
-          style={StyleSheet.absoluteFill}
-        />
+        <Background />
         <SafeAreaView style={s.centerGate}>
-         <ActivityIndicator color={'#E8A855'} />
+          <ActivityIndicator color={C.amber} />
         </SafeAreaView>
       </View>
     );
@@ -308,33 +291,25 @@ export default function HomeScreen() {
     return (
       <View style={s.root}>
         <StatusBar style="light" />
-        <Image
-          source={HORIZON_PHOTO}
-          style={StyleSheet.absoluteFill}
-          resizeMode="cover"
-        />
-        <LinearGradient
-          colors={[
-            'rgba(15,10,18,0.45)',
-            'rgba(15,10,18,0.65)',
-            'rgba(15,10,18,0.82)',
-          ]}
-          style={StyleSheet.absoluteFill}
-        />
+        <Background />
         <SafeAreaView style={s.safe} edges={['top']}>
           <View style={s.emptyWrap}>
             <Text style={s.greeting}>{greeting}, {displayName}.</Text>
             <Text style={s.emptyTitle}>Let's add your first child.</Text>
             <Text style={s.emptyBody}>
-              Sturdy tailors every response to your child's age and world. Start by telling us a little about them.
+              Sturdy tailors every response to your child's age and world.
             </Text>
             <Pressable
               onPress={handleAddChild}
-              style={({ pressed }) => [pressed && { opacity: 0.9 }]}
+              style={({ pressed }) => [pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] }]}
             >
-              <View style={s.primaryBtn}>
+              <LinearGradient
+                colors={[C.amber, C.amberMid]}
+                start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
+                style={s.primaryBtn}
+              >
                 <Text style={s.primaryBtnText}>Add a child</Text>
-              </View>
+              </LinearGradient>
             </Pressable>
           </View>
         </SafeAreaView>
@@ -342,24 +317,11 @@ export default function HomeScreen() {
     );
   }
 
-  // ─── 1 or more children: question input is always visible ───
+  // ─── 1 or more children ───
   return (
     <View style={s.root}>
       <StatusBar style="light" />
-
-      <Image
-        source={HORIZON_PHOTO}
-        style={StyleSheet.absoluteFill}
-        resizeMode="cover"
-      />
-      <LinearGradient
-        colors={[
-          'rgba(15,10,18,0.45)',
-          'rgba(15,10,18,0.65)',
-          'rgba(15,10,18,0.82)',
-        ]}
-        style={StyleSheet.absoluteFill}
-      />
+      <Background />
 
       <SafeAreaView style={s.safe} edges={['top']}>
         <KeyboardAvoidingView
@@ -375,7 +337,7 @@ export default function HomeScreen() {
             {/* ─── Greeting ─── */}
             <View style={s.greetingWrap}>
               <Text style={s.greeting}>{greeting}, {displayName}.</Text>
-              <Text style={s.subGreeting}>What's on your mind?</Text>
+              <Text style={s.subGreeting}>What's happening right now?</Text>
             </View>
 
             {/* ─── Question input ─── */}
@@ -384,7 +346,7 @@ export default function HomeScreen() {
                 multiline
                 numberOfLines={4}
                 placeholder="Ask anything about your child — sleep, behavior, big feelings, hard conversations…"
-                placeholderTextColor={C.textMuted}
+                placeholderTextColor={C.inputPlaceholder}
                 value={question}
                 onChangeText={(t) => { setQuestion(t); if (error) setError(''); }}
                 onFocus={() => setInputFocused(true)}
@@ -402,20 +364,27 @@ export default function HomeScreen() {
               onPress={handleSend}
               disabled={!canSend}
               style={({ pressed }) => [
-                pressed && canSend && { opacity: 0.9, transform: [{ scale: 0.98 }] },
+                pressed && canSend && { opacity: 0.92, transform: [{ scale: 0.98 }] },
               ]}
             >
-              <View style={[s.sendBtn, !canSend && s.sendBtnDisabled]}>
-                <Text style={[s.sendBtnText, !canSend && { color: C.textMuted }]}>
-                  {sending ? 'Asking Sturdy…' : 'Ask Sturdy'}
-                </Text>
-              </View>
+              {canSend ? (
+                <LinearGradient
+                  colors={[C.amber, C.amberMid]}
+                  start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
+                  style={s.sendBtn}
+                >
+                  <Text style={s.sendBtnText}>{sending ? 'Asking Sturdy…' : 'Ask Sturdy'}</Text>
+                </LinearGradient>
+              ) : (
+                <View style={[s.sendBtn, s.sendBtnDisabled]}>
+                  <Text style={[s.sendBtnText, { color: C.textMuted }]}>
+                    {sending ? 'Asking Sturdy…' : 'Ask Sturdy'}
+                  </Text>
+                </View>
+              )}
             </Pressable>
 
-            {/* ─── Outcome selector ─── */}
-            {/* 4 modes surfaced as a 2×2 grid; tapping routes to the
-                per-child hub with mode preset. SOS is visually distinct
-                with a sos-color border accent; the others are calmer. */}
+            {/* ─── Outcome icon-badge grid ─── */}
             <View style={s.outcomeWrap}>
               <Text style={s.outcomeLabel}>Or pick a mode</Text>
               <View style={s.outcomeGrid}>
@@ -425,100 +394,100 @@ export default function HomeScreen() {
                     onPress={() => handleSelectOutcome(o.mode)}
                     style={({ pressed }) => [
                       s.outcomeCard,
-                      { borderColor: `${o.accentColor}55` },
-                      o.mode === 'sos' && s.outcomeCardSos,
                       pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] },
                     ]}
                     accessibilityRole="button"
                     accessibilityLabel={`${o.title} — ${o.subtitle}`}
                   >
-                    <Text style={s.outcomeEmoji}>{o.emoji}</Text>
-                    <Text style={s.outcomeTitle}>{o.title}</Text>
-                    <Text style={s.outcomeSubtitle} numberOfLines={1}>{o.subtitle}</Text>
+                    <LinearGradient
+                      colors={o.iconGradient}
+                      start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+                      style={s.outcomeIcon}
+                    >
+                      <Text style={s.outcomeIconText}>{o.emoji}</Text>
+                    </LinearGradient>
+                    <View style={s.outcomeTextWrap}>
+                      <Text style={s.outcomeTitle} numberOfLines={1}>{o.title}</Text>
+                      <Text style={s.outcomeSubtitle} numberOfLines={1}>{o.subtitle}</Text>
+                    </View>
                   </Pressable>
                 ))}
               </View>
             </View>
 
-            {/* ─── 1 child: lite view shows quick link to their hub ─── */}
+            {/* ─── 1 child: lite view ─── */}
             {isSingleChild && onlyChild ? (
-              <>
+              <View style={s.childrenSection}>
+                <Text style={s.childrenLabel}>YOUR CHILDREN</Text>
                 <Pressable
                   onPress={() => handleOpenChild(onlyChild.id)}
                   style={({ pressed }) => [
-                    s.singleChildCard,
-                    pressed && { opacity: 0.92, transform: [{ scale: 0.99 }] },
+                    s.childRow,
+                    pressed && { opacity: 0.92 },
                   ]}
                 >
-                  <View style={[s.singleChildAvatar, { backgroundColor: CHILD_COLORS[0] }]}>
-                    <Text style={s.singleChildAvatarText}>
+                  <LinearGradient
+                    colors={CHILD_GRADIENTS[0]}
+                    start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+                    style={s.childAvatar}
+                  >
+                    <Text style={s.childAvatarText}>
                       {(onlyChild.name?.trim()?.[0] ?? '?').toUpperCase()}
                     </Text>
-                  </View>
+                  </LinearGradient>
                   <View style={{ flex: 1 }}>
-                    <Text style={s.singleChildName}>Open {onlyChild.name}'s hub</Text>
-                    <Text style={s.singleChildSub}>Saved scripts, history, and SOS</Text>
+                    <Text style={s.childName}>{onlyChild.name}</Text>
+                    <Text style={s.childAge}>Age {onlyChild.childAge}</Text>
                   </View>
-                  <Text style={s.singleChildArrow}>→</Text>
+                  <Text style={s.chevron}>›</Text>
                 </Pressable>
                 <Pressable
                   onPress={handleAddChild}
-                  style={({ pressed }) => [
-                    s.addChildLink,
-                    pressed && { opacity: 0.7 },
-                  ]}
+                  style={({ pressed }) => [s.addRow, pressed && { opacity: 0.7 }]}
                   accessibilityRole="button"
                   accessibilityLabel="Add another child"
                 >
-                  <Text style={s.addChildLinkText}>+ Add another child</Text>
+                  <Text style={s.addRowText}>+ Add another child</Text>
                 </Pressable>
-              </>
+              </View>
             ) : null}
 
-            {/* ─── 2+ children: child selector ─── */}
+            {/* ─── 2+ children: list inside section card ─── */}
             {isMultiChild ? (
-              <View style={s.selectorWrap}>
-                <Text style={s.selectorLabel}>Or open a child's hub</Text>
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  contentContainerStyle={s.childRow}
-                >
-                  {kidList.map((kid: any, index: number) => {
-                    const color = CHILD_COLORS[index % CHILD_COLORS.length];
-                    const initial = (kid?.name?.trim()?.[0] ?? '?').toUpperCase();
-                    return (
-                      <Pressable
-                        key={kid.id}
-                        onPress={() => handleOpenChild(kid.id)}
-                        style={({ pressed }) => [
-                          s.childCard,
-                          pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] },
-                        ]}
+              <View style={s.childrenSection}>
+                <Text style={s.childrenLabel}>YOUR CHILDREN</Text>
+                {kidList.map((kid: any, index: number) => {
+                  const grad = CHILD_GRADIENTS[index % CHILD_GRADIENTS.length];
+                  const initial = (kid?.name?.trim()?.[0] ?? '?').toUpperCase();
+                  return (
+                    <Pressable
+                      key={kid.id}
+                      onPress={() => handleOpenChild(kid.id)}
+                      style={({ pressed }) => [s.childRow, pressed && { opacity: 0.92 }]}
+                    >
+                      <LinearGradient
+                        colors={grad}
+                        start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+                        style={s.childAvatar}
                       >
-                        <View style={[s.childAvatar, { backgroundColor: color, shadowColor: color }]}>
-                          <Text style={s.childAvatarText}>{initial}</Text>
-                        </View>
-                        <Text style={s.childCardName} numberOfLines={1}>{kid.name}</Text>
-                        <Text style={s.childCardAge}>Age {kid.childAge}</Text>
-                      </Pressable>
-                    );
-                  })}
-
-                  {/* Add child card */}
-                  <Pressable
-                    onPress={handleAddChild}
-                    style={({ pressed }) => [
-                      s.addCard,
-                      pressed && { opacity: 0.85, transform: [{ scale: 0.98 }] },
-                    ]}
-                  >
-                    <View style={s.addAvatar}>
-                      <Text style={s.addAvatarText}>+</Text>
-                    </View>
-                    <Text style={s.addCardText}>Add child</Text>
-                  </Pressable>
-                </ScrollView>
+                        <Text style={s.childAvatarText}>{initial}</Text>
+                      </LinearGradient>
+                      <View style={{ flex: 1 }}>
+                        <Text style={s.childName}>{kid.name}</Text>
+                        <Text style={s.childAge}>Age {kid.childAge}</Text>
+                      </View>
+                      <Text style={s.chevron}>›</Text>
+                    </Pressable>
+                  );
+                })}
+                <Pressable
+                  onPress={handleAddChild}
+                  style={({ pressed }) => [s.addRow, pressed && { opacity: 0.7 }]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Add another child"
+                >
+                  <Text style={s.addRowText}>+ Add another child</Text>
+                </Pressable>
               </View>
             ) : null}
 
@@ -528,8 +497,6 @@ export default function HomeScreen() {
       </SafeAreaView>
 
       {/* ─── Outcome → multi-child picker modal ─── */}
-      {/* Only used when 2+ children exist. Single-child + zero-child
-          paths route directly without showing the modal. */}
       <Modal
         visible={pickerMode !== null}
         animationType="fade"
@@ -544,7 +511,7 @@ export default function HomeScreen() {
             </Text>
             <View style={s.pickerRow}>
               {kidList.map((kid: any, index: number) => {
-                const color = CHILD_COLORS[index % CHILD_COLORS.length];
+                const grad = CHILD_GRADIENTS[index % CHILD_GRADIENTS.length];
                 const initial = (kid?.name?.trim()?.[0] ?? '?').toUpperCase();
                 return (
                   <Pressable
@@ -555,9 +522,13 @@ export default function HomeScreen() {
                       pressed && { opacity: 0.85, transform: [{ scale: 0.97 }] },
                     ]}
                   >
-                    <View style={[s.pickerAvatar, { backgroundColor: color, shadowColor: color }]}>
+                    <LinearGradient
+                      colors={grad}
+                      start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+                      style={s.pickerAvatar}
+                    >
                       <Text style={s.pickerAvatarText}>{initial}</Text>
-                    </View>
+                    </LinearGradient>
                     <Text style={s.pickerChildName} numberOfLines={1}>{kid.name}</Text>
                     <Text style={s.pickerChildAge}>Age {kid.childAge}</Text>
                   </Pressable>
@@ -580,231 +551,261 @@ export default function HomeScreen() {
 // ═══════════════════════════════════════════════
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.base },
+  root: { flex: 1, backgroundColor: C.background },
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingTop: 16, paddingBottom: 20, gap: 22 },
 
   centerGate: { flex: 1, alignItems: 'center', justifyContent: 'center' },
 
-  // Blobs
-  blob: { position: 'absolute', borderRadius: 999 },
-  blob1: {
-    top: -80, right: -60, width: 280, height: 280,
-    backgroundColor: 'rgba(253, 221, 230, 0.55)',
-  },
-  blob2: {
-    bottom: -60, left: -80, width: 240, height: 240,
-    backgroundColor: 'rgba(212, 232, 209, 0.50)',
+  // Atmospheric amber glow behind the greeting zone (warm-zone tint)
+  amberGlow: {
+    position:        'absolute',
+    top:             -120,
+    left:            -80,
+    right:           -80,
+    height:          340,
+    backgroundColor: C.amberGlow,
+    opacity:         0.7,
+    borderRadius:    200,
   },
 
-  // Greeting
+  // ─── Greeting (sits on warm-parchment top zone — uses dark text) ───
   greetingWrap: { gap: 6, marginTop: 8 },
   greeting: {
-    fontFamily: F.heading, fontSize: 32, color: '#FFFFFF',
-    letterSpacing: -0.5, lineHeight: 38,
+    fontFamily:    F.heading,
+    fontSize:      32,
+    color:         C.textDark,
+    letterSpacing: -0.5,
+    lineHeight:    38,
   },
   subGreeting: {
-    fontFamily: F.body, fontSize: 16, color: 'rgba(255,255,255,0.78)', lineHeight: 22,
+    fontFamily: F.body,
+    fontSize:   16,
+    color:      C.sosSubtle,
+    lineHeight: 22,
   },
 
-  // Question input
+  // ─── Question input ───
   textareaCard: {
-    backgroundColor: C.cardGlass,
-    borderWidth: 1, borderColor: C.border,
-    borderRadius: 18, overflow: 'hidden',
+    backgroundColor: C.inputBg,
+    borderRadius:    18,
+    overflow:        'hidden',
+    borderWidth:     1,
+    borderColor:     C.inputBorder,
+    borderTopWidth:  1,
+    borderTopColor:  C.inputHighlight,
   },
-  textareaFocused: { borderColor: 'rgba(129,178,154,0.40)' },
+  textareaFocused: { borderColor: C.borderFocus },
   textarea: {
-    padding: 16,
-    fontFamily: F.body, fontSize: 16,
-    color: C.text, lineHeight: 24, minHeight: 110,
+    padding:    16,
+    fontFamily: F.body,
+    fontSize:   16,
+    color:      C.text,
+    lineHeight: 24,
+    minHeight:  110,
   },
 
   errorText: {
-    fontFamily: F.body, fontSize: 14, color: C.rose, textAlign: 'center',
+    fontFamily: F.body, fontSize: 14, color: C.sos, textAlign: 'center',
   },
 
-  // Send button
- sendBtn: {
-    backgroundColor: '#C8883A',
-    shadowColor:     '#D4944A',
-    shadowOffset:    { width: 0, height: 4 },
-    shadowOpacity:   0.40,
-    shadowRadius:    12,
-    elevation:       8,
+  // ─── Send button ───
+  sendBtn: {
+    minHeight:       54,
+    borderRadius:    18,
+    alignItems:      'center',
+    justifyContent:  'center',
+    shadowColor:     C.amber,
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
   },
-
-  sendBtnDisabled: { backgroundColor: 'rgba(0,0,0,0.06)' },
+  sendBtnDisabled: {
+    backgroundColor: 'rgba(26,24,22,0.45)',
+    shadowOpacity:   0,
+    elevation:       0,
+  },
   sendBtnText: {
     fontFamily: F.subheading, fontSize: 17, color: '#FFFFFF', letterSpacing: 0.3,
   },
 
-  // Single-child lite link card
-  singleChildCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 14,
-    padding: 16,
-    borderRadius: 18,
-    backgroundColor: C.cardGlass,
-    borderWidth: 1, borderColor: C.border,
-  },
-  singleChildAvatar: {
-    width: 48, height: 48, borderRadius: 24,
-    alignItems: 'center', justifyContent: 'center',
-  },
-  singleChildAvatarText: {
-    fontFamily: F.heading, fontSize: 20, color: '#FFFFFF', letterSpacing: -0.3,
-  },
-  singleChildName: {
-    fontFamily: F.bodySemi, fontSize: 15, color: C.text,
-  },
-  singleChildSub: {
-    fontFamily: F.body, fontSize: 13, color: C.textSub,
-  },
-  singleChildArrow: {
-    fontFamily: F.bodySemi, fontSize: 20, color: C.rose,
-  },
-
-  // Add-another-child link (single-child view only)
-  addChildLink: {
-    alignItems: 'center',
-    paddingVertical: 12,
-  },
-  addChildLinkText: {
-    fontFamily: F.bodyMedium,
-    fontSize: 13,
-    color: '#D4944A',
-    letterSpacing: 0.3,
-  },
-
-  // Multi-child selector
-  selectorWrap: { gap: 10 },
-  selectorLabel: {
-    fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, letterSpacing: 0.3,
-  },
-  childRow: { gap: 12, paddingRight: 8 },
-  childCard: {
-    width: 130,
-    padding: 16, gap: 8,
-    alignItems: 'center', justifyContent: 'center',
-    borderRadius: 18,
-    backgroundColor: C.cardGlass,
-    borderWidth: 1, borderColor: C.border,
-  },
-  childAvatar: {
-    width: 56, height: 56, borderRadius: 28,
-    alignItems: 'center', justifyContent: 'center',
-    shadowOpacity: 0.25, shadowRadius: 12,
-    shadowOffset: { width: 0, height: 4 }, elevation: 3,
-  },
-  childAvatarText: {
-    fontFamily: F.heading, fontSize: 24, color: '#FFFFFF', letterSpacing: -0.3,
-  },
-  childCardName: {
-    fontFamily: F.bodySemi, fontSize: 14, color: C.text, textAlign: 'center',
-  },
-  childCardAge: {
-    fontFamily: F.body, fontSize: 12, color: C.textSub,
-  },
-
-  // Add card
-  addCard: {
-    width: 130,
-    padding: 16, gap: 8,
-    alignItems: 'center', justifyContent: 'center',
-    borderRadius: 18,
-    backgroundColor: 'rgba(0,0,0,0.02)',
-    borderWidth: 1, borderColor: C.border,
-    borderStyle: 'dashed',
-  },
-  addAvatar: {
-    width: 56, height: 56, borderRadius: 28,
-    alignItems: 'center', justifyContent: 'center',
-    backgroundColor: 'rgba(0,0,0,0.04)',
-  },
-  addAvatarText: {
-    fontFamily: F.heading, fontSize: 28, color: C.textMuted,
-  },
-  addCardText: {
-    fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted,
-  },
-
-  // Outcome selector (4 mode cards in a 2×2 grid)
+  // ─── Outcome icon-badge grid ───
   outcomeWrap: { gap: 10 },
   outcomeLabel: {
-    fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, letterSpacing: 0.3,
+    fontFamily:    F.bodyMedium,
+    fontSize:      11,
+    color:         C.textMuted,
+    letterSpacing: 1.0,
+    textTransform: 'uppercase',
   },
   outcomeGrid: {
     flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 12,
+    flexWrap:      'wrap',
+    gap:           12,
   },
   outcomeCard: {
-    flexBasis: '47%',
-    flexGrow: 1,
-    padding: 14,
-    gap: 4,
-    borderRadius: 18,
-    borderWidth: 1,
-    backgroundColor: C.cardGlass,
-    minHeight: 96,
+    flexBasis:       '47%',
+    flexGrow:        1,
+    flexDirection:   'row',
+    alignItems:      'center',
+    gap:             12,
+    padding:         12,
+    borderRadius:    18,
+    backgroundColor: 'rgba(26,24,22,0.75)',
+    borderWidth:     1,
+    borderColor:     C.border,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
+    shadowColor:     '#000000',
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
   },
-  outcomeCardSos: {
-    // SOS gets a slightly stronger tint so it reads as the urgent option.
-    backgroundColor: 'rgba(232,116,97,0.08)',
+  outcomeIcon: {
+    width:          46,
+    height:         46,
+    borderRadius:   14,
+    alignItems:     'center',
+    justifyContent: 'center',
   },
-  outcomeEmoji: {
-    fontSize: 22,
-    lineHeight: 26,
-    marginBottom: 2,
-  },
+  outcomeIconText: { fontSize: 22 },
+  outcomeTextWrap: { flex: 1 },
   outcomeTitle: {
-    fontFamily: F.subheading, fontSize: 15, color: C.text, letterSpacing: -0.1,
+    fontFamily: F.bodySemi, fontSize: 14, color: C.text, letterSpacing: -0.1,
   },
   outcomeSubtitle: {
-    fontFamily: F.body, fontSize: 12, color: C.textSub,
+    fontFamily: F.body, fontSize: 11, color: C.textSecondary, marginTop: 1,
   },
 
-  // Outcome → child picker modal
+  // ─── Children section card ───
+  childrenSection: {
+    backgroundColor: 'rgba(26,24,22,0.75)',
+    borderRadius:    18,
+    borderWidth:     1,
+    borderColor:     C.border,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
+    padding:         18,
+    gap:             10,
+    shadowColor:     '#000000',
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
+  },
+  childrenLabel: {
+    fontFamily:    F.label,
+    fontSize:      10,
+    color:         C.textMuted,
+    letterSpacing: 1.2,
+    marginBottom:  4,
+  },
+  childRow: {
+    flexDirection: 'row',
+    alignItems:    'center',
+    gap:           14,
+    paddingVertical: 4,
+  },
+  childAvatar: {
+    width:          44,
+    height:         44,
+    borderRadius:   22,
+    alignItems:     'center',
+    justifyContent: 'center',
+  },
+  childAvatarText: {
+    fontFamily: F.heading, fontSize: 18, color: '#FFFFFF', letterSpacing: -0.3,
+  },
+  childName:  { fontFamily: F.bodySemi, fontSize: 16, color: C.text },
+  childAge:   { fontFamily: F.body,     fontSize: 13, color: C.textSecondary, marginTop: 1 },
+  chevron:    { fontFamily: F.heading,  fontSize: 22, color: C.textMuted },
+
+  addRow: {
+    paddingVertical: 8,
+    alignItems:      'flex-start',
+  },
+  addRowText: {
+    fontFamily: F.bodyMedium, fontSize: 13, color: C.amberLight, letterSpacing: 0.3,
+  },
+
+  // ─── Empty state (0 children) ───
+  emptyWrap: {
+    flex: 1, paddingHorizontal: 24, gap: 14,
+    justifyContent: 'center',
+  },
+  emptyTitle: {
+    fontFamily: F.heading, fontSize: 26, color: C.textDark, letterSpacing: -0.3,
+  },
+  emptyBody: {
+    fontFamily: F.body, fontSize: 15, color: C.textDarkSecondary, lineHeight: 22,
+    marginBottom: 8,
+  },
+  primaryBtn: {
+    borderRadius:    18,
+    minHeight:       54,
+    alignSelf:       'flex-start',
+    alignItems:      'center',
+    justifyContent:  'center',
+    paddingHorizontal: 32,
+    shadowColor:     C.amber,
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
+  },
+  primaryBtnText: {
+    fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3,
+  },
+
+  // ─── Picker modal ───
   pickerBackdrop: {
     flex: 1,
-    backgroundColor: 'rgba(15,10,18,0.65)',
-    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.65)',
+    justifyContent:  'flex-end',
   },
   pickerSheet: {
-    backgroundColor: 'rgba(28,22,30,0.98)',
-    borderTopLeftRadius: 24,
+    backgroundColor:     'rgba(26,24,22,0.98)',
+    borderTopLeftRadius:  24,
     borderTopRightRadius: 24,
-    padding: 24,
-    paddingBottom: 36,
-    gap: 16,
+    padding:              24,
+    paddingBottom:        36,
+    gap:                  16,
+    borderTopWidth:       1,
+    borderTopColor:       C.borderHi,
   },
   pickerTitle: {
     fontFamily: F.heading, fontSize: 22, color: C.text, letterSpacing: -0.3,
   },
   pickerSub: {
-    fontFamily: F.body, fontSize: 14, color: C.textSub,
+    fontFamily: F.body, fontSize: 14, color: C.textSecondary,
   },
   pickerRow: {
     flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 12,
-    paddingTop: 4,
+    flexWrap:      'wrap',
+    gap:           12,
+    paddingTop:    4,
   },
   pickerChild: {
-    width: 96,
-    padding: 12, gap: 6,
-    alignItems: 'center', justifyContent: 'center',
-    borderRadius: 16,
-    backgroundColor: C.cardGlass,
-    borderWidth: 1, borderColor: C.border,
+    width:           96,
+    padding:         12,
+    gap:             6,
+    alignItems:      'center',
+    justifyContent:  'center',
+    borderRadius:    16,
+    backgroundColor: 'rgba(26,24,22,0.75)',
+    borderWidth:     1,
+    borderColor:     C.border,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
   },
   pickerAvatar: {
-    width: 48, height: 48, borderRadius: 24,
-    alignItems: 'center', justifyContent: 'center',
-    shadowOpacity: 0.25, shadowRadius: 10,
-    shadowOffset: { width: 0, height: 4 }, elevation: 3,
+    width:          48,
+    height:         48,
+    borderRadius:   24,
+    alignItems:     'center',
+    justifyContent: 'center',
   },
   pickerAvatarText: {
     fontFamily: F.heading, fontSize: 20, color: '#FFFFFF', letterSpacing: -0.3,
@@ -813,35 +814,12 @@ const s = StyleSheet.create({
     fontFamily: F.bodySemi, fontSize: 13, color: C.text, textAlign: 'center',
   },
   pickerChildAge: {
-    fontFamily: F.body, fontSize: 11, color: C.textSub,
+    fontFamily: F.body, fontSize: 11, color: C.textSecondary,
   },
   pickerCancel: {
-    paddingVertical: 12,
-    alignItems: 'center',
+    paddingVertical: 12, alignItems: 'center',
   },
   pickerCancelText: {
     fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted,
-  },
-
-  // Empty state (0 children)
-  emptyWrap: {
-    flex: 1, paddingHorizontal: 8, gap: 14,
-    justifyContent: 'center',
-  },
-  emptyTitle: {
-    fontFamily: F.heading, fontSize: 24, color: C.text, letterSpacing: -0.3,
-  },
-  emptyBody: {
-    fontFamily: F.body, fontSize: 14, color: C.textSub, lineHeight: 21,
-    marginBottom: 8,
-  },
-  primaryBtn: {
-    borderRadius: 18, minHeight: 54, alignSelf: 'flex-start',
-    alignItems: 'center', justifyContent: 'center',
-    backgroundColor: C.rose,
-    paddingHorizontal: 28,
-  },
-  primaryBtnText: {
-    fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3,
   },
 });

--- a/apps/mobile/app/welcome/index.tsx
+++ b/apps/mobile/app/welcome/index.tsx
@@ -205,7 +205,6 @@ export default function WelcomeScreen() {
           <Animated.View
             style={[
               s.splashContent,
-              { paddingTop: insets.top + 70 },
               { opacity: splashOpacity },
             ]}
           >
@@ -219,7 +218,7 @@ export default function WelcomeScreen() {
             </LinearGradient>
 
             <Text style={s.splashName}>Sturdy</Text>
-            <Text style={s.splashTagline}>The bridge between chaos and calm.</Text>
+            <Text style={s.splashTagline}>The bridge from chaos to connection.</Text>
           </Animated.View>
         </View>
 
@@ -303,7 +302,7 @@ export default function WelcomeScreen() {
 
               <Text style={s.finalTitle}>
                 {'From chaos.\n'}
-                <Text style={s.finalAccent}>To calm.</Text>
+                <Text style={s.finalAccent}>To connection.</Text>
               </Text>
 
               <Text style={s.finalSub}>
@@ -375,10 +374,8 @@ const s = StyleSheet.create({
   // ── Splash ──────────────────────────────────────────────────────────────────
 
   splashContent: {
-    position:          'absolute',
-    top:               0,
-    left:              0,
-    right:             0,
+    flex:              1,
+    justifyContent:    'center',
     alignItems:        'center',
     paddingHorizontal: 32,
   },
@@ -455,18 +452,19 @@ const s = StyleSheet.create({
   },
 
   card: {
-    backgroundColor:  C.surface,
+    backgroundColor:  'rgba(26,24,22,0.45)',
     borderRadius:     24,
     overflow:         'hidden',
     padding:          22,
     borderWidth:      1,
     borderColor:      C.border,
-    borderTopColor:   C.borderHi,
+    borderTopWidth:   1,
+    borderTopColor:   'rgba(255,255,255,0.20)',
     shadowColor:      '#000000',
-    shadowOffset:     { width: 0, height: 6 },
-    shadowOpacity:    0.35,
-    shadowRadius:     20,
-    elevation:        4,
+    shadowOffset:     { width: 0, height: 12 },
+    shadowOpacity:    0.50,
+    shadowRadius:     32,
+    elevation:        8,
   },
 
   // ── Feature slide card content ───────────────────────────────────────────────
@@ -505,7 +503,7 @@ const s = StyleSheet.create({
     fontSize:     14,
     color:        C.textSecondary,
     lineHeight:   21,
-    marginBottom: 12,
+    marginBottom: 16,
   },
 
   itemList: { gap: 7 },


### PR DESCRIPTION
## Summary

Two highest-priority screens onto Deep Warm v5.2: welcome polish + full Home migration.

### Part 1 — Welcome polish (`app/welcome/index.tsx`)

- **1A — Floating-glass cards.** Card fill 0.78 → **0.45** so the C-2 gradient reads through. Bright top edge (`rgba(255,255,255,0.20)`), stronger drop shadow (`offset { 0, 12 }`, opacity 0.50, radius 32, elevation 8). Cards now feel like they're floating above the gradient.
- **1B — Item chip spacing.** `featDesc` marginBottom 12 → **16**, no auto/flex spacer existed (verified via grep). Chips now sit at the brief's specified ~16px gap.
- **1C — Splash centering.** `splashContent` now uses `flex: 1` + `justifyContent: 'center'` + `alignItems: 'center'`; dropped the `paddingTop: insets.top + 70` override so the logo/wordmark/tagline sit dead-center on page 0.
- **1D — Product sentence.** Splash tagline → "**The bridge from chaos to connection.**" (was "between chaos and calm"). Final-CTA accent → "**To connection.**" (was "To calm." — out of sync with the locked product sentence in `PRODUCT_PRINCIPLES.md`).

### Part 2 — Home migration (`app/(tabs)/index.tsx`)

| Concern | Before | After |
|---|---|---|
| Background | `welcome-horizon.jpg` + dark dim gradient | Single C-2 gradient + soft amber glow behind greeting |
| Root bg | `C.base` | `C.background` (#111111) |
| Greeting | `#FFFFFF` on photo | `C.textDark` on warm-parchment zone |
| Subtitle | "What's on your mind?" in white | "What's happening right now?" in `C.sosSubtle` |
| Input | `C.cardGlass` + sage focus | `C.inputBg` + `C.inputBorder` + `C.inputHighlight` (top edge) + `C.borderFocus` |
| Outcome cards | Stacked emoji + small text + colored border | v5.2 icon-badge: 46×46 gradient square + title/subtitle horizontal layout, 3D floating glass |
| Empty-state CTA | `C.rose` (pink) | `[C.amber, C.amberMid]` gradient |
| Auto-redirect on 0 children | n/a (was already manual) | Verified: parent must tap "Add a child" |
| Children list | Single-child lite card + horizontal multi-child scroller | Single "YOUR CHILDREN" section card with rows: 44px gradient avatar + name + age + ›. "Add another child" link in `C.amberLight`. |
| Send button | Solid amber + amber shadow | `[C.amber, C.amberMid]` gradient when enabled, dark-glass disabled state |
| Photo imports | `HORIZON_PHOTO = require(...)` | Removed |

Outcome icon gradients pulled from the committed tokens: `iconSos*`, `iconRepair*`, `iconUnderstand*`, `iconTalk*`. Per-child avatar gradients rotate through the same four pairs.

**Routing + state preserved verbatim** — `handleOpenChild`, `handleAddChild`, `handleSelectOutcome`, `handlePickerSelectChild`, `handlePickerCancel`, `detectChildFromMessage`, the focus-effect greeting reroll, `getQuestionResponse` + `CrisisDetectedError` handling, `OutcomeMode` type, and `OUTCOMES` data shape are unchanged. The picker modal is also preserved (restyled to dark-glass).

### Part 3 — Tab bar (`app/(tabs)/_layout.tsx`)

- Background: `rgba(20,17,14,0.92)` → `rgba(10,10,10,0.97)`
- Removed `borderTopWidth`; replaced with shadow separator (`shadowOffset { 0, -4 }`, opacity 0.30, radius 12, elevation 8).
- Active tint stays `C.tabActive` (amber, token unchanged).

## Out of scope (per brief)

- Auth screen and all other screens — separate PRs
- Theme tokens (locked)
- Photo assets in `assets/images/welcome/` — leave on disk for later cleanup
- Routing logic and outcome data shapes

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `grep "HORIZON_PHOTO\|welcome-horizon\|require.*welcome\|C.rose\|C.cardGlass\|C.base"` against `(tabs)/index.tsx` → no hits
- [x] All routing handlers (`handleOpenChild` / `handleAddChild` / `handleSelectOutcome` / `detectChildFromMessage` / `getQuestionResponse` / `CrisisDetectedError`) intact
- [ ] Manual: welcome 5-page swipe shows floating dark-glass cards on warm-to-dark gradient, splash content vertically centered, "From chaos. / To connection." on final CTA
- [ ] Manual: Home 0-children → empty state with amber "Add a child" button (NOT pink), no auto-redirect
- [ ] Manual: Home 1+ children → greeting + input + send + 4-card outcome icon-badge grid + YOUR CHILDREN section card
- [ ] Manual: tap outcome card → routes correctly (single-child direct, multi-child opens picker modal)
- [ ] Manual: tab bar shows amber active state with shadow-separator look

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_