### PR TITLE
feat: full-app Deep Warm v5.2 migration

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -574,14 +574,14 @@ const s = StyleSheet.create({
   greeting: {
     fontFamily:    F.heading,
     fontSize:      32,
-    color:         C.textDark,
+    color:         C.text,
     letterSpacing: -0.5,
     lineHeight:    38,
   },
   subGreeting: {
     fontFamily: F.body,
     fontSize:   16,
-    color:      C.sosSubtle,
+    color:      'rgba(232,116,97,0.90)',
     lineHeight: 22,
   },
 
@@ -736,10 +736,10 @@ const s = StyleSheet.create({
     justifyContent: 'center',
   },
   emptyTitle: {
-    fontFamily: F.heading, fontSize: 26, color: C.textDark, letterSpacing: -0.3,
+    fontFamily: F.heading, fontSize: 26, color: C.text, letterSpacing: -0.3,
   },
   emptyBody: {
-    fontFamily: F.body, fontSize: 15, color: C.textDarkSecondary, lineHeight: 22,
+    fontFamily: F.body, fontSize: 15, color: C.textSecondary, lineHeight: 22,
     marginBottom: 8,
   },
   primaryBtn: {

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -227,7 +227,7 @@ const s = StyleSheet.create({
   title: {
     fontFamily:    F.heading,
     fontSize:      28,
-    color:         C.textDark,
+    color:         C.text,
     letterSpacing: -0.3,
     marginBottom:  8,
   },

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,6 +1,5 @@
 // app/(tabs)/settings.tsx
-// v3 — Journal identity: pastel gradient, frosted glass cards
-// Settings screen with grouped sections
+// v4 — Deep Warm v5.2: C-2 settings gradient, dark glass, amber section labels.
 
 import { useState } from 'react';
 import {
@@ -30,18 +29,8 @@ function SectionLabel({ label }: { label: string }) {
   );
 }
 
-function SettingGroup({ children, tint }: { children: React.ReactNode; tint?: 'rose' | 'sage' }) {
-  const bg = tint === 'rose' ? 'rgba(201,123,99,0.05)'
-    : tint === 'sage' ? 'rgba(129,178,154,0.05)'
-    : C.cardGlass;
-  const bc = tint === 'rose' ? 'rgba(201,123,99,0.12)'
-    : tint === 'sage' ? 'rgba(129,178,154,0.12)'
-    : C.border;
-  return (
-    <View style={[s.group, { backgroundColor: bg, borderColor: bc }]}>
-      {children}
-    </View>
-  );
+function SettingGroup({ children }: { children: React.ReactNode }) {
+  return <View style={s.group}>{children}</View>;
 }
 
 function SettingRow({
@@ -58,8 +47,8 @@ function SettingRow({
     >
       <Text style={[
         s.rowLabel,
-        danger && { color: '#C0524A' },
-        accent && { color: C.rose },
+        danger && { color: C.sos },
+        accent && { color: C.amber },
       ]}>
         {label}
       </Text>
@@ -67,7 +56,7 @@ function SettingRow({
         <Switch
           value={toggleValue}
           onValueChange={(v) => { Haptics.selectionAsync(); onToggle?.(v); }}
-          trackColor={{ false: 'rgba(0,0,0,0.08)', true: C.sage }}
+          trackColor={{ false: 'rgba(255,255,255,0.10)', true: C.amber }}
           thumbColor="#FFFFFF"
         />
       ) : value ? (
@@ -98,171 +87,250 @@ export default function SettingsScreen() {
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     try {
       await signOut();
-      // AuthGate in _layout.tsx handles post-signout routing (returning users
-      // → /auth?mode=signin). Do NOT router.replace here — bypassing AuthGate
-      // leaves /welcome in the back stack and creates the guest re-entry loop.
+      // AuthGate handles post-signout routing.
     } catch {
       setSigningOut(false);
     }
   };
 
   return (
-    <SafeAreaView style={s.root} edges={['top']}>
-      <StatusBar style="dark" />
+    <View style={s.root}>
+      <StatusBar style="light" />
       <LinearGradient
-        colors={[C.gradStart, C.gradMid1, C.gradMid2, C.gradEnd]}
-        start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+        colors={[
+          C.gradientSettingsTop,
+          C.gradientSettingsMid1,
+          C.gradientSettingsMid2,
+          C.gradientMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.12, 0.26, 0.42, 0.58, 1]}
         style={StyleSheet.absoluteFill}
       />
+      <SafeAreaView style={s.safe} edges={['top']}>
+        <ScrollView
+          contentContainerStyle={s.scroll}
+          showsVerticalScrollIndicator={false}
+        >
+          <Text style={s.title}>Settings</Text>
 
-      <ScrollView
-        contentContainerStyle={s.scroll}
-        showsVerticalScrollIndicator={false}
-      >
-        <Text style={s.title}>Settings</Text>
-
-        {/* ACCOUNT */}
-        <SectionLabel label="ACCOUNT" />
-        <SettingGroup>
-          <View style={s.accountRow}>
-            <View style={s.accountAva}>
-              <Text style={s.accountAvaText}>
-                {email ? email[0].toUpperCase() : '?'}
-              </Text>
+          {/* ACCOUNT */}
+          <SectionLabel label="ACCOUNT" />
+          <SettingGroup>
+            <View style={s.accountRow}>
+              <LinearGradient
+                colors={[C.amber, C.amberMid]}
+                start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+                style={s.accountAva}
+              >
+                <Text style={s.accountAvaText}>
+                  {email ? email[0].toUpperCase() : '?'}
+                </Text>
+              </LinearGradient>
+              <View style={{ flex: 1, gap: 2 }}>
+                <Text style={s.accountEmail}>{email ?? 'Guest'}</Text>
+                <Text style={s.accountPlan}>Free plan</Text>
+              </View>
             </View>
-            <View style={{ flex: 1, gap: 2 }}>
-              <Text style={s.accountEmail}>{email ?? 'Guest'}</Text>
-              <Text style={s.accountPlan}>Free plan</Text>
-            </View>
-          </View>
-        </SettingGroup>
+          </SettingGroup>
 
-        {/* SUBSCRIPTION */}
-        <SectionLabel label="SUBSCRIPTION" />
-        <SettingGroup tint="rose">
-          <Pressable
-            onPress={() => router.push('/upgrade')}
-            style={({ pressed }) => [s.upgradeRow, pressed && { opacity: 0.85 }]}
-          >
-            <View style={{ flex: 1, gap: 2 }}>
-              <Text style={s.upgradeLabel}>Upgrade to Sturdy+</Text>
-              <Text style={s.upgradeSub}>Unlimited scripts, full history, insights</Text>
-            </View>
-            <View style={s.upgradeBtn}>
-              <Text style={s.upgradeBtnText}>→</Text>
-            </View>
-          </Pressable>
-          <Divider />
-          <SettingRow label="Restore purchase" onPress={() => {}} />
-        </SettingGroup>
+          {/* SUBSCRIPTION */}
+          <SectionLabel label="SUBSCRIPTION" />
+          <SettingGroup>
+            <Pressable
+              onPress={() => router.push('/upgrade')}
+              style={({ pressed }) => [s.upgradeRow, pressed && { opacity: 0.85 }]}
+            >
+              <View style={{ flex: 1, gap: 2 }}>
+                <Text style={s.upgradeLabel}>Upgrade to Sturdy+</Text>
+                <Text style={s.upgradeSub}>Unlimited scripts, full history, insights</Text>
+              </View>
+              <View style={s.upgradeBtn}>
+                <Text style={s.upgradeBtnText}>→</Text>
+              </View>
+            </Pressable>
+            <Divider />
+            <SettingRow label="Restore purchase" onPress={() => {}} />
+          </SettingGroup>
 
-        {/* CHILDREN */}
-        <SectionLabel label="CHILDREN" />
-        <SettingGroup tint="sage">
-          <SettingRow label="Manage children" onPress={() => router.push('/child/new')} />
-        </SettingGroup>
+          {/* CHILDREN */}
+          <SectionLabel label="CHILDREN" />
+          <SettingGroup>
+            <SettingRow label="Manage children" onPress={() => router.push('/child/new')} />
+          </SettingGroup>
 
-        {/* GENERAL */}
-        <SectionLabel label="GENERAL" />
-        <SettingGroup>
-          <SettingRow
-            label="Push notifications"
-            toggle toggleValue={pushEnabled} onToggle={setPushEnabled}
-          />
-        </SettingGroup>
+          {/* GENERAL */}
+          <SectionLabel label="GENERAL" />
+          <SettingGroup>
+            <SettingRow
+              label="Push notifications"
+              toggle toggleValue={pushEnabled} onToggle={setPushEnabled}
+            />
+          </SettingGroup>
 
-        {/* PRIVACY */}
-        <SectionLabel label="PRIVACY" />
-        <SettingGroup>
-          <SettingRow
-            label="Research consent"
-            toggle toggleValue={researchConsent} onToggle={setResearchConsent}
-          />
-          <Divider />
-          <SettingRow label="Privacy policy" onPress={() => router.push('/legal/privacy-policy')} />
-          <Divider />
-          <SettingRow label="Terms of service" onPress={() => router.push('/legal/terms-of-service')} />
-        </SettingGroup>
+          {/* PRIVACY */}
+          <SectionLabel label="PRIVACY" />
+          <SettingGroup>
+            <SettingRow
+              label="Research consent"
+              toggle toggleValue={researchConsent} onToggle={setResearchConsent}
+            />
+            <Divider />
+            <SettingRow label="Privacy policy" onPress={() => router.push('/legal/privacy-policy')} />
+            <Divider />
+            <SettingRow label="Terms of service" onPress={() => router.push('/legal/terms-of-service')} />
+          </SettingGroup>
 
-        {/* SUPPORT */}
-        <SectionLabel label="SUPPORT" />
-        <SettingGroup>
-          <SettingRow label="Help & FAQ" onPress={() => {}} />
-          <Divider />
-          <SettingRow label="Contact us" onPress={() => {}} />
-        </SettingGroup>
+          {/* SUPPORT */}
+          <SectionLabel label="SUPPORT" />
+          <SettingGroup>
+            <SettingRow label="Help & FAQ" onPress={() => {}} />
+            <Divider />
+            <SettingRow label="Contact us" onPress={() => {}} />
+          </SettingGroup>
 
-        {/* MANAGE ACCOUNT */}
-        <SectionLabel label="MANAGE ACCOUNT" />
-        <SettingGroup>
-          <SettingRow label="Export my data" onPress={() => router.push('/account/export')} />
-          <Divider />
-          <SettingRow label="Pause account"  onPress={() => router.push('/account/pause')} />
-          <Divider />
-          <SettingRow label="Delete account" danger onPress={() => router.push('/account/delete')} />
-        </SettingGroup>
+          {/* MANAGE ACCOUNT */}
+          <SectionLabel label="MANAGE ACCOUNT" />
+          <SettingGroup>
+            <SettingRow label="Export my data" onPress={() => router.push('/account/export')} />
+            <Divider />
+            <SettingRow label="Pause account"  onPress={() => router.push('/account/pause')} />
+            <Divider />
+            <SettingRow label="Delete account" danger onPress={() => router.push('/account/delete')} />
+          </SettingGroup>
 
-        {/* SIGN OUT */}
-        <SettingGroup>
-          <SettingRow
-            label={signingOut ? 'Signing out…' : 'Sign out'}
-            onPress={handleSignOut}
-          />
-        </SettingGroup>
+          {/* SIGN OUT */}
+          <SettingGroup>
+            <SettingRow
+              label={signingOut ? 'Signing out…' : 'Sign out'}
+              onPress={handleSignOut}
+            />
+          </SettingGroup>
 
-        <Text style={s.version}>Sturdy v6.0 · Made with ♥</Text>
+          <Text style={s.version}>Sturdy v6.0 · Made with ♥</Text>
 
-        <View style={{ height: 40 }} />
-      </ScrollView>
-    </SafeAreaView>
+          <View style={{ height: 60 }} />
+        </ScrollView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 // ─── Styles ───
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.base },
+  root: { flex: 1, backgroundColor: C.background },
+  safe: { flex: 1 },
   scroll: { paddingHorizontal: 20, paddingTop: 16, paddingBottom: 60, gap: 6 },
 
-  title: { fontFamily: F.display, fontSize: 28, color: C.text, letterSpacing: -0.3, marginBottom: 8 },
+  title: {
+    fontFamily:    F.heading,
+    fontSize:      28,
+    color:         C.textDark,
+    letterSpacing: -0.3,
+    marginBottom:  8,
+  },
 
-  sectionRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginTop: 12, marginBottom: 4 },
-  sectionLabel: { fontFamily: F.label, fontSize: 10, letterSpacing: 0.9, color: C.textMuted },
-  sectionLine: { flex: 1, height: StyleSheet.hairlineWidth, backgroundColor: 'rgba(0,0,0,0.08)' },
+  sectionRow: {
+    flexDirection: 'row',
+    alignItems:    'center',
+    gap:           10,
+    marginTop:     14,
+    marginBottom:  4,
+  },
+  sectionLabel: {
+    fontFamily:    F.label,
+    fontSize:      10,
+    letterSpacing: 1.2,
+    color:         C.amber,
+    textTransform: 'uppercase',
+  },
+  sectionLine: {
+    flex:            1,
+    height:          StyleSheet.hairlineWidth,
+    backgroundColor: C.divider,
+  },
 
-  group: { borderRadius: 18, borderWidth: 1, overflow: 'hidden' },
+  group: {
+    backgroundColor: C.surface,
+    borderWidth:     1,
+    borderColor:     C.border,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
+    borderRadius:    18,
+    overflow:        'hidden',
+    shadowColor:     '#000000',
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
+  },
 
-  divider: { height: StyleSheet.hairlineWidth, backgroundColor: 'rgba(0,0,0,0.06)', marginLeft: 16 },
+  divider: {
+    height:          StyleSheet.hairlineWidth,
+    backgroundColor: C.divider,
+    marginLeft:      16,
+  },
 
   row: {
-    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    paddingHorizontal: 16, paddingVertical: 15, minHeight: 52,
+    flexDirection:     'row',
+    alignItems:        'center',
+    justifyContent:    'space-between',
+    paddingHorizontal: 16,
+    paddingVertical:   15,
+    minHeight:         52,
   },
-  rowLabel: { fontFamily: F.bodyMedium, fontSize: 15, color: C.text },
-  rowValue: { fontFamily: F.body, fontSize: 14, color: C.textMuted },
-  rowChevron: { fontSize: 18, color: 'rgba(42,37,32,0.18)' },
+  rowLabel:   { fontFamily: F.bodyMedium, fontSize: 15, color: C.text },
+  rowValue:   { fontFamily: F.body,       fontSize: 14, color: C.textMuted },
+  rowChevron: { fontSize: 22, color: C.textFaint },
 
-  accountRow: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingHorizontal: 16, paddingVertical: 14 },
+  accountRow: {
+    flexDirection:     'row',
+    alignItems:        'center',
+    gap:               12,
+    paddingHorizontal: 16,
+    paddingVertical:   14,
+  },
   accountAva: {
-    width: 44, height: 44, borderRadius: 22,
-    backgroundColor: C.sage,
-    alignItems: 'center', justifyContent: 'center',
+    width:          44,
+    height:         44,
+    borderRadius:   22,
+    alignItems:     'center',
+    justifyContent: 'center',
   },
-  accountAvaText: { fontFamily: F.subheading, fontSize: 16, color: '#FFF' },
+  accountAvaText: {
+    fontFamily: F.subheading,
+    fontSize:   16,
+    color:      '#FFFFFF',
+  },
   accountEmail: { fontFamily: F.bodyMedium, fontSize: 14, color: C.text },
-  accountPlan: { fontFamily: F.body, fontSize: 12, color: C.textMuted },
+  accountPlan:  { fontFamily: F.body,       fontSize: 12, color: C.textMuted },
 
-  upgradeRow: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingHorizontal: 16, paddingVertical: 14 },
-  upgradeLabel: { fontFamily: F.bodySemi, fontSize: 15, color: '#D4944A' },
-  upgradeSub: { fontFamily: F.body, fontSize: 12, color: C.textMuted },
+  upgradeRow: {
+    flexDirection:     'row',
+    alignItems:        'center',
+    gap:               12,
+    paddingHorizontal: 16,
+    paddingVertical:   14,
+  },
+  upgradeLabel: { fontFamily: F.bodySemi, fontSize: 15, color: C.amber },
+  upgradeSub:   { fontFamily: F.body,     fontSize: 12, color: C.textSecondary },
   upgradeBtn: {
-    width: 36, height: 36, borderRadius: 12,
-    backgroundColor: '#C8883A',
-    alignItems: 'center', justifyContent: 'center',
+    width:          36,
+    height:         36,
+    borderRadius:   12,
+    backgroundColor: C.amber,
+    alignItems:     'center',
+    justifyContent: 'center',
   },
   upgradeBtnText: { fontSize: 16, color: '#FFFFFF', fontFamily: F.bodySemi },
 
-  version: { fontFamily: F.body, fontSize: 12, color: C.textMuted, textAlign: 'center', marginTop: 16 },
+  version: {
+    fontFamily: F.body,
+    fontSize:   12,
+    color:      C.textMuted,
+    textAlign:  'center',
+    marginTop:  20,
+  },
 });
-
-

--- a/apps/mobile/app/account/delete.tsx
+++ b/apps/mobile/app/account/delete.tsx
@@ -12,18 +12,13 @@ import { router }   from 'expo-router';
 import { StatusBar }   from 'expo-status-bar';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
-import { fonts as F } from '../../src/theme';
+import { colors as C, fonts as F } from '../../src/theme';
 import { supabase } from '../../src/lib/supabase';
 import { deleteAccount } from '../../src/lib/accountApi';
 import { resetOnboarding } from '../../src/utils/onboarding';
 
 const GUEST_SEEN_KEY = 'sturdy_guest_seen_v1';
 
-const BG         = '#0e0a10';
-const TEXT       = 'rgba(255,255,255,0.92)';
-const TEXT_SEC   = 'rgba(255,255,255,0.52)';
-const TEXT_MUTED = 'rgba(255,255,255,0.28)';
-const CORAL      = '#E87461';
 
 const CONFIRMATION = 'DELETE';
 
@@ -96,7 +91,7 @@ export default function DeleteAccountScreen() {
             textContentType="none"
             importantForAutofill="no"
             placeholder="DELETE"
-            placeholderTextColor={TEXT_MUTED}
+            placeholderTextColor={C.textMuted}
             style={[
               s.input,
               { borderColor: confirmText ? 'rgba(232,116,97,0.40)' : 'rgba(255,255,255,0.07)' },
@@ -131,24 +126,24 @@ export default function DeleteAccountScreen() {
 }
 
 const s = StyleSheet.create({
-  root:   { flex: 1, backgroundColor: BG },
+  root:   { flex: 1, backgroundColor: C.background },
   scroll: { padding: 24, paddingBottom: 40, gap: 24 },
 
   closeBtn:  { alignSelf: 'flex-start', paddingVertical: 8 },
-  closeText: { fontFamily: F.bodyMedium, fontSize: 15, color: TEXT_MUTED },
+  closeText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted },
 
   body:        { gap: 14, paddingTop: 12 },
-  heading:     { fontFamily: F.heading, fontSize: 28, color: TEXT, letterSpacing: -0.4, lineHeight: 34 },
-  bodyText:    { fontFamily: F.body, fontSize: 16, color: TEXT_SEC, lineHeight: 24 },
-  subText:     { fontFamily: F.body, fontSize: 14, color: TEXT_SEC, lineHeight: 20, marginTop: 4 },
-  subTextBold: { fontFamily: F.bodySemi, color: TEXT },
+  heading:     { fontFamily: F.heading, fontSize: 28, color: C.text, letterSpacing: -0.4, lineHeight: 34 },
+  bodyText:    { fontFamily: F.body, fontSize: 16, color: C.textSecondary, lineHeight: 24 },
+  subText:     { fontFamily: F.body, fontSize: 14, color: C.textSecondary, lineHeight: 20, marginTop: 4 },
+  subTextBold: { fontFamily: F.bodySemi, color: C.text },
 
   input: {
     backgroundColor: 'rgba(255,255,255,0.06)',
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
-    color: TEXT,
+    color: C.text,
     fontFamily: F.bodySemi,
     fontSize: 16,
     letterSpacing: 1.2,
@@ -158,7 +153,7 @@ const s = StyleSheet.create({
   actions: { gap: 12, marginTop: 12 },
 
   cta: {
-    backgroundColor: CORAL,
+    backgroundColor: C.sos,
     borderRadius: 18,
     paddingVertical: 16,
     alignItems: 'center',
@@ -169,8 +164,8 @@ const s = StyleSheet.create({
   ctaText:         { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
   ctaTextDisabled: { color: 'rgba(255,255,255,0.20)' },
 
-  errorText: { fontFamily: F.body, fontSize: 14, color: CORAL, textAlign: 'center' },
+  errorText: { fontFamily: F.body, fontSize: 14, color: C.sos, textAlign: 'center' },
 
   secondaryBtn:  { paddingVertical: 14, alignItems: 'center' },
-  secondaryText: { fontFamily: F.bodyMedium, fontSize: 14, color: TEXT_MUTED },
+  secondaryText: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textMuted },
 });

--- a/apps/mobile/app/account/export.tsx
+++ b/apps/mobile/app/account/export.tsx
@@ -11,16 +11,9 @@ import { StatusBar }   from 'expo-status-bar';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
-import { fonts as F } from '../../src/theme';
+import { colors as C, fonts as F } from '../../src/theme';
 import { requestExport } from '../../src/lib/accountApi';
 
-const BG          = '#0e0a10';
-const TEXT        = 'rgba(255,255,255,0.92)';
-const TEXT_SEC    = 'rgba(255,255,255,0.52)';
-const TEXT_MUTED  = 'rgba(255,255,255,0.28)';
-const CORAL       = '#E87461';
-const AMBER_DEEP  = '#C8883A';
-const AMBER_LIGHT = '#E8A855';
 
 export default function ExportAccountScreen() {
   const [loading, setLoading] = useState(false);
@@ -76,7 +69,7 @@ export default function ExportAccountScreen() {
             style={({ pressed }) => [pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] }]}
           >
             <LinearGradient
-              colors={[AMBER_DEEP, AMBER_LIGHT]}
+              colors={[C.amber, C.amberMid]}
               start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
               style={s.cta}
             >
@@ -103,24 +96,24 @@ export default function ExportAccountScreen() {
 }
 
 const s = StyleSheet.create({
-  root:   { flex: 1, backgroundColor: BG },
+  root:   { flex: 1, backgroundColor: C.background },
   scroll: { padding: 24, paddingBottom: 40, gap: 24 },
 
   closeBtn:  { alignSelf: 'flex-start', paddingVertical: 8 },
-  closeText: { fontFamily: F.bodyMedium, fontSize: 15, color: TEXT_MUTED },
+  closeText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted },
 
   body:     { gap: 14, paddingTop: 12 },
-  heading:  { fontFamily: F.heading, fontSize: 28, color: TEXT, letterSpacing: -0.4, lineHeight: 34 },
-  bodyText: { fontFamily: F.body, fontSize: 16, color: TEXT_SEC, lineHeight: 24 },
+  heading:  { fontFamily: F.heading, fontSize: 28, color: C.text, letterSpacing: -0.4, lineHeight: 34 },
+  bodyText: { fontFamily: F.body, fontSize: 16, color: C.textSecondary, lineHeight: 24 },
 
   actions: { gap: 12, marginTop: 12 },
 
   cta:     { borderRadius: 18, paddingVertical: 16, alignItems: 'center' },
   ctaText: { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
 
-  errorText:   { fontFamily: F.body, fontSize: 14, color: CORAL,    textAlign: 'center' },
-  successText: { fontFamily: F.body, fontSize: 14, color: TEXT_SEC, textAlign: 'center' },
+  errorText:   { fontFamily: F.body, fontSize: 14, color: C.sos,    textAlign: 'center' },
+  successText: { fontFamily: F.body, fontSize: 14, color: C.textSecondary, textAlign: 'center' },
 
   secondaryBtn:  { paddingVertical: 14, alignItems: 'center' },
-  secondaryText: { fontFamily: F.bodyMedium, fontSize: 14, color: TEXT_MUTED },
+  secondaryText: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textMuted },
 });

--- a/apps/mobile/app/account/pause.tsx
+++ b/apps/mobile/app/account/pause.tsx
@@ -12,17 +12,10 @@ import { StatusBar }   from 'expo-status-bar';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
-import { fonts as F } from '../../src/theme';
+import { colors as C, fonts as F } from '../../src/theme';
 import { supabase } from '../../src/lib/supabase';
 import { pauseAccount } from '../../src/lib/accountApi';
 
-const BG          = '#0e0a10';
-const TEXT        = 'rgba(255,255,255,0.92)';
-const TEXT_SEC    = 'rgba(255,255,255,0.52)';
-const TEXT_MUTED  = 'rgba(255,255,255,0.28)';
-const CORAL       = '#E87461';
-const AMBER_DEEP  = '#C8883A';
-const AMBER_LIGHT = '#E8A855';
 
 async function clearAuthStorage() {
   try {
@@ -94,7 +87,7 @@ export default function PauseAccountScreen() {
             style={({ pressed }) => [pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] }]}
           >
             <LinearGradient
-              colors={[AMBER_DEEP, AMBER_LIGHT]}
+              colors={[C.amber, C.amberMid]}
               start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
               style={s.cta}
             >
@@ -116,23 +109,23 @@ export default function PauseAccountScreen() {
 }
 
 const s = StyleSheet.create({
-  root:   { flex: 1, backgroundColor: BG },
+  root:   { flex: 1, backgroundColor: C.background },
   scroll: { padding: 24, paddingBottom: 40, gap: 24 },
 
   closeBtn:  { alignSelf: 'flex-start', paddingVertical: 8 },
-  closeText: { fontFamily: F.bodyMedium, fontSize: 15, color: TEXT_MUTED },
+  closeText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted },
 
   body:     { gap: 14, paddingTop: 12 },
-  heading:  { fontFamily: F.heading, fontSize: 28, color: TEXT, letterSpacing: -0.4, lineHeight: 34 },
-  bodyText: { fontFamily: F.body, fontSize: 16, color: TEXT_SEC, lineHeight: 24 },
+  heading:  { fontFamily: F.heading, fontSize: 28, color: C.text, letterSpacing: -0.4, lineHeight: 34 },
+  bodyText: { fontFamily: F.body, fontSize: 16, color: C.textSecondary, lineHeight: 24 },
 
   actions: { gap: 12, marginTop: 12 },
 
   cta:     { borderRadius: 18, paddingVertical: 16, alignItems: 'center' },
   ctaText: { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
 
-  errorText: { fontFamily: F.body, fontSize: 14, color: CORAL, textAlign: 'center' },
+  errorText: { fontFamily: F.body, fontSize: 14, color: C.sos, textAlign: 'center' },
 
   secondaryBtn:  { paddingVertical: 14, alignItems: 'center' },
-  secondaryText: { fontFamily: F.bodyMedium, fontSize: 14, color: TEXT_MUTED },
+  secondaryText: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textMuted },
 });

--- a/apps/mobile/app/auth/index.tsx
+++ b/apps/mobile/app/auth/index.tsx
@@ -264,11 +264,11 @@ const s = StyleSheet.create({
   content: { paddingHorizontal: 28, paddingTop: 12, paddingBottom: 110, gap: 20 },
 
   back:     { alignSelf: 'flex-start', paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textSecondary },
 
   hlArea:      { alignItems: 'center', gap: 8, paddingVertical: 16 },
-  headline:    { fontFamily: F.heading, fontSize: 26, color: C.textDark, textAlign: 'center', letterSpacing: -0.3 },
-  headlineSub: { fontFamily: F.body, fontSize: 14, color: C.textDarkSecondary, textAlign: 'center', lineHeight: 20 },
+  headline:    { fontFamily: F.heading, fontSize: 26, color: C.text, textAlign: 'center', letterSpacing: -0.3 },
+  headlineSub: { fontFamily: F.body, fontSize: 14, color: C.textSecondary, textAlign: 'center', lineHeight: 20 },
 
   formCard: {
     borderRadius:    20,

--- a/apps/mobile/app/auth/index.tsx
+++ b/apps/mobile/app/auth/index.tsx
@@ -1,16 +1,8 @@
 // app/auth/index.tsx
-// Unified auth screen — sign-in and sign-up merged into one surface.
-// v3 dark identity (solid #0e0a10, glass card, amber gradient CTA).
+// v4 — Deep Warm v5.2: C-2 gradient, dark glass form card, amber CTA.
 //
 // Mode is read from `?mode=` query param; defaults to 'signup' when
 // missing. Tapping the toggle link switches mode without remounting.
-//
-// Replaces the two prior screens:
-//   - app/auth/sign-in.tsx
-//   - app/auth/sign-up.tsx
-//
-// Other files updated their route refs from /auth/sign-in →
-// /auth?mode=signin and /auth/sign-up → /auth.
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useState } from 'react';
@@ -29,26 +21,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { supabase }       from '../../src/lib/supabase';
 import { markOnboardingComplete } from '../../src/utils/onboarding';
 import { useAuth }        from '../../src/context/AuthContext';
-import { fonts as F }     from '../../src/theme/colors';
-
-// ═══════════════════════════════════════════════
-// V3 DARK TOKENS (hardcoded — this screen owns its identity even when
-// the global theme is mid-transition elsewhere in the app)
-// ═══════════════════════════════════════════════
-
-const BG          = '#0e0a10';
-const SURFACE     = 'rgba(255,255,255,0.055)';
-const BORDER      = 'rgba(255,255,255,0.07)';
-const INPUT_BG    = 'rgba(255,255,255,0.06)';
-const INPUT_FOCUS = 'rgba(212,148,74,0.40)';
-const TEXT        = 'rgba(255,255,255,0.92)';
-const TEXT_SEC    = 'rgba(255,255,255,0.52)';
-const TEXT_MUTED  = 'rgba(255,255,255,0.28)';
-const AMBER       = '#D4944A';                          // toggle accent
-const AMBER_DEEP  = '#C8883A';                          // CTA gradient start
-const AMBER_LIGHT = '#E8A855';                          // CTA gradient end
-const CORAL_SOS   = '#E87461';                          // error / SOS only
-const DISABLED_BG = 'rgba(255,255,255,0.06)';
+import { colors as C, fonts as F } from '../../src/theme/colors';
 
 const PENDING_CHILD_KEY = 'sturdy_pending_child_v1';
 
@@ -138,8 +111,21 @@ export default function AuthScreen() {
   };
 
   return (
-    <SafeAreaView style={s.root} edges={['top', 'bottom']}>
+    <View style={s.root}>
       <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          C.gradientTop,
+          C.gradientMid1,
+          C.gradientMid2,
+          C.gradientMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
 
       <ScrollView
         contentContainerStyle={s.content}
@@ -169,7 +155,7 @@ export default function AuthScreen() {
                 keyboardType="email-address"
                 autoComplete="email"
                 placeholder="you@example.com"
-                placeholderTextColor={TEXT_MUTED}
+                placeholderTextColor={C.inputPlaceholder}
                 value={email}
                 onChangeText={(v) => { setEmail(v); if (error) setError(''); }}
                 onFocus={() => setEmailFocused(true)}
@@ -189,7 +175,7 @@ export default function AuthScreen() {
                 autoCorrect={false}
                 autoComplete={isSignup ? 'password-new' : 'password'}
                 placeholder={isSignup ? 'Choose a password' : 'Enter your password'}
-                placeholderTextColor={TEXT_MUTED}
+                placeholderTextColor={C.inputPlaceholder}
                 value={password}
                 onChangeText={(v) => { setPassword(v); if (error) setError(''); }}
                 onFocus={() => setPwFocused(true)}
@@ -231,7 +217,7 @@ export default function AuthScreen() {
       {/* Sticky CTA with gradient fade into the dark base */}
       <View style={s.stickyWrap}>
         <LinearGradient
-          colors={['transparent', 'rgba(14,10,16,0.95)', BG]}
+          colors={['transparent', 'rgba(12,12,12,0.85)', C.background]}
           locations={[0, 0.45, 0.85]}
           style={s.stickyFade}
           pointerEvents="none"
@@ -247,7 +233,7 @@ export default function AuthScreen() {
           >
             {(!canSubmit || loading) ? (
               <View style={[s.ctaBase, s.ctaDisabled]}>
-                <Text style={[s.ctaText, { color: TEXT_MUTED }]}>
+                <Text style={[s.ctaText, { color: C.disabledText }]}>
                   {loading
                     ? (isSignup ? 'Creating account…' : 'Signing in…')
                     : (isSignup ? 'Create account' : 'Sign in')}
@@ -255,7 +241,7 @@ export default function AuthScreen() {
               </View>
             ) : (
               <LinearGradient
-                colors={[AMBER_DEEP, AMBER_LIGHT]}
+                colors={[C.amber, C.amberMid]}
                 start={{ x: 0, y: 0 }}
                 end={{ x: 1, y: 0 }}
                 style={s.ctaBase}
@@ -268,70 +254,91 @@ export default function AuthScreen() {
           </Pressable>
         </View>
       </View>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 const s = StyleSheet.create({
-  root:    { flex: 1, backgroundColor: BG },
+  root:    { flex: 1, backgroundColor: C.background },
   content: { paddingHorizontal: 28, paddingTop: 12, paddingBottom: 110, gap: 20 },
 
   back:     { alignSelf: 'flex-start', paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: TEXT_MUTED },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
 
   hlArea:      { alignItems: 'center', gap: 8, paddingVertical: 16 },
-  headline:    { fontFamily: F.heading, fontSize: 26, color: TEXT, textAlign: 'center', letterSpacing: -0.3 },
-  headlineSub: { fontFamily: F.body, fontSize: 14, color: TEXT_SEC, textAlign: 'center', lineHeight: 20 },
+  headline:    { fontFamily: F.heading, fontSize: 26, color: C.textDark, textAlign: 'center', letterSpacing: -0.3 },
+  headlineSub: { fontFamily: F.body, fontSize: 14, color: C.textDarkSecondary, textAlign: 'center', lineHeight: 20 },
 
   formCard: {
-    borderRadius: 20,
-    padding: 22,
-    gap: 18,
-    backgroundColor: SURFACE,
-    borderWidth: 1, borderColor: BORDER,
+    borderRadius:    20,
+    padding:         22,
+    gap:             18,
+    backgroundColor: C.surface,
+    borderWidth:     1,
+    borderColor:     C.border,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
+    shadowColor:     '#000000',
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
   },
   field: { gap: 6 },
   fieldLabel: {
-    fontFamily: F.label, fontSize: 11,
-    letterSpacing: 0.8, color: TEXT_MUTED,
+    fontFamily:    F.label,
+    fontSize:      11,
+    letterSpacing: 0.8,
+    color:         C.textMuted,
     textTransform: 'uppercase',
   },
   inputWrap: {
-    borderRadius: 14,
-    backgroundColor: INPUT_BG,
-    borderWidth: 1, borderColor: BORDER,
+    borderRadius:    14,
+    backgroundColor: C.inputBg,
+    borderWidth:     1,
+    borderColor:     C.inputBorder,
+    borderTopWidth:  1,
+    borderTopColor:  C.inputHighlight,
   },
   inputRow:     { flexDirection: 'row', alignItems: 'center' },
-  inputFocused: { borderColor: INPUT_FOCUS },
+  inputFocused: { borderColor: C.borderFocus },
   input: {
-    fontFamily: F.body, fontSize: 16,
-    color: TEXT,
-    paddingHorizontal: 16, paddingVertical: 14,
+    fontFamily:        F.body,
+    fontSize:          16,
+    color:             C.text,
+    paddingHorizontal: 16,
+    paddingVertical:   14,
   },
   eyeBtn:  { paddingHorizontal: 14, paddingVertical: 12 },
   eyeIcon: { fontSize: 18, opacity: 0.5 },
-  pwHint:  { fontFamily: F.body, fontSize: 12, color: TEXT_MUTED },
+  pwHint:  { fontFamily: F.body, fontSize: 12, color: C.textMuted },
 
-  errorText: { fontFamily: F.body, fontSize: 14, color: CORAL_SOS, textAlign: 'center' },
+  errorText: { fontFamily: F.body, fontSize: 14, color: C.sos, textAlign: 'center' },
 
   linkBtn:    { alignSelf: 'center', paddingVertical: 8 },
-  linkText:   { fontFamily: F.body, fontSize: 14, color: TEXT_SEC, textAlign: 'center' },
-  linkAccent: { fontFamily: F.bodySemi, color: AMBER },
+  linkText:   { fontFamily: F.body, fontSize: 14, color: C.textSecondary, textAlign: 'center' },
+  linkAccent: { fontFamily: F.bodySemi, color: C.amberLight },
 
   stickyWrap: { position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 },
   stickyFade: { height: 36 },
   stickyContent: {
-    backgroundColor: BG,
+    backgroundColor:   C.background,
     paddingHorizontal: 28,
-    paddingTop: 4,
-    paddingBottom: 28,
+    paddingTop:        4,
+    paddingBottom:     28,
   },
   ctaBase: {
-    borderRadius: 18,
-    minHeight: 56,
-    alignItems: 'center',
+    borderRadius:   18,
+    minHeight:      56,
+    alignItems:     'center',
     justifyContent: 'center',
+    shadowColor:    C.amber,
+    shadowOffset:   { width: 0, height: 6 },
+    shadowOpacity:  0.35,
+    shadowRadius:   20,
+    elevation:      4,
   },
-  ctaDisabled: { backgroundColor: DISABLED_BG },
+  ctaDisabled: { backgroundColor: C.disabled, shadowOpacity: 0, elevation: 0 },
   ctaText:     { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
 });

--- a/apps/mobile/app/child-profile/[id].tsx
+++ b/apps/mobile/app/child-profile/[id].tsx
@@ -298,7 +298,7 @@ const s = StyleSheet.create({
   // Top bar
   topBar:   { flexDirection: 'row', alignItems: 'center', paddingTop: 4, paddingBottom: 4 },
   backBtn:  { paddingVertical: 6, paddingHorizontal: 4 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textSecondary },
 
   // Identity header (warm zone)
   identity: { alignItems: 'center', gap: 6, paddingTop: 4 },
@@ -320,14 +320,14 @@ const s = StyleSheet.create({
     fontFamily: F.heading, fontSize: 32, color: '#FFFFFF', letterSpacing: -0.4,
   },
   childName: {
-    fontFamily: F.heading, fontSize: 24, color: C.textDark,
+    fontFamily: F.heading, fontSize: 24, color: C.text,
     letterSpacing: -0.3, textAlign: 'center',
   },
   childAge: {
-    fontFamily: F.body, fontSize: 14, color: C.textDarkSecondary,
+    fontFamily: F.body, fontSize: 14, color: C.textSecondary,
   },
   interactionMeta: {
-    fontFamily: F.body, fontSize: 12, color: C.textDarkMuted, marginTop: 4,
+    fontFamily: F.body, fontSize: 12, color: C.textMuted, marginTop: 4,
   },
 
   // Sections

--- a/apps/mobile/app/child-profile/[id].tsx
+++ b/apps/mobile/app/child-profile/[id].tsx
@@ -16,7 +16,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  Image,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -34,7 +33,6 @@ import { loadSavedScripts, type SavedScriptRow } from '../../src/lib/loadSavedSc
 import { loadChildInsights, type ChildInsights } from '../../src/lib/loadChildInsights';
 import { colors as C, fonts as F } from '../../src/theme';
 
-const HORIZON_PHOTO = require('../../assets/images/welcome/welcome-horizon.jpg');
 
 // ═══════════════════════════════════════════════
 // SCREEN
@@ -92,13 +90,20 @@ export default function ChildProfileScreen() {
     return (
       <View style={s.root}>
         <StatusBar style="light" />
-        <Image source={HORIZON_PHOTO} style={StyleSheet.absoluteFill} resizeMode="cover" />
         <LinearGradient
-          colors={['rgba(15,10,18,0.45)', 'rgba(15,10,18,0.65)', 'rgba(15,10,18,0.82)']}
+          colors={[
+            C.gradientTop,
+            C.gradientMid1,
+            C.gradientMid2,
+            C.gradientMid3,
+            C.gradientMid4,
+            C.gradientBottom,
+          ]}
+          locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
           style={StyleSheet.absoluteFill}
         />
         <SafeAreaView style={s.centerGate}>
-          <ActivityIndicator color={'#E8A855'} />
+          <ActivityIndicator color={C.amberMid} />
         </SafeAreaView>
       </View>
     );
@@ -112,9 +117,16 @@ export default function ChildProfileScreen() {
   return (
     <View style={s.root}>
       <StatusBar style="light" />
-      <Image source={HORIZON_PHOTO} style={StyleSheet.absoluteFill} resizeMode="cover" />
       <LinearGradient
-        colors={['rgba(15,10,18,0.45)', 'rgba(15,10,18,0.65)', 'rgba(15,10,18,0.82)']}
+        colors={[
+          C.gradientTop,
+          C.gradientMid1,
+          C.gradientMid2,
+          C.gradientMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
         style={StyleSheet.absoluteFill}
       />
 
@@ -278,38 +290,44 @@ export default function ChildProfileScreen() {
 // ═══════════════════════════════════════════════
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.base },
+  root: { flex: 1, backgroundColor: C.background },
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 32, gap: 22 },
   centerGate: { flex: 1, alignItems: 'center', justifyContent: 'center' },
 
   // Top bar
-  topBar: { flexDirection: 'row', alignItems: 'center', paddingTop: 4, paddingBottom: 4 },
-  backBtn: { paddingVertical: 6, paddingHorizontal: 4 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.text },
+  topBar:   { flexDirection: 'row', alignItems: 'center', paddingTop: 4, paddingBottom: 4 },
+  backBtn:  { paddingVertical: 6, paddingHorizontal: 4 },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
 
-  // Identity header
+  // Identity header (warm zone)
   identity: { alignItems: 'center', gap: 6, paddingTop: 4 },
   avatar: {
-    width: 80, height: 80, borderRadius: 40,
-    alignItems: 'center', justifyContent: 'center',
-    backgroundColor: C.sage,
-    shadowColor: C.sage, shadowOpacity: 0.30, shadowRadius: 16,
-    shadowOffset: { width: 0, height: 6 }, elevation: 4,
-    marginBottom: 8,
+    width:          80,
+    height:         80,
+    borderRadius:   40,
+    alignItems:     'center',
+    justifyContent: 'center',
+    backgroundColor: C.amber,
+    shadowColor:    C.amber,
+    shadowOpacity:  0.35,
+    shadowRadius:   20,
+    shadowOffset:   { width: 0, height: 6 },
+    elevation:      4,
+    marginBottom:   8,
   },
   avatarText: {
     fontFamily: F.heading, fontSize: 32, color: '#FFFFFF', letterSpacing: -0.4,
   },
   childName: {
-    fontFamily: F.heading, fontSize: 24, color: C.text,
+    fontFamily: F.heading, fontSize: 24, color: C.textDark,
     letterSpacing: -0.3, textAlign: 'center',
   },
   childAge: {
-    fontFamily: F.body, fontSize: 14, color: C.textSub,
+    fontFamily: F.body, fontSize: 14, color: C.textDarkSecondary,
   },
   interactionMeta: {
-    fontFamily: F.body, fontSize: 12, color: C.textMuted, marginTop: 4,
+    fontFamily: F.body, fontSize: 12, color: C.textDarkMuted, marginTop: 4,
   },
 
   // Sections
@@ -320,14 +338,14 @@ const s = StyleSheet.create({
 
   // Generic card
   card: {
-    backgroundColor: C.cardGlass,
+    backgroundColor: C.surface,
     borderColor: C.border, borderWidth: 1,
     borderRadius: 18, padding: 16, gap: 14,
   },
 
   // Empty state card (warm, not punitive)
   emptyCard: {
-    backgroundColor: C.cardGlass,
+    backgroundColor: C.surface,
     borderColor: C.border, borderWidth: 1,
     borderRadius: 18, padding: 18, gap: 8,
     alignItems: 'flex-start',
@@ -337,14 +355,14 @@ const s = StyleSheet.create({
     fontFamily: F.subheading, fontSize: 15, color: C.text, letterSpacing: -0.1,
   },
   emptyBody: {
-    fontFamily: F.body, fontSize: 14, color: C.textSub, lineHeight: 21,
+    fontFamily: F.body, fontSize: 14, color: C.textSecondary, lineHeight: 21,
   },
 
   // Triggers
   triggerRow: { gap: 6 },
   triggerHeader: { flexDirection: 'row', justifyContent: 'space-between' },
   triggerLabel: { fontFamily: F.bodyMedium, fontSize: 14, color: C.text },
-  triggerCount: { fontFamily: F.body, fontSize: 13, color: C.textSub },
+  triggerCount: { fontFamily: F.body, fontSize: 13, color: C.textSecondary },
   triggerBarBg: {
     height: 6, borderRadius: 3, backgroundColor: 'rgba(255,255,255,0.06)',
     overflow: 'hidden',
@@ -360,13 +378,13 @@ const s = StyleSheet.create({
     backgroundColor: C.sage,
   },
   workTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
-  workQuote: { fontFamily: F.body, fontSize: 13, color: C.textSub, lineHeight: 19, marginTop: 2 },
+  workQuote: { fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 19, marginTop: 2 },
   workSeeAll: { paddingTop: 4 },
   workSeeAllText: { fontFamily: F.bodyMedium, fontSize: 13, color: C.amber },
 
   // Locked / coming-soon card
   lockedCard: {
-    backgroundColor: C.cardGlass,
+    backgroundColor: C.surface,
     borderColor: C.border, borderWidth: 1,
     borderRadius: 18, padding: 16, gap: 8,
   },
@@ -374,12 +392,12 @@ const s = StyleSheet.create({
   lockedIcon: { fontSize: 16 },
   lockedPill: {
     fontFamily: F.label, fontSize: 9, letterSpacing: 0.8,
-    color: C.amber, backgroundColor: 'rgba(247,149,102,0.12)',
+    color: C.amber, backgroundColor: C.amberBadge,
     paddingHorizontal: 8, paddingVertical: 3,
     borderRadius: 999, overflow: 'hidden',
   },
   lockedBody: {
-    fontFamily: F.body, fontSize: 13, color: C.textSub, lineHeight: 19,
+    fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 19,
   },
 
   // Profile basics (read-only)

--- a/apps/mobile/app/child-setup.tsx
+++ b/apps/mobile/app/child-setup.tsx
@@ -232,7 +232,7 @@ router.replace('/(tabs)');
         >
           <LinearGradient
             colors={canContinue ? ['#C8883A', '#E8A855'] : ['rgba(255,255,255,0.06)', 'rgba(255,255,255,0.04)']}
-            start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+            
             style={s.ctaBtn}
           >
             <Text style={[s.ctaText, !canContinue && { color: 'rgba(255,255,255,0.20)' }]}>
@@ -263,7 +263,7 @@ const s = StyleSheet.create({
 
   header: { alignItems: 'center', gap: 6 },
   title: { fontFamily: F.heading, fontSize: 26, color: C.text, textAlign: 'center', letterSpacing: -0.3, lineHeight: 34 },
-  subtitle: { fontFamily: F.body, fontSize: 14, color: C.textSub, textAlign: 'center' },
+  subtitle: { fontFamily: F.body, fontSize: 14, color: C.textSecondary, textAlign: 'center' },
 
   formCard: {
     borderRadius: 24, padding: 22, gap: 24, borderWidth: 1,
@@ -272,7 +272,7 @@ const s = StyleSheet.create({
   },
 
   field: { gap: 10 },
-  fieldLabel: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textBody },
+  fieldLabel: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textSecondary },
 
   inputWrap: { borderRadius: 14, backgroundColor: 'rgba(255,255,255,0.05)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.08)' },
   inputFocused: { borderColor: 'rgba(87,120,163,0.35)' },
@@ -281,7 +281,7 @@ const s = StyleSheet.create({
   agePickerRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 20 },
   ageArrowBtn: { width: 44, height: 44, borderRadius: 22, backgroundColor: 'rgba(255,255,255,0.06)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.10)', alignItems: 'center', justifyContent: 'center' },
   ageArrowDisabled: { opacity: 0.3 },
-  ageArrowText: { fontFamily: F.heading, fontSize: 22, color: C.textBody, marginTop: -2 },
+  ageArrowText: { fontFamily: F.heading, fontSize: 22, color: C.textSecondary, marginTop: -2 },
   ageArrowTextDisabled: { color: C.textMuted },
   ageDisplay: { alignItems: 'center', minWidth: 60 },
   ageNumber: { fontFamily: F.heading, fontSize: 42, color: C.amber, lineHeight: 48 },
@@ -297,7 +297,7 @@ const s = StyleSheet.create({
   hintIcon: { fontSize: 18 },
   hintText: { fontFamily: F.body, fontSize: 13, color: C.sage, flex: 1, lineHeight: 19 },
 
-  error: { fontFamily: F.body, fontSize: 14, color: C.coral },
+  error: { fontFamily: F.body, fontSize: 14, color: C.sos },
 
   ctaBtn: { borderRadius: 18, minHeight: 56, alignItems: 'center', justifyContent: 'center' },
   ctaText: { fontFamily: F.subheading, fontSize: 17, color: '#FFFFFF', letterSpacing: 0.3 },

--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -645,7 +645,7 @@ const s = StyleSheet.create({
   // Top bar
   topBar:   { flexDirection: 'row', alignItems: 'center', paddingTop: 4, paddingBottom: 4 },
   backBtn:  { paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textSecondary },
 
   // Identity (sits on warm parchment top zone)
   identityWrap: { alignItems: 'center', gap: 10, marginTop: 8 },
@@ -663,8 +663,8 @@ const s = StyleSheet.create({
     elevation:      4,
   },
   avatarText: { fontFamily: F.heading, fontSize: 36, color: '#FFFFFF', letterSpacing: -0.5 },
-  childName:  { fontFamily: F.heading, fontSize: 28, color: C.textDark, letterSpacing: -0.3, marginTop: 4 },
-  childAge:   { fontFamily: F.body, fontSize: 14, color: C.textDarkSecondary },
+  childName:  { fontFamily: F.heading, fontSize: 28, color: C.text, letterSpacing: -0.3, marginTop: 4 },
+  childAge:   { fontFamily: F.body, fontSize: 14, color: C.textSecondary },
 
   // Textarea
   textareaCard: {
@@ -780,7 +780,7 @@ const s = StyleSheet.create({
   // Tone selector
   toneSection: { gap: 8 },
   toneHeader:  { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  toneLabel:   { fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, letterSpacing: 0.3 },
+  toneLabel:   { fontFamily: F.bodyMedium, fontSize: 13, color: C.text, letterSpacing: 0.3 },
   tonePremiumPill: {
     fontFamily:        F.label,
     fontSize:          9,

--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -6,7 +6,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Animated,
-  Image,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -34,7 +33,6 @@ import { getTone, setTone, type Tone, TONE_DEFAULT } from '../../src/utils/tone'
 import { PaywallSheet } from '../../src/components/ui/PaywallSheet';
 import { colors as C, fonts as F } from '../../src/theme';
 
-const HORIZON_PHOTO = require('../../assets/images/welcome/welcome-horizon.jpg');
 
 // ═══════════════════════════════════════════════
 // CONSTANTS
@@ -44,7 +42,7 @@ const INTENSITY_OPTIONS = [
   { level: 1, label: 'Mild',     color: C.sage },
   { level: 2, label: 'Building', color: '#5778A3' },
   { level: 3, label: 'Hard',     color: '#F79566' },
-  { level: 4, label: 'Intense',  color: C.rose },
+  { level: 4, label: 'Intense',  color: C.sos },
 ] as const;
 
 // Tone selector — Sturdy+ only. Free users default to Gentle (per
@@ -341,24 +339,28 @@ export default function ChildHubScreen() {
     return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
   };
 
+  // ─── Background — single C-2 gradient ───
+  const Background = () => (
+    <LinearGradient
+      colors={[
+        C.gradientTop,
+        C.gradientMid1,
+        C.gradientMid2,
+        C.gradientMid3,
+        C.gradientMid4,
+        C.gradientBottom,
+      ]}
+      locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
+      style={StyleSheet.absoluteFill}
+    />
+  );
+
   // ─── Loading gate (child profile not yet resolved) ───
   if (!child) {
     return (
       <View style={s.root}>
         <StatusBar style="light" />
-        <Image
-          source={HORIZON_PHOTO}
-          style={StyleSheet.absoluteFill}
-          resizeMode="cover"
-        />
-        <LinearGradient
-          colors={[
-            'rgba(15,10,18,0.45)',
-            'rgba(15,10,18,0.65)',
-            'rgba(15,10,18,0.82)',
-          ]}
-          style={StyleSheet.absoluteFill}
-        />
+        <Background />
       </View>
     );
   }
@@ -366,20 +368,7 @@ export default function ChildHubScreen() {
   return (
     <View style={s.root}>
       <StatusBar style="light" />
-
-      <Image
-        source={HORIZON_PHOTO}
-        style={StyleSheet.absoluteFill}
-        resizeMode="cover"
-      />
-      <LinearGradient
-        colors={[
-          'rgba(15,10,18,0.45)',
-          'rgba(15,10,18,0.65)',
-          'rgba(15,10,18,0.82)',
-        ]}
-        style={StyleSheet.absoluteFill}
-      />
+      <Background />
 
       <SafeAreaView style={s.safe} edges={['top']}>
         <KeyboardAvoidingView
@@ -396,7 +385,7 @@ export default function ChildHubScreen() {
               <RefreshControl
                 refreshing={refreshing}
                 onRefresh={handleRefresh}
-                tintColor={C.rose}
+                tintColor={C.amber}
               />
             }
           >
@@ -521,11 +510,21 @@ export default function ChildHubScreen() {
                 pressed && canSubmit && !loading && { opacity: 0.9, transform: [{ scale: 0.98 }] },
               ]}
             >
-              <View style={[s.ctaBtn, (!canSubmit || loading) && s.ctaBtnDisabled]}>
-                <Text style={[s.ctaLabel, (!canSubmit || loading) && { color: C.textMuted }]}>
-                  {loading ? copy.ctaLoading : copy.cta}
-                </Text>
-              </View>
+              {(!canSubmit || loading) ? (
+                <View style={[s.ctaBtn, s.ctaBtnDisabled]}>
+                  <Text style={[s.ctaLabel, { color: C.disabledText }]}>
+                    {loading ? copy.ctaLoading : copy.cta}
+                  </Text>
+                </View>
+              ) : (
+                <LinearGradient
+                  colors={[C.amber, C.amberMid]}
+                  start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
+                  style={s.ctaBtn}
+                >
+                  <Text style={s.ctaLabel}>{copy.cta}</Text>
+                </LinearGradient>
+              )}
             </Pressable>
 
             {/* ─── Emergency link ─── */}
@@ -624,171 +623,217 @@ export default function ChildHubScreen() {
 // STYLES
 // ═══════════════════════════════════════════════
 
+const card = {
+  backgroundColor: C.surface,
+  borderWidth:     1,
+  borderColor:     C.border,
+  borderTopWidth:  1,
+  borderTopColor:  C.borderHi,
+  borderRadius:    18,
+  shadowColor:     '#000000',
+  shadowOffset:    { width: 0, height: 6 },
+  shadowOpacity:   0.35,
+  shadowRadius:    20,
+  elevation:       4,
+} as const;
+
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.base },
+  root: { flex: 1, backgroundColor: C.background },
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingBottom: 20, gap: 22 },
 
-  // Blobs
-  blob: { position: 'absolute', borderRadius: 999 },
-  blob1: {
-    top: -80, right: -60, width: 280, height: 280,
-    backgroundColor: 'rgba(253, 221, 230, 0.55)',
-  },
-  blob2: {
-    bottom: -60, left: -80, width: 240, height: 240,
-    backgroundColor: 'rgba(212, 232, 209, 0.50)',
-  },
-
   // Top bar
-  topBar: { flexDirection: 'row', alignItems: 'center', paddingTop: 4, paddingBottom: 4 },
-  backBtn: { paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted },
+  topBar:   { flexDirection: 'row', alignItems: 'center', paddingTop: 4, paddingBottom: 4 },
+  backBtn:  { paddingVertical: 6 },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
 
-  // Identity
+  // Identity (sits on warm parchment top zone)
   identityWrap: { alignItems: 'center', gap: 10, marginTop: 8 },
   avatar: {
-    width: 88, height: 88, borderRadius: 44,
-    backgroundColor: C.sage,
-    alignItems: 'center', justifyContent: 'center',
-    shadowColor: C.sage,
-    shadowOpacity: 0.25,
-    shadowRadius: 18,
-    shadowOffset: { width: 0, height: 6 },
-    elevation: 4,
+    width:          88,
+    height:         88,
+    borderRadius:   44,
+    backgroundColor: C.amber,
+    alignItems:     'center',
+    justifyContent: 'center',
+    shadowColor:    C.amber,
+    shadowOpacity:  0.35,
+    shadowRadius:   20,
+    shadowOffset:   { width: 0, height: 6 },
+    elevation:      4,
   },
   avatarText: { fontFamily: F.heading, fontSize: 36, color: '#FFFFFF', letterSpacing: -0.5 },
-  childName: { fontFamily: F.heading, fontSize: 28, color: '#FFFFFF', letterSpacing: -0.3, marginTop: 4 },
-  childAge: { fontFamily: F.body, fontSize: 14, color: 'rgba(255,255,255,0.72)' },
+  childName:  { fontFamily: F.heading, fontSize: 28, color: C.textDark, letterSpacing: -0.3, marginTop: 4 },
+  childAge:   { fontFamily: F.body, fontSize: 14, color: C.textDarkSecondary },
 
   // Textarea
   textareaCard: {
-    backgroundColor: C.cardGlass,
-    borderWidth: 1, borderColor: C.border,
-    borderRadius: 18, overflow: 'hidden',
+    backgroundColor: C.inputBg,
+    borderWidth:     1,
+    borderColor:     C.inputBorder,
+    borderTopWidth:  1,
+    borderTopColor:  C.inputHighlight,
+    borderRadius:    18,
+    overflow:        'hidden',
   },
-  textareaFocused: { borderColor: 'rgba(129,178,154,0.40)' },
+  textareaFocused: { borderColor: C.borderFocus },
   textarea: {
-    padding: 16, fontFamily: F.body, fontSize: 16,
-    color: C.text, lineHeight: 24, minHeight: 130,
+    padding:    16,
+    fontFamily: F.body,
+    fontSize:   16,
+    color:      C.text,
+    lineHeight: 24,
+    minHeight:  130,
   },
   textareaHint: {
-    fontFamily: F.body, fontSize: 12,
-    color: C.textMuted, fontStyle: 'italic',
-    paddingHorizontal: 16, paddingBottom: 12,
+    fontFamily:        F.body,
+    fontSize:          12,
+    color:             C.textMuted,
+    fontStyle:         'italic',
+    paddingHorizontal: 16,
+    paddingBottom:     12,
   },
 
   // Crisis banner
   crisisBanner: {
-    borderTopWidth: 1, borderTopColor: 'rgba(201,123,99,0.20)',
-    backgroundColor: 'rgba(201,123,99,0.06)',
+    borderTopWidth:  1,
+    borderTopColor:  'rgba(232,116,97,0.30)',
+    backgroundColor: C.sosLight,
   },
   crisisBannerInner: {
-    flexDirection: 'row', alignItems: 'center', gap: 10,
-    padding: 12, paddingHorizontal: 16,
+    flexDirection:     'row',
+    alignItems:        'center',
+    gap:               10,
+    padding:           12,
+    paddingHorizontal: 16,
   },
-  crisisIcon: { fontSize: 16 },
-  crisisTitle: { fontFamily: F.bodySemi, fontSize: 13, color: C.rose },
-  crisisSub: { fontFamily: F.body, fontSize: 11, color: C.textSub },
+  crisisIcon:  { fontSize: 16 },
+  crisisTitle: { fontFamily: F.bodySemi, fontSize: 13, color: C.sos },
+  crisisSub:   { fontFamily: F.body,     fontSize: 11, color: C.textSecondary },
 
   // Intensity
   intensitySection: { gap: 10 },
-  intensityHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  intensityLabel: { fontFamily: F.bodyMedium, fontSize: 14, color: C.text },
-  intensityOpt: { fontFamily: F.body, fontSize: 12, color: C.textMuted, fontStyle: 'italic' },
-  intensityRow: { flexDirection: 'row', gap: 6, flexWrap: 'wrap' },
+  intensityHeader:  { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  intensityLabel:   { fontFamily: F.bodyMedium, fontSize: 14, color: C.text },
+  intensityOpt:     { fontFamily: F.body, fontSize: 12, color: C.textMuted, fontStyle: 'italic' },
+  intensityRow:     { flexDirection: 'row', gap: 6, flexWrap: 'wrap' },
   intensityPill: {
-    flex: 1, minWidth: 60,
-    paddingVertical: 10, paddingHorizontal: 8, borderRadius: 12,
-    backgroundColor: C.cardGlass,
-    borderWidth: 1, borderColor: C.border,
-    alignItems: 'center', justifyContent: 'center',
+    flex:              1,
+    minWidth:          60,
+    paddingVertical:   10,
+    paddingHorizontal: 8,
+    borderRadius:      12,
+    backgroundColor:   C.surface,
+    borderWidth:       1,
+    borderColor:       C.border,
+    borderTopWidth:    1,
+    borderTopColor:    C.borderHi,
+    alignItems:        'center',
+    justifyContent:    'center',
   },
-  intensityPillText: { fontFamily: F.bodyMedium, fontSize: 12, color: C.textSub },
+  intensityPillText: { fontFamily: F.bodyMedium, fontSize: 12, color: C.textSecondary },
 
   // Error
-  errorText: { fontFamily: F.body, fontSize: 14, color: C.rose, textAlign: 'center' },
+  errorText: { fontFamily: F.body, fontSize: 14, color: C.sos, textAlign: 'center' },
 
   // CTA
- ctaBtn: {
-    backgroundColor: '#C8883A',
-    shadowColor:     '#D4944A',
-    shadowOffset:    { width: 0, height: 4 },
-    shadowOpacity:   0.40,
-    shadowRadius:    12,
-    elevation:       8,
+  ctaBtn: {
+    minHeight:      56,
+    borderRadius:   18,
+    alignItems:     'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    shadowColor:    C.amber,
+    shadowOffset:   { width: 0, height: 6 },
+    shadowOpacity:  0.35,
+    shadowRadius:   20,
+    elevation:      4,
   },
-  ctaBtnDisabled: { backgroundColor: 'rgba(0,0,0,0.06)' },
-  ctaLabel: { fontFamily: F.subheading, fontSize: 17, color: '#FFFFFF', letterSpacing: 0.3 },
+  ctaBtnDisabled: { backgroundColor: C.disabled, shadowOpacity: 0, elevation: 0 },
+  ctaLabel:       { fontFamily: F.subheading, fontSize: 17, color: '#FFFFFF', letterSpacing: 0.3 },
 
-  emergencyBtn: { alignSelf: 'center', paddingVertical: 6 },
-  emergencyText: { fontFamily: F.body, fontSize: 12, color: C.textMuted, textDecorationLine: 'underline' },
+  emergencyBtn:  { alignSelf: 'center', paddingVertical: 6 },
+  emergencyText: { fontFamily: F.body, fontSize: 12, color: C.sos, textDecorationLine: 'underline' },
 
   // Saved scripts
   savedSection: { gap: 10, marginTop: 8 },
   sectionHeader: {
-    flexDirection: 'row', alignItems: 'baseline', justifyContent: 'space-between',
+    flexDirection:  'row',
+    alignItems:     'baseline',
+    justifyContent: 'space-between',
   },
   sectionTitle: { fontFamily: F.bodySemi, fontSize: 15, color: C.text },
-  sectionLink: { fontFamily: F.bodyMedium, fontSize: 13, color: C.rose },
+  sectionLink:  { fontFamily: F.bodyMedium, fontSize: 13, color: C.amberLight },
 
   savedScroll: { gap: 10, paddingRight: 4 },
   savedCard: {
-    width: 220,
-    padding: 14, gap: 6,
+    ...card,
+    width:        220,
+    padding:      14,
+    gap:          6,
     borderRadius: 16,
-    backgroundColor: C.cardGlass,
-    borderWidth: 1, borderColor: C.border,
   },
-  savedDate: { fontFamily: F.body, fontSize: 11, color: C.textMuted },
-  savedTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.text, lineHeight: 20 },
-  savedPreview: {
-    fontFamily: F.scriptItalic, fontSize: 13, color: C.textBody, lineHeight: 19,
-  },
+  savedDate:    { fontFamily: F.body, fontSize: 11, color: C.textMuted },
+  savedTitle:   { fontFamily: F.bodySemi, fontSize: 14, color: C.text, lineHeight: 20 },
+  savedPreview: { fontFamily: F.scriptItalic, fontSize: 13, color: C.textSecondary, lineHeight: 19 },
 
   // Tone selector
   toneSection: { gap: 8 },
-  toneHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  toneLabel: { fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, letterSpacing: 0.3 },
+  toneHeader:  { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  toneLabel:   { fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, letterSpacing: 0.3 },
   tonePremiumPill: {
-    fontFamily: F.label, fontSize: 9, letterSpacing: 0.8,
-    color: C.amber, backgroundColor: 'rgba(247,149,102,0.12)',
-    paddingHorizontal: 8, paddingVertical: 3,
-    borderRadius: 999, overflow: 'hidden',
+    fontFamily:        F.label,
+    fontSize:          9,
+    letterSpacing:     0.8,
+    color:             C.amber,
+    backgroundColor:   C.amberBadge,
+    paddingHorizontal: 8,
+    paddingVertical:   3,
+    borderRadius:      999,
+    overflow:          'hidden',
   },
   toneRow: { flexDirection: 'row', gap: 8 },
   tonePill: {
-    flex: 1, padding: 12, gap: 4,
-    borderRadius: 14,
-    backgroundColor: C.cardGlass,
-    borderColor: C.border, borderWidth: 1,
+    flex:            1,
+    padding:         12,
+    gap:             4,
+    borderRadius:    14,
+    backgroundColor: C.surface,
+    borderColor:     C.border,
+    borderWidth:     1,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
   },
   tonePillSelected: {
-    backgroundColor: 'rgba(247,149,102,0.10)',
-    borderColor: 'rgba(247,149,102,0.45)',
+    backgroundColor: 'rgba(200,136,58,0.08)',
+    borderColor:     C.amber,
   },
-  toneTopRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  tonePillLabel: { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
+  toneTopRow:            { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  tonePillLabel:         { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
   tonePillLabelSelected: { color: C.amber },
-  tonePillSub: { fontFamily: F.body, fontSize: 11, color: C.textSub },
-  toneLockIcon: { fontSize: 11 },
+  tonePillSub:           { fontFamily: F.body, fontSize: 11, color: C.textSecondary },
+  toneLockIcon:          { fontSize: 11, color: C.amber },
 
   // Insights / profile-link card
   insightsSection: {
-    padding: 16, gap: 6,
-    borderRadius: 16,
-    backgroundColor: 'rgba(129,178,154,0.08)',
-    borderWidth: 1, borderColor: 'rgba(129,178,154,0.18)',
+    ...card,
+    padding:         16,
+    gap:             6,
+    borderRadius:    16,
+    backgroundColor: C.sageLight,
+    borderColor:     'rgba(138,160,96,0.30)',
   },
-  insightsRow:    { flexDirection: 'row', alignItems: 'center', gap: 12 },
-  insightsTitle:  { fontFamily: F.bodySemi, fontSize: 14, color: C.sage },
-  insightsBody:   { fontFamily: F.body, fontSize: 13, color: C.textBody, lineHeight: 20 },
-  insightsArrow:  { fontFamily: F.bodySemi, fontSize: 18, color: C.sage },
+  insightsRow:   { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  insightsTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.sage },
+  insightsBody:  { fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 20 },
+  insightsArrow: { fontFamily: F.bodySemi, fontSize: 18, color: C.sage },
 
   // Edit
-  editBtn: { alignSelf: 'center', paddingVertical: 8 },
+  editBtn:  { alignSelf: 'center', paddingVertical: 8 },
   editText: {
-    fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted,
+    fontFamily:         F.bodyMedium,
+    fontSize:           13,
+    color:              C.textMuted,
     textDecorationLine: 'underline',
   },
 });

--- a/apps/mobile/app/child/new.tsx
+++ b/apps/mobile/app/child/new.tsx
@@ -271,14 +271,14 @@ const st = StyleSheet.create({
   scroll: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 24, gap: 20 },
 
   back:     { alignSelf: 'flex-start', paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 16, color: C.textDarkSecondary },
+  backText: { fontFamily: F.bodyMedium, fontSize: 16, color: C.textSecondary },
 
   logoWrap: { alignItems: 'center' },
   logo:     { width: 44, height: 44 },
 
   header:   { alignItems: 'center', gap: 6 },
-  title:    { fontFamily: F.heading, fontSize: 26, color: C.textDark, textAlign: 'center', letterSpacing: -0.3 },
-  subtitle: { fontFamily: F.body, fontSize: 14, color: C.textDarkSecondary, textAlign: 'center' },
+  title:    { fontFamily: F.heading, fontSize: 26, color: C.text, textAlign: 'center', letterSpacing: -0.3 },
+  subtitle: { fontFamily: F.body, fontSize: 14, color: C.textSecondary, textAlign: 'center' },
 
   formCard: {
     backgroundColor: C.surface,

--- a/apps/mobile/app/child/new.tsx
+++ b/apps/mobile/app/child/new.tsx
@@ -41,22 +41,6 @@ function getAgeHint(age: number): string {
   return 'Sturdy will use near-adult tone with warmth and respect';
 }
 
-// ─── Stars ───
-function Stars({ count = 25 }: { count?: number }) {
-  const [stars] = useState(() =>
-    Array.from({ length: count }, () => ({
-      top: Math.random() * 40, left: Math.random() * 100,
-      size: Math.random() * 1.8 + 0.4, opacity: Math.random() * 0.2 + 0.04,
-    }))
-  );
-  return (
-    <View style={{ position: 'absolute', top: 0, left: 0, right: 0, height: '40%', zIndex: 1 }} pointerEvents="none">
-      {stars.map((s, i) => (
-        <View key={i} style={{ position: 'absolute', top: `${s.top}%` as any, left: `${s.left}%` as any, width: s.size, height: s.size, opacity: s.opacity, borderRadius: 10, backgroundColor: '#FFF' }} />
-      ))}
-    </View>
-  );
-}
 
 // ─── Main ───
 export default function NewChildScreen() {
@@ -108,18 +92,18 @@ export default function NewChildScreen() {
     <SafeAreaView style={st.root} edges={['top', 'bottom']}>
       <StatusBar style="light" />
 
-      {/* Background */}
+      {/* Background — C-2 fast-fade gradient */}
       <LinearGradient
-        colors={['#0e0a10', '#14101a', '#1a1622', '#1e1a28', '#201c2a', '#1e1a24', '#1a1620', '#18141e', '#14101a']}
-        locations={[0, 0.10, 0.22, 0.35, 0.48, 0.60, 0.72, 0.85, 1]}
+        colors={[
+          C.gradientTop,
+          C.gradientMid1,
+          C.gradientMid2,
+          C.gradientMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
         style={StyleSheet.absoluteFill}
-      />
-      <Stars />
-      <LinearGradient
-        colors={['transparent', 'rgba(212,148,74,0.03)', 'rgba(212,148,74,0.06)']}
-        locations={[0, 0.5, 1]}
-        style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: '40%', zIndex: 1 }}
-        pointerEvents="none"
       />
 
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1 }}>
@@ -144,12 +128,7 @@ export default function NewChildScreen() {
           </View>
 
           {/* ── Name + Age Card ── */}
-          <LinearGradient
-            colors={['rgba(255,255,255,0.08)', 'rgba(255,255,255,0.02)', 'rgba(0,0,0,0.12)']}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 0.8, y: 1 }}
-            style={st.formCard}
-          >
+          <View style={st.formCard}>
             {/* Name */}
             <View style={st.field}>
               <Text style={st.fieldLabel}>Child's name</Text>
@@ -159,7 +138,7 @@ export default function NewChildScreen() {
                   autoCapitalize="words"
                   autoCorrect={false}
                   placeholder="e.g. Emma"
-                  placeholderTextColor="rgba(255,255,255,0.18)"
+                  placeholderTextColor={C.inputPlaceholder}
                   value={name}
                   onChangeText={v => { setName(v); if (error) setError(''); }}
                   onFocus={() => setNameFocused(true)}
@@ -201,7 +180,7 @@ export default function NewChildScreen() {
               <View style={st.sliderWrap}>
                 <View style={st.sliderTrack}>
                   <LinearGradient
-                    colors={[C.amber, C.peach]}
+                    colors={[C.amber, C.amberMid]}
                     start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
                     style={[st.sliderFill, { width: `${sliderProgress}%` as any }]}
                   />
@@ -218,7 +197,7 @@ export default function NewChildScreen() {
                 <Text style={st.hintText}>{getAgeHint(age)}</Text>
               </View>
             </View>
-          </LinearGradient>
+          </View>
 
           {/* ── Personality Notes ── */}
           <Pressable onPress={() => setShowNotes(v => !v)} style={st.notesToggle}>
@@ -229,24 +208,20 @@ export default function NewChildScreen() {
           </Pressable>
 
           {showNotes && (
-            <LinearGradient
-              colors={['rgba(255,255,255,0.06)', 'rgba(255,255,255,0.02)', 'rgba(0,0,0,0.10)']}
-              start={{ x: 0, y: 0 }} end={{ x: 0.8, y: 1 }}
-              style={st.notesCard}
-            >
+            <View style={st.notesCard}>
               <Text style={st.notesLabel}>PERSONALITY & WHAT HELPS</Text>
               <TextInput
                 multiline
                 numberOfLines={4}
                 placeholder="e.g. Very sensitive to tone of voice. Needs 5 min warning before transitions."
-                placeholderTextColor="rgba(255,255,255,0.18)"
+                placeholderTextColor={C.inputPlaceholder}
                 value={notes}
                 onChangeText={setNotes}
                 style={st.notesInput}
                 textAlignVertical="top"
               />
               <Text style={st.notesHint}>This helps Claude write scripts that feel personal.</Text>
-            </LinearGradient>
+            </View>
           )}
 
           {error ? <Text style={st.error}>{error}</Text> : null}
@@ -264,13 +239,21 @@ export default function NewChildScreen() {
               (!canSave || saving) && { opacity: 0.35 },
             ]}
           >
-            <LinearGradient
-              colors={canSave ? ['#C8883A', '#E8A855'] : ['rgba(255,255,255,0.06)', 'rgba(255,255,255,0.04)']}
-              start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
-              style={st.saveBtn}
-            >
-              <Text style={st.saveBtnText}>{saving ? 'Saving…' : 'Add child'}</Text>
-            </LinearGradient>
+            {canSave ? (
+              <LinearGradient
+                colors={[C.amber, C.amberMid]}
+                start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
+                style={st.saveBtn}
+              >
+                <Text style={st.saveBtnText}>{saving ? 'Saving…' : 'Add child'}</Text>
+              </LinearGradient>
+            ) : (
+              <View style={[st.saveBtn, st.saveBtnDisabled]}>
+                <Text style={[st.saveBtnText, { color: C.disabledText }]}>
+                  {saving ? 'Saving…' : 'Add child'}
+                </Text>
+              </View>
+            )}
           </Pressable>
 
           <Pressable onPress={() => router.replace('/(tabs)')} style={st.skipBtn}>
@@ -284,64 +267,121 @@ export default function NewChildScreen() {
 
 // ─── Styles ───
 const st = StyleSheet.create({
-  root: { flex: 1, backgroundColor: '#0e0a10' },
+  root: { flex: 1, backgroundColor: C.background },
   scroll: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 24, gap: 20 },
 
-  back: { alignSelf: 'flex-start', paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 16, color: 'rgba(255,255,255,0.30)' },
+  back:     { alignSelf: 'flex-start', paddingVertical: 6 },
+  backText: { fontFamily: F.bodyMedium, fontSize: 16, color: C.textDarkSecondary },
 
   logoWrap: { alignItems: 'center' },
-  logo: { width: 44, height: 44 },
+  logo:     { width: 44, height: 44 },
 
-  header: { alignItems: 'center', gap: 6 },
-  title: { fontFamily: F.heading, fontSize: 26, color: C.text, textAlign: 'center', letterSpacing: -0.3 },
-  subtitle: { fontFamily: F.body, fontSize: 14, color: C.textSub, textAlign: 'center' },
+  header:   { alignItems: 'center', gap: 6 },
+  title:    { fontFamily: F.heading, fontSize: 26, color: C.textDark, textAlign: 'center', letterSpacing: -0.3 },
+  subtitle: { fontFamily: F.body, fontSize: 14, color: C.textDarkSecondary, textAlign: 'center' },
 
   formCard: {
-    borderRadius: 24, padding: 22, gap: 24, borderWidth: 1,
-    borderTopColor: 'rgba(255,255,255,0.18)', borderLeftColor: 'rgba(255,255,255,0.08)',
-    borderRightColor: 'rgba(0,0,0,0.08)', borderBottomColor: 'rgba(0,0,0,0.12)',
+    backgroundColor: C.surface,
+    borderRadius:    24,
+    padding:         22,
+    gap:             24,
+    borderWidth:     1,
+    borderColor:     C.border,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
+    shadowColor:     '#000000',
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
   },
-  field: { gap: 10 },
-  fieldLabel: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textBody },
+  field:      { gap: 10 },
+  fieldLabel: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textSecondary },
 
-  inputWrap: { borderRadius: 14, backgroundColor: 'rgba(255,255,255,0.05)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.08)' },
-  inputFocused: { borderColor: 'rgba(87,120,163,0.35)' },
-  nameInput: { fontFamily: F.body, fontSize: 16, color: C.text, paddingHorizontal: 16, paddingVertical: 13 },
+  inputWrap: {
+    borderRadius:    14,
+    backgroundColor: C.inputBg,
+    borderWidth:     1,
+    borderColor:     C.inputBorder,
+    borderTopWidth:  1,
+    borderTopColor:  C.inputHighlight,
+  },
+  inputFocused: { borderColor: C.borderFocus },
+  nameInput:    { fontFamily: F.body, fontSize: 16, color: C.text, paddingHorizontal: 16, paddingVertical: 13 },
 
   agePickerRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 20 },
-  ageArrowBtn: { width: 44, height: 44, borderRadius: 22, backgroundColor: 'rgba(255,255,255,0.06)', borderWidth: 1, borderColor: 'rgba(255,255,255,0.10)', alignItems: 'center', justifyContent: 'center' },
-  ageArrowDisabled: { opacity: 0.3 },
-  ageArrowText: { fontFamily: F.heading, fontSize: 22, color: C.textBody, marginTop: -2 },
+  ageArrowBtn: {
+    width:           44,
+    height:          44,
+    borderRadius:    22,
+    backgroundColor: C.chipBg,
+    borderWidth:     1,
+    borderColor:     C.chipBorder,
+    alignItems:      'center',
+    justifyContent:  'center',
+  },
+  ageArrowDisabled:     { opacity: 0.3 },
+  ageArrowText:         { fontFamily: F.heading, fontSize: 22, color: C.text, marginTop: -2 },
   ageArrowTextDisabled: { color: C.textMuted },
-  ageDisplay: { alignItems: 'center', minWidth: 60 },
-  ageNumber: { fontFamily: F.heading, fontSize: 42, color: C.amber, lineHeight: 48 },
-  ageUnit: { fontFamily: F.body, fontSize: 13, color: C.textMuted, marginTop: -2 },
+  ageDisplay:           { alignItems: 'center', minWidth: 60 },
+  ageNumber:            { fontFamily: F.heading, fontSize: 42, color: C.amber, lineHeight: 48 },
+  ageUnit:              { fontFamily: F.body, fontSize: 13, color: C.textMuted, marginTop: -2 },
 
-  sliderWrap: { gap: 4 },
-  sliderTrack: { height: 4, borderRadius: 2, backgroundColor: 'rgba(255,255,255,0.08)', overflow: 'hidden' },
-  sliderFill: { height: 4, borderRadius: 2 },
+  sliderWrap:   { gap: 4 },
+  sliderTrack:  { height: 4, borderRadius: 2, backgroundColor: C.divider, overflow: 'hidden' },
+  sliderFill:   { height: 4, borderRadius: 2 },
   sliderLabels: { flexDirection: 'row', justifyContent: 'space-between' },
-  sliderLabel: { fontFamily: F.body, fontSize: 11, color: C.textMuted },
+  sliderLabel:  { fontFamily: F.body, fontSize: 11, color: C.textMuted },
 
-  hintCard: { flexDirection: 'row', alignItems: 'center', gap: 8, backgroundColor: 'rgba(138,160,96,0.08)', borderRadius: 12, borderWidth: 1, borderColor: 'rgba(138,160,96,0.15)', paddingHorizontal: 14, paddingVertical: 10 },
+  hintCard: {
+    flexDirection:     'row',
+    alignItems:        'center',
+    gap:               8,
+    backgroundColor:   'rgba(200,136,58,0.08)',
+    borderRadius:      12,
+    borderWidth:       1,
+    borderColor:       C.amberBorder,
+    paddingHorizontal: 14,
+    paddingVertical:   10,
+  },
   hintIcon: { fontSize: 18 },
-  hintText: { fontFamily: F.body, fontSize: 13, color: C.sage, flex: 1, lineHeight: 19 },
+  hintText: { fontFamily: F.body, fontSize: 13, color: C.amberLight, flex: 1, lineHeight: 19 },
 
-  notesToggle: { paddingVertical: 4 },
-  notesToggleText: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textMuted },
-  notesToggleSub: { fontFamily: F.body, fontSize: 13, color: C.textGhost },
+  notesToggle:     { paddingVertical: 4 },
+  notesToggleText: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textSecondary },
+  notesToggleSub:  { fontFamily: F.body, fontSize: 13, color: C.textMuted },
 
-  notesCard: { borderRadius: 24, padding: 22, gap: 12, borderWidth: 1, borderTopColor: 'rgba(255,255,255,0.12)', borderLeftColor: 'rgba(255,255,255,0.06)', borderRightColor: 'rgba(0,0,0,0.06)', borderBottomColor: 'rgba(0,0,0,0.10)' },
+  notesCard: {
+    backgroundColor: C.surface,
+    borderRadius:    24,
+    padding:         22,
+    gap:             12,
+    borderWidth:     1,
+    borderColor:     C.border,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
+  },
   notesLabel: { fontFamily: F.label, fontSize: 10, letterSpacing: 0.8, color: C.textMuted },
   notesInput: { fontFamily: F.body, fontSize: 15, color: C.text, lineHeight: 24, minHeight: 100 },
-  notesHint: { fontFamily: F.body, fontSize: 12, color: C.textMuted, fontStyle: 'italic' },
+  notesHint:  { fontFamily: F.body, fontSize: 12, color: C.textMuted, fontStyle: 'italic' },
 
-  error: { fontFamily: F.body, fontSize: 13, color: C.coral },
+  error: { fontFamily: F.body, fontSize: 13, color: C.sos },
 
   footer: { paddingHorizontal: 24, paddingVertical: 14, paddingBottom: 28, gap: 10, alignItems: 'center' },
-  saveBtn: { width: W - 48, minHeight: 56, borderRadius: 18, alignItems: 'center', justifyContent: 'center' },
-  saveBtnText: { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
-  skipBtn: { paddingVertical: 8 },
-  skipText: { fontFamily: F.body, fontSize: 14, color: C.textMuted },
+  saveBtn: {
+    width:          W - 48,
+    minHeight:      56,
+    borderRadius:   18,
+    alignItems:     'center',
+    justifyContent: 'center',
+    shadowColor:    C.amber,
+    shadowOffset:   { width: 0, height: 6 },
+    shadowOpacity:  0.35,
+    shadowRadius:   20,
+    elevation:      4,
+  },
+  saveBtnDisabled: { backgroundColor: C.disabled, shadowOpacity: 0, elevation: 0 },
+  saveBtnText:     { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
+  skipBtn:         { paddingVertical: 8 },
+  skipText:        { fontFamily: F.body, fontSize: 14, color: C.textMuted },
 });

--- a/apps/mobile/app/crisis.tsx
+++ b/apps/mobile/app/crisis.tsx
@@ -1,7 +1,6 @@
 // app/crisis.tsx
-// v8 — Journal identity: pastel gradient, frosted glass, calm blue cards
-// Calm, warm, no red, no alarm aesthetics
-// Per SAFETY_SYSTEM.md: "invisible infrastructure — protects without alarming"
+// v9 — Deep Warm v5.2: result-variant gradient, dark glass cards with calm
+// steel accents. No red, no alarm. "Invisible infrastructure" still applies.
 
 import { Pressable, ScrollView, StyleSheet, Text, View, Linking } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -111,13 +110,21 @@ export default function CrisisScreen() {
   };
 
   return (
-    <SafeAreaView style={s.root} edges={['top', 'bottom']}>
-      <StatusBar style="dark" />
+    <View style={s.root}>
+      <StatusBar style="light" />
       <LinearGradient
-        colors={[C.gradStart, C.gradMid1, C.gradMid2, C.gradEnd]}
-        start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+        colors={[
+          C.gradientResultTop,
+          C.gradientResultMid1,
+          C.gradientResultMid2,
+          C.gradientResultMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
         style={StyleSheet.absoluteFill}
       />
+      <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
 
       <ScrollView contentContainerStyle={s.scroll} showsVerticalScrollIndicator={false}>
         <Pressable onPress={() => router.back()} style={s.backBtn} hitSlop={12}>
@@ -175,50 +182,79 @@ export default function CrisisScreen() {
 
         <View style={{ height: 40 }} />
       </ScrollView>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
+const card = {
+  backgroundColor: C.surface,
+  borderWidth:     1,
+  borderColor:     C.border,
+  borderTopWidth:  1,
+  borderTopColor:  C.borderHi,
+  borderRadius:    18,
+  shadowColor:     '#000000',
+  shadowOffset:    { width: 0, height: 6 },
+  shadowOpacity:   0.35,
+  shadowRadius:    20,
+  elevation:       4,
+} as const;
+
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.base },
+  root: { flex: 1, backgroundColor: C.background },
   scroll: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 60, gap: 16 },
 
-  backBtn: { alignSelf: 'flex-start', paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted },
+  backBtn:  { alignSelf: 'flex-start', paddingVertical: 6 },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
 
   groundingCard: {
-    borderRadius: 18, padding: 18, alignItems: 'center',
-    backgroundColor: 'rgba(87,120,163,0.06)', borderWidth: 1, borderColor: 'rgba(87,120,163,0.12)',
+    ...card,
+    padding:    18,
+    alignItems: 'center',
+    backgroundColor: C.steelLight,
+    borderColor:     'rgba(87,120,163,0.20)',
   },
-  groundingText: { fontFamily: F.bodyMedium, fontSize: 16, color: C.textSub, lineHeight: 24, textAlign: 'center' },
+  groundingText: { fontFamily: F.bodyMedium, fontSize: 16, color: C.text, lineHeight: 24, textAlign: 'center' },
 
-  header: { gap: 12, marginTop: 4 },
-  title: { fontFamily: F.heading, fontSize: 28, color: C.text, letterSpacing: -0.3 },
-  message: { fontFamily: F.body, fontSize: 16, color: C.text, lineHeight: 25 },
+  header:  { gap: 12, marginTop: 4 },
+  title:   { fontFamily: F.heading, fontSize: 28, color: C.textDark, letterSpacing: -0.3 },
+  message: { fontFamily: F.body, fontSize: 16, color: C.textDark, lineHeight: 25 },
 
   resources: { gap: 12 },
   resourceCard: {
-    borderRadius: 18, padding: 18, flexDirection: 'row', alignItems: 'center', gap: 12,
-    backgroundColor: C.cardGlass, borderWidth: 1, borderColor: 'rgba(87,120,163,0.12)',
+    ...card,
+    padding:        18,
+    flexDirection:  'row',
+    alignItems:     'center',
+    gap:            12,
+    borderColor:    'rgba(87,120,163,0.20)',
   },
-  resourceLabel: { fontFamily: F.bodySemi, fontSize: 16, color: C.text },
-  resourceDetail: { fontFamily: F.body, fontSize: 14, color: C.textSub },
+  resourceLabel:  { fontFamily: F.bodySemi, fontSize: 16, color: C.text },
+  resourceDetail: { fontFamily: F.body,     fontSize: 14, color: C.textSecondary },
   resourceArrow: {
-    width: 36, height: 36, borderRadius: 12,
-    backgroundColor: 'rgba(87,120,163,0.10)', borderWidth: 1, borderColor: 'rgba(87,120,163,0.20)',
-    alignItems: 'center', justifyContent: 'center',
+    width:           36,
+    height:          36,
+    borderRadius:    12,
+    backgroundColor: C.steelLight,
+    borderWidth:     1,
+    borderColor:     'rgba(87,120,163,0.30)',
+    alignItems:      'center',
+    justifyContent:  'center',
   },
-  resourceArrowText: { fontSize: 16, color: '#5778A3', fontFamily: F.bodySemi },
+  resourceArrowText: { fontSize: 16, color: C.steel, fontFamily: F.bodySemi },
 
-  reassurance: { paddingVertical: 8 },
+  reassurance:     { paddingVertical: 8 },
   reassuranceText: { fontFamily: F.body, fontSize: 13, color: C.textMuted, lineHeight: 20, textAlign: 'center' },
 
   actions: { gap: 16, alignItems: 'center' },
   safeBtn: {
-    borderRadius: 18, paddingVertical: 16, alignItems: 'center', width: '100%',
-    backgroundColor: C.cardGlass, borderWidth: 1, borderColor: C.border,
+    ...card,
+    paddingVertical: 16,
+    alignItems:      'center',
+    width:           '100%',
   },
   safeBtnText: { fontFamily: F.bodySemi, fontSize: 16, color: C.text },
-  homeLink: { fontFamily: F.bodyMedium, fontSize: 14, color: C.textMuted },
+  homeLink:    { fontFamily: F.bodyMedium, fontSize: 14, color: C.textMuted },
 });
 

--- a/apps/mobile/app/crisis.tsx
+++ b/apps/mobile/app/crisis.tsx
@@ -206,7 +206,7 @@ const s = StyleSheet.create({
   scroll: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 60, gap: 16 },
 
   backBtn:  { alignSelf: 'flex-start', paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textSecondary },
 
   groundingCard: {
     ...card,
@@ -218,8 +218,8 @@ const s = StyleSheet.create({
   groundingText: { fontFamily: F.bodyMedium, fontSize: 16, color: C.text, lineHeight: 24, textAlign: 'center' },
 
   header:  { gap: 12, marginTop: 4 },
-  title:   { fontFamily: F.heading, fontSize: 28, color: C.textDark, letterSpacing: -0.3 },
-  message: { fontFamily: F.body, fontSize: 16, color: C.textDark, lineHeight: 25 },
+  title:   { fontFamily: F.heading, fontSize: 28, color: C.text, letterSpacing: -0.3 },
+  message: { fontFamily: F.body, fontSize: 16, color: C.text, lineHeight: 25 },
 
   resources: { gap: 12 },
   resourceCard: {

--- a/apps/mobile/app/history.tsx
+++ b/apps/mobile/app/history.tsx
@@ -141,7 +141,7 @@ export default function HistoryScreen() {
       {/* Loading */}
       {loading ? (
         <View style={st.center}>
-          <ActivityIndicator color={colors.coral} size="large" />
+          <ActivityIndicator color={colors.sos} size="large" />
         </View>
       ) : error ? (
         <View style={st.center}>
@@ -216,7 +216,7 @@ const st = StyleSheet.create({
   back: { alignSelf: 'flex-start', paddingVertical: 4 },
   backText: { fontFamily: F.bodyMedium, fontSize: 15, color: colors.textMuted },
   title: { fontFamily: F.heading, fontSize: 26, color: colors.text },
-  subtitle: { fontFamily: F.body, fontSize: 14, color: colors.textSub },
+  subtitle: { fontFamily: F.body, fontSize: 14, color: colors.textSecondary },
 
   center: {
     flex: 1,
@@ -225,17 +225,17 @@ const st = StyleSheet.create({
     gap: 12,
     paddingVertical: 60,
   },
-  errorText: { fontFamily: F.body, fontSize: 14, color: colors.danger },
-  retryText: { fontFamily: F.bodySemi, fontSize: 14, color: colors.coral },
+  errorText: { fontFamily: F.body, fontSize: 14, color: colors.sos },
+  retryText: { fontFamily: F.bodySemi, fontSize: 14, color: colors.sos },
 
   emptyIcon: { fontSize: 40, marginBottom: 8 },
   emptyTitle: { fontFamily: F.bodySemi, fontSize: 18, color: colors.text },
   emptyBody: {
-    fontFamily: F.body, fontSize: 14, color: colors.textSub,
+    fontFamily: F.body, fontSize: 14, color: colors.textSecondary,
     textAlign: 'center', lineHeight: 20, maxWidth: 260,
   },
   emptyBtn: {
-    backgroundColor: colors.coral,
+    backgroundColor: colors.sos,
     borderRadius: 14,
     paddingVertical: 12,
     paddingHorizontal: 24,
@@ -250,10 +250,10 @@ const st = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
   },
-  itemMode: { fontFamily: F.bodySemi, fontSize: 13, color: colors.textBody },
+  itemMode: { fontFamily: F.bodySemi, fontSize: 13, color: colors.textSecondary },
   itemDate: { fontFamily: F.body, fontSize: 12, color: colors.textMuted },
   itemSummary: {
-    fontFamily: F.body, fontSize: 15, color: colors.textBody,
+    fontFamily: F.body, fontSize: 15, color: colors.textSecondary,
     lineHeight: 22, marginTop: 4,
   },
   itemMeta: {
@@ -263,12 +263,12 @@ const st = StyleSheet.create({
   },
   itemChild: {
     fontFamily: F.bodyMedium, fontSize: 12, color: colors.textMuted,
-    backgroundColor: colors.subtle,
+    backgroundColor: colors.divider,
     paddingHorizontal: 8, paddingVertical: 2, borderRadius: 8,
   },
   itemTrigger: {
     fontFamily: F.bodyMedium, fontSize: 12, color: colors.textMuted,
-    backgroundColor: colors.subtle,
+    backgroundColor: colors.divider,
     paddingHorizontal: 8, paddingVertical: 2, borderRadius: 8,
   },
 });

--- a/apps/mobile/app/result.tsx
+++ b/apps/mobile/app/result.tsx
@@ -412,7 +412,7 @@ const s = StyleSheet.create({
 
   backRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   back: { alignSelf: 'flex-start', paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textSecondary },
   homeBtn: { paddingVertical: 6, paddingHorizontal: 10 },
   homeBtnText: { fontSize: 20 },
 
@@ -420,11 +420,11 @@ const s = StyleSheet.create({
   fallbackTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.sage },
   fallbackBody: { fontFamily: F.body, fontSize: 13, color: C.textSecondary },
 
-  summary: { fontFamily: F.scriptItalic, fontSize: 21, color: C.textDark, lineHeight: 30, marginBottom: 8 },
+  summary: { fontFamily: F.scriptItalic, fontSize: 21, color: C.text, lineHeight: 30, marginBottom: 8 },
   tagRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   ava: { width: 22, height: 22, borderRadius: 11, backgroundColor: C.sage, alignItems: 'center', justifyContent: 'center' },
   avaText: { fontFamily: F.bodySemi, fontSize: 10, color: '#FFFFFF' },
-  tagText: { fontFamily: F.body, fontSize: 12, color: C.textDarkSecondary },
+  tagText: { fontFamily: F.body, fontSize: 12, color: C.textSecondary },
 
   safetyLink: { flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 2 },
   safetyIcon: { color: C.sos, fontSize: 16 },

--- a/apps/mobile/app/result.tsx
+++ b/apps/mobile/app/result.tsx
@@ -103,7 +103,7 @@ function PulsingDot() {
     Animated.timing(anim, { toValue: 1, duration: 600, useNativeDriver: true }),
     Animated.timing(anim, { toValue: 0.4, duration: 600, useNativeDriver: true }),
   ])).start(); }, [anim]);
-  return <Animated.View style={[{ width: 6, height: 6, borderRadius: 3, backgroundColor: C.rose }, { opacity: anim }]} />;
+  return <Animated.View style={[{ width: 6, height: 6, borderRadius: 3, backgroundColor: C.sos }, { opacity: anim }]} />;
 }
 
 // ═══════════════════════════════════════════════
@@ -227,9 +227,21 @@ const handleRetry = () => {
   const showEscalationHelp = feedbackGiven && feedbackHelpful === 'no';
 
   return (
-    <SafeAreaView style={s.root} edges={['top']}>
-      <StatusBar style="dark" />
-      <LinearGradient colors={[C.gradStart, C.gradMid1, C.gradMid2, C.gradEnd]} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={StyleSheet.absoluteFill} />
+    <View style={s.root}>
+      <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          C.gradientResultTop,
+          C.gradientResultMid1,
+          C.gradientResultMid2,
+          C.gradientResultMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={{ flex: 1 }} edges={['top']}>
 
       <ScrollView contentContainerStyle={s.scroll} showsVerticalScrollIndicator={false}>
         {/* Back */}
@@ -355,7 +367,12 @@ const handleRetry = () => {
 
       {/* Footer */}
       <View style={s.footer}>
-        <LinearGradient colors={['transparent', 'rgba(253,250,245,0.95)', C.base]} locations={[0, 0.35, 0.75]} style={s.footerFade} pointerEvents="none" />
+        <LinearGradient
+          colors={['transparent', 'rgba(12,12,12,0.85)', C.background]}
+          locations={[0, 0.35, 0.75]}
+          style={s.footerFade}
+          pointerEvents="none"
+        />
         <View style={s.footerContent}>
           <View style={s.footerRow}>
             <Pressable onPress={handleSave} disabled={saved || saving} style={({ pressed }) => [s.footerGhost, pressed && { opacity: 0.7 }]}>
@@ -370,84 +387,99 @@ const handleRetry = () => {
           </View>
         </View>
       </View>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
+const card = {
+  backgroundColor: C.surface,
+  borderWidth:     1,
+  borderColor:     C.border,
+  borderTopWidth:  1,
+  borderTopColor:  C.borderHi,
+  borderRadius:    18,
+  shadowColor:     '#000000',
+  shadowOffset:    { width: 0, height: 6 },
+  shadowOpacity:   0.35,
+  shadowRadius:    20,
+  elevation:       4,
+} as const;
+
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.base },
+  root: { flex: 1, backgroundColor: C.background },
   scroll: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 40, gap: 14 },
 
   backRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   back: { alignSelf: 'flex-start', paddingVertical: 6 },
-  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textDarkSecondary },
   homeBtn: { paddingVertical: 6, paddingHorizontal: 10 },
   homeBtnText: { fontSize: 20 },
 
-  fallbackCard: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, borderRadius: 16, padding: 14, backgroundColor: 'rgba(129,178,154,0.08)', borderWidth: 1, borderColor: 'rgba(129,178,154,0.15)' },
+  fallbackCard: { ...card, flexDirection: 'row', alignItems: 'flex-start', gap: 10, padding: 14 },
   fallbackTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.sage },
-  fallbackBody: { fontFamily: F.body, fontSize: 13, color: C.textSub },
+  fallbackBody: { fontFamily: F.body, fontSize: 13, color: C.textSecondary },
 
-  summary: { fontFamily: F.scriptItalic, fontSize: 21, color: C.rose, lineHeight: 30, marginBottom: 8 },
+  summary: { fontFamily: F.scriptItalic, fontSize: 21, color: C.textDark, lineHeight: 30, marginBottom: 8 },
   tagRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   ava: { width: 22, height: 22, borderRadius: 11, backgroundColor: C.sage, alignItems: 'center', justifyContent: 'center' },
-  avaText: { fontFamily: F.bodySemi, fontSize: 10, color: '#FFF' },
-  tagText: { fontFamily: F.body, fontSize: 12, color: C.textMuted },
+  avaText: { fontFamily: F.bodySemi, fontSize: 10, color: '#FFFFFF' },
+  tagText: { fontFamily: F.body, fontSize: 12, color: C.textDarkSecondary },
 
   safetyLink: { flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 2 },
-  safetyIcon: { color: C.rose, fontSize: 16 },
-  safetyText: { fontFamily: F.body, fontSize: 12, color: C.textMuted },
-  safetyLinkText: { fontFamily: F.bodySemi, color: C.rose, textDecorationLine: 'underline' },
+  safetyIcon: { color: C.sos, fontSize: 16 },
+  safetyText: { fontFamily: F.body, fontSize: 12, color: C.textSecondary },
+  safetyLinkText: { fontFamily: F.bodySemi, color: C.sos, textDecorationLine: 'underline' },
 
-  voiceCard: { flexDirection: 'row', alignItems: 'center', gap: 12, padding: 14, borderRadius: 18, backgroundColor: C.cardGlass, borderWidth: 1, borderColor: C.border },
+  voiceCard: { ...card, flexDirection: 'row', alignItems: 'center', gap: 12, padding: 14 },
   playBtn: { width: 42, height: 42, borderRadius: 21, backgroundColor: C.sage, alignItems: 'center', justifyContent: 'center' },
-  playBtnActive: { backgroundColor: C.rose },
-  playBtnLocked: { backgroundColor: 'rgba(247,149,102,0.45)' },
+  playBtnActive: { backgroundColor: C.sos },
+  playBtnLocked: { backgroundColor: C.amberMuted },
   voicePremiumPill: {
     fontFamily: F.label, fontSize: 9, letterSpacing: 0.8,
-    color: C.amber, backgroundColor: 'rgba(247,149,102,0.12)',
+    color: C.amber, backgroundColor: C.amberBadge,
     paddingHorizontal: 8, paddingVertical: 3,
     borderRadius: 999, overflow: 'hidden', marginLeft: 4,
   },
   voiceTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
-  voiceSub: { fontFamily: F.body, fontSize: 12, color: C.textMuted, marginTop: 2 },
+  voiceSub: { fontFamily: F.body, fontSize: 12, color: C.textSecondary, marginTop: 2 },
 
-  avoidHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', padding: 14, borderRadius: 18, backgroundColor: C.cardGlass, borderWidth: 1, borderColor: C.border },
-  avoidLabel: { fontFamily: F.bodySemi, fontSize: 12, letterSpacing: 0.6, color: C.rose },
-  avoidCount: { fontFamily: F.bodyMedium, fontSize: 11, color: C.textMuted, backgroundColor: 'rgba(0,0,0,0.04)', paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10 },
+  avoidHeader: { ...card, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', padding: 14 },
+  avoidLabel: { fontFamily: F.bodySemi, fontSize: 12, letterSpacing: 0.6, color: C.sos },
+  avoidCount: { fontFamily: F.bodyMedium, fontSize: 11, color: C.textMuted, backgroundColor: C.chipBg, paddingHorizontal: 8, paddingVertical: 2, borderRadius: 10 },
   avoidBody: { paddingHorizontal: 18, paddingBottom: 14, gap: 8, marginTop: -8 },
-  avoidX: { fontFamily: F.bodySemi, fontSize: 10, color: C.rose, marginTop: 3 },
-  avoidText: { fontFamily: F.script, fontSize: 14, color: C.textSub, lineHeight: 21, flex: 1 },
+  avoidX: { fontFamily: F.bodySemi, fontSize: 10, color: C.sos, marginTop: 3 },
+  avoidText: { fontFamily: F.script, fontSize: 14, color: C.textSecondary, lineHeight: 21, flex: 1 },
 
-  feedbackCard: { alignItems: 'center', gap: 12, borderRadius: 18, padding: 18, backgroundColor: C.cardGlass, borderWidth: 1, borderColor: C.border },
+  feedbackCard: { ...card, alignItems: 'center', gap: 12, padding: 18 },
   feedbackQuestion: { fontFamily: F.bodySemi, fontSize: 15, color: C.text },
   feedbackRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, justifyContent: 'center' },
-  feedbackChip: { paddingHorizontal: 14, paddingVertical: 10, borderRadius: 14, backgroundColor: 'rgba(0,0,0,0.04)', borderWidth: 1, borderColor: C.border },
+  feedbackChip: { paddingHorizontal: 14, paddingVertical: 10, borderRadius: 14, backgroundColor: C.chipBg, borderWidth: 1, borderColor: C.chipBorder },
   feedbackChipText: { fontFamily: F.bodyMedium, fontSize: 13, color: C.text },
   feedbackThanks: { alignItems: 'center', paddingVertical: 12 },
   feedbackThanksText: { fontFamily: F.bodyMedium, fontSize: 13, color: C.sage },
 
-  escalationCard: { borderRadius: 18, padding: 18, gap: 10, backgroundColor: 'rgba(201,123,99,0.06)', borderWidth: 1, borderColor: 'rgba(201,123,99,0.15)' },
-  escalationTitle: { fontFamily: F.display, fontSize: 18, color: C.rose },
+  escalationCard: { ...card, padding: 18, gap: 10, backgroundColor: C.sosLight, borderColor: 'rgba(232,116,97,0.20)' },
+  escalationTitle: { fontFamily: F.heading, fontSize: 18, color: C.sos },
   escalationBody: { fontFamily: F.body, fontSize: 14, color: C.text, lineHeight: 22 },
-  escalationBtn: { alignSelf: 'flex-start', paddingVertical: 10, paddingHorizontal: 16, borderRadius: 12, backgroundColor: 'rgba(201,123,99,0.12)', borderWidth: 1, borderColor: 'rgba(201,123,99,0.25)' },
-  escalationBtnText: { fontFamily: F.bodySemi, fontSize: 14, color: C.rose },
+  escalationBtn: { alignSelf: 'flex-start', paddingVertical: 10, paddingHorizontal: 16, borderRadius: 12, backgroundColor: C.sosBadge, borderWidth: 1, borderColor: 'rgba(232,116,97,0.30)' },
+  escalationBtnText: { fontFamily: F.bodySemi, fontSize: 14, color: C.sos },
 
-  nudgeCard: { alignSelf: 'center', maxWidth: 360, alignItems: 'center', gap: 6, borderRadius: 18, paddingVertical: 14, paddingHorizontal: 18, backgroundColor: 'rgba(129,178,154,0.06)', borderWidth: 1, borderColor: 'rgba(129,178,154,0.12)' },
-  nudgeText: { fontFamily: F.body, fontSize: 13, color: C.textSub, textAlign: 'center' },
+  nudgeCard: { ...card, alignSelf: 'center', maxWidth: 360, alignItems: 'center', gap: 6, paddingVertical: 14, paddingHorizontal: 18, backgroundColor: C.sageLight, borderColor: 'rgba(138,160,96,0.20)' },
+  nudgeText: { fontFamily: F.body, fontSize: 13, color: C.textSecondary, textAlign: 'center' },
   nudgeName: { fontFamily: F.headingItalic, fontSize: 14, color: C.text },
   nudgeLink: { fontFamily: F.bodySemi, fontSize: 13, color: C.sage },
 
-  shareText: { fontFamily: F.bodySemi, fontSize: 13, color: C.rose, textDecorationLine: 'underline' },
-  errorText: { fontFamily: F.body, fontSize: 13, color: C.rose, textAlign: 'center' },
+  shareText: { fontFamily: F.bodySemi, fontSize: 13, color: C.amberLight, textDecorationLine: 'underline' },
+  errorText: { fontFamily: F.body, fontSize: 13, color: C.sos, textAlign: 'center' },
 
   footer: { position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 },
   footerFade: { height: 40 },
-  footerContent: { backgroundColor: C.base, paddingHorizontal: 24, paddingBottom: 28, paddingTop: 4 },
+  footerContent: { backgroundColor: C.background, paddingHorizontal: 24, paddingBottom: 28, paddingTop: 4 },
   footerRow: { flexDirection: 'row', gap: 10 },
-  footerGhost: { flex: 1, borderRadius: 16, minHeight: 50, alignItems: 'center', justifyContent: 'center', backgroundColor: C.cardGlass, borderWidth: 1, borderColor: C.border },
+  footerGhost: { flex: 1, borderRadius: 16, minHeight: 50, alignItems: 'center', justifyContent: 'center', backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderTopWidth: 1, borderTopColor: C.borderHi },
   footerGhostText: { fontFamily: F.bodyMedium, fontSize: 14, color: C.text },
-  footerPrimary: { flex: 1, borderRadius: 16, minHeight: 50, minWidth: 100, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 20, backgroundColor: C.rose },
+  footerPrimary: { flex: 1, borderRadius: 16, minHeight: 50, minWidth: 100, alignItems: 'center', justifyContent: 'center', paddingHorizontal: 20, backgroundColor: C.sos },
   footerPrimaryText: { fontFamily: F.subheading, fontSize: 14, color: '#FFFFFF', letterSpacing: 0.3 },
 });
 

--- a/apps/mobile/app/saved.tsx
+++ b/apps/mobile/app/saved.tsx
@@ -198,7 +198,7 @@ export default function SavedScriptsScreen() {
 
      {/* Pastel gradient background */}
      <LinearGradient
-       colors={[C.gradStart, C.gradMid1, C.gradMid2, C.gradEnd]}
+       colors={[C.gradientResultTop, C.gradientResultMid1, C.gradientResultMid2, C.gradientResultMid3, C.gradientMid4, C.gradientBottom]}
        start={{ x: 0, y: 0 }}
        end={{ x: 1, y: 1 }}
        style={StyleSheet.absoluteFill}
@@ -233,7 +233,7 @@ export default function SavedScriptsScreen() {
        {/* ─── Content ─── */}
        {loading ? (
          <View style={s.center}>
-           <ActivityIndicator color={C.rose} size="large" />
+           <ActivityIndicator color={C.amber} size="large" />
          </View>
        ) : error ? (
          <View style={s.center}>
@@ -252,7 +252,7 @@ export default function SavedScriptsScreen() {
              <RefreshControl
                refreshing={refreshing}
                onRefresh={handleRefresh}
-               tintColor={C.rose}
+               tintColor={C.amber}
              />
            }
          >
@@ -365,7 +365,7 @@ router.push('/(tabs)');       }}
 
 
 const s = StyleSheet.create({
- root: { flex: 1, backgroundColor: C.base },
+ root: { flex: 1, backgroundColor: C.background },
  safe: { flex: 1 },
 
 
@@ -407,7 +407,7 @@ const s = StyleSheet.create({
  subtitle: {
    fontFamily: F.body,
    fontSize: 14,
-   color: C.textSub,
+   color: C.textSecondary,
  },
 
 
@@ -422,13 +422,13 @@ const s = StyleSheet.create({
  errorText: {
    fontFamily: F.body,
    fontSize: 14,
-   color: C.rose,
+   color: C.sos,
    textAlign: 'center',
  },
  retryText: {
    fontFamily: F.bodySemi,
    fontSize: 14,
-   color: C.rose,
+   color: C.sos,
    textDecorationLine: 'underline',
  },
 
@@ -452,7 +452,7 @@ const s = StyleSheet.create({
  groupName: {
    fontFamily: F.bodySemi,
    fontSize: 15,
-   color: C.rose,
+   color: C.sos,
    letterSpacing: 0.2,
  },
  groupCount: {
@@ -467,7 +467,7 @@ const s = StyleSheet.create({
  card: {
    borderRadius: 18,
    padding: 16,
-   backgroundColor: C.cardGlass,
+   backgroundColor: C.surface,
    borderWidth: 1,
    borderColor: C.border,
    gap: 8,
@@ -492,7 +492,7 @@ const s = StyleSheet.create({
  cardPreview: {
    fontFamily: F.scriptItalic,
    fontSize: 14,
-   color: C.textBody,
+   color: C.textSecondary,
    lineHeight: 21,
  },
  cardFooter: {
@@ -518,7 +518,7 @@ const s = StyleSheet.create({
  deleteText: {
    fontFamily: F.bodyMedium,
    fontSize: 12,
-   color: C.rose,
+   color: C.sos,
  },
 
 
@@ -542,7 +542,7 @@ const s = StyleSheet.create({
  },
  emptyCard: {
    width: '100%',
-   backgroundColor: C.cardGlass,
+   backgroundColor: C.surface,
    borderRadius: 24,
    borderWidth: 1,
    borderColor: C.border,
@@ -554,7 +554,7 @@ const s = StyleSheet.create({
    width: 56,
    height: 56,
    borderRadius: 28,
-   backgroundColor: C.roseMuted,
+   backgroundColor: C.sosLight,
    alignItems: 'center',
    justifyContent: 'center',
    marginBottom: 4,
@@ -570,16 +570,16 @@ const s = StyleSheet.create({
    fontFamily: F.body,
    fontSize: 14,
    lineHeight: 21,
-   color: C.textBody,
+   color: C.textSecondary,
    textAlign: 'center',
    maxWidth: 260,
  },
  emptyCta: {
-   backgroundColor: C.rose,
+   backgroundColor: C.sos,
    paddingHorizontal: 28,
    paddingVertical: 14,
    borderRadius: 14,
-   shadowColor: C.rose,
+   shadowColor: C.sos,
    shadowOpacity: 0.22,
    shadowRadius: 16,
    shadowOffset: { width: 0, height: 4 },

--- a/apps/mobile/app/saved.tsx
+++ b/apps/mobile/app/saved.tsx
@@ -1,19 +1,18 @@
 // app/saved.tsx
-// v7 — Saved scripts library (grouped by child)
-// Journal design system: pastel gradient + Manrope + rose accent
+// Deep Warm — Saved scripts library (grouped by child)
+// C-2 Settings gradient + dark glass cards + amber/sos accents
 // Data: loadSavedScripts() + deleteSavedScript() from src/lib/loadSavedScripts
-
 
 import { useCallback, useMemo, useState } from 'react';
 import {
- ActivityIndicator,
- Alert,
- Pressable,
- RefreshControl,
- ScrollView,
- StyleSheet,
- Text,
- View,
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
 } from 'react-native';
 import { router, useFocusEffect } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -22,575 +21,524 @@ import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
 import { colors as C, fonts as F } from '../src/theme';
 import {
- loadSavedScripts,
- deleteSavedScript,
- type SavedScriptRow,
+  loadSavedScripts,
+  deleteSavedScript,
+  type SavedScriptRow,
 } from '../src/lib/loadSavedScripts';
-
 
 // ═══════════════════════════════════════════════
 // TYPES
 // ═══════════════════════════════════════════════
 
-
 type ChildGroup = {
- key: string;
- childName: string;
- scripts: SavedScriptRow[];
+  key: string;
+  childName: string;
+  scripts: SavedScriptRow[];
 };
 
-
 const OTHER_KEY = '__unassigned__';
-
 
 // ═══════════════════════════════════════════════
 // SCREEN
 // ═══════════════════════════════════════════════
 
-
 export default function SavedScriptsScreen() {
- const [scripts, setScripts] = useState<SavedScriptRow[]>([]);
- const [loading, setLoading] = useState(true);
- const [refreshing, setRefreshing] = useState(false);
- const [error, setError] = useState('');
+  const [scripts, setScripts] = useState<SavedScriptRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState('');
 
+  // ─── Data ───
+  const fetchSaved = useCallback(async () => {
+    setError('');
+    try {
+      const data = await loadSavedScripts();
+      setScripts(data);
+    } catch {
+      setError('Could not load your saved scripts.');
+    }
+  }, []);
 
- // ─── Data ───
- const fetchSaved = useCallback(async () => {
-   setError('');
-   try {
-     const data = await loadSavedScripts();
-     setScripts(data);
-   } catch {
-     setError('Could not load your saved scripts.');
-   }
- }, []);
+  useFocusEffect(
+    useCallback(() => {
+      setLoading(true);
+      fetchSaved().finally(() => setLoading(false));
+    }, [fetchSaved])
+  );
 
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    Haptics.selectionAsync();
+    await fetchSaved();
+    setRefreshing(false);
+  }, [fetchSaved]);
 
- useFocusEffect(
-   useCallback(() => {
-     setLoading(true);
-     fetchSaved().finally(() => setLoading(false));
-   }, [fetchSaved])
- );
+  // ─── Group by child (preserves newest-first order within groups) ───
+  const groups: ChildGroup[] = useMemo(() => {
+    const map = new Map<string, ChildGroup>();
+    scripts.forEach((sc) => {
+      const key = sc.child_profile_id || OTHER_KEY;
+      const childName = sc.child_name || 'Other';
+      const existing = map.get(key);
+      if (existing) {
+        existing.scripts.push(sc);
+      } else {
+        map.set(key, { key, childName, scripts: [sc] });
+      }
+    });
 
+    // Unassigned scripts drift to the bottom
+    const arr = Array.from(map.values());
+    arr.sort((a, b) => {
+      if (a.key === OTHER_KEY) return 1;
+      if (b.key === OTHER_KEY) return -1;
+      return 0;
+    });
+    return arr;
+  }, [scripts]);
 
- const handleRefresh = useCallback(async () => {
-   setRefreshing(true);
-   Haptics.selectionAsync();
-   await fetchSaved();
-   setRefreshing(false);
- }, [fetchSaved]);
+  // ─── Actions ───
+  const handleDelete = (id: string, title: string | null) => {
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+    Alert.alert(
+      'Delete script?',
+      `Remove "${title || 'this script'}" from your saved scripts?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await deleteSavedScript(id);
+              setScripts((prev) => prev.filter((x) => x.id !== id));
+              Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+            } catch {
+              Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+            }
+          },
+        },
+      ]
+    );
+  };
 
+  const handleOpenScript = (item: SavedScriptRow) => {
+    const d = item.structured;
+    if (!d) return;
+    Haptics.selectionAsync();
 
- // ─── Group by child (preserves newest-first order within groups) ───
- const groups: ChildGroup[] = useMemo(() => {
-   const map = new Map<string, ChildGroup>();
-   scripts.forEach((sc) => {
-     const key = sc.child_profile_id || OTHER_KEY;
-     const childName = sc.child_name || 'Other';
-     const existing = map.get(key);
-     if (existing) {
-       existing.scripts.push(sc);
-     } else {
-       map.set(key, { key, childName, scripts: [sc] });
-     }
-   });
+    router.push({
+      pathname: '/result',
+      params: {
+        situationSummary: d.situation_summary || '',
+        regulateAction: d.regulate?.parent_action || '',
+        regulateScript: d.regulate?.script || '',
+        regulateCoaching: d.regulate?.coaching || '',
+        regulateStrategies: JSON.stringify(d.regulate?.strategies || []),
+        connectAction: d.connect?.parent_action || '',
+        connectScript: d.connect?.script || '',
+        connectCoaching: d.connect?.coaching || '',
+        connectStrategies: JSON.stringify(d.connect?.strategies || []),
+        guideAction: d.guide?.parent_action || '',
+        guideScript: d.guide?.script || '',
+        guideCoaching: d.guide?.coaching || '',
+        guideStrategies: JSON.stringify(d.guide?.strategies || []),
+        avoid: JSON.stringify(d.avoid || []),
+        mode: 'sos',
+      },
+    });
+  };
 
+  const handleBack = () => {
+    Haptics.selectionAsync();
+    if (router.canGoBack()) router.back();
+    else router.replace('/(tabs)');
+  };
 
-   // Unassigned scripts drift to the bottom
-   const arr = Array.from(map.values());
-   arr.sort((a, b) => {
-     if (a.key === OTHER_KEY) return 1;
-     if (b.key === OTHER_KEY) return -1;
-     return 0;
-   });
-   return arr;
- }, [scripts]);
+  const handleRetry = () => {
+    setLoading(true);
+    fetchSaved().finally(() => setLoading(false));
+  };
 
+  // ─── Helpers ───
+  const formatDate = (iso: string): string => {
+    const d = new Date(iso);
+    const now = new Date();
+    const diff = now.getTime() - d.getTime();
+    const days = Math.floor(diff / 86400000);
+    if (days === 0) return 'Today';
+    if (days === 1) return 'Yesterday';
+    if (days < 7) return `${days} days ago`;
+    return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  };
 
- // ─── Actions ───
- const handleDelete = (id: string, title: string | null) => {
-   Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-   Alert.alert(
-     'Delete script?',
-     `Remove "${title || 'this script'}" from your saved scripts?`,
-     [
-       { text: 'Cancel', style: 'cancel' },
-       {
-         text: 'Delete',
-         style: 'destructive',
-         onPress: async () => {
-           try {
-             await deleteSavedScript(id);
-             setScripts((prev) => prev.filter((x) => x.id !== id));
-             Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-           } catch {
-             Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
-           }
-         },
-       },
-     ]
-   );
- };
+  // ─── Render ───
+  return (
+    <View style={s.root}>
+      <StatusBar style="light" />
 
+      {/* C-2 Settings gradient */}
+      <LinearGradient
+        colors={[
+          C.gradientSettingsTop,
+          C.gradientSettingsMid1,
+          C.gradientSettingsMid2,
+          C.gradientMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.12, 0.26, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
 
- const handleOpenScript = (item: SavedScriptRow) => {
-   const d = item.structured;
-   if (!d) return;
-   Haptics.selectionAsync();
+      <SafeAreaView style={s.safe} edges={['top', 'bottom']}>
+        {/* ─── Header ─── */}
+        <View style={s.header}>
+          <Pressable onPress={handleBack} hitSlop={12} style={s.backBtn}>
+            <Text style={s.backText}>← Back</Text>
+          </Pressable>
+        </View>
 
+        <View style={s.titleWrap}>
+          <Text style={s.title}>Saved Scripts</Text>
+          {!loading && scripts.length > 0 && (
+            <Text style={s.subtitle}>
+              {scripts.length} script{scripts.length !== 1 ? 's' : ''}
+              {groups.length > 1 ? ` · ${groups.length} children` : ''}
+            </Text>
+          )}
+        </View>
 
-   router.push({
-     pathname: '/result',
-     params: {
-       situationSummary: d.situation_summary || '',
-       regulateAction: d.regulate?.parent_action || '',
-       regulateScript: d.regulate?.script || '',
-       regulateCoaching: d.regulate?.coaching || '',
-       regulateStrategies: JSON.stringify(d.regulate?.strategies || []),
-       connectAction: d.connect?.parent_action || '',
-       connectScript: d.connect?.script || '',
-       connectCoaching: d.connect?.coaching || '',
-       connectStrategies: JSON.stringify(d.connect?.strategies || []),
-       guideAction: d.guide?.parent_action || '',
-       guideScript: d.guide?.script || '',
-       guideCoaching: d.guide?.coaching || '',
-       guideStrategies: JSON.stringify(d.guide?.strategies || []),
-       avoid: JSON.stringify(d.avoid || []),
-       mode: 'sos',
-     },
-   });
- };
+        {/* ─── Content ─── */}
+        {loading ? (
+          <View style={s.center}>
+            <ActivityIndicator color={C.amber} size="large" />
+          </View>
+        ) : error ? (
+          <View style={s.center}>
+            <Text style={s.errorText}>{error}</Text>
+            <Pressable onPress={handleRetry}>
+              <Text style={s.retryText}>Try again</Text>
+            </Pressable>
+          </View>
+        ) : scripts.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <ScrollView
+            contentContainerStyle={s.scroll}
+            showsVerticalScrollIndicator={false}
+            refreshControl={
+              <RefreshControl
+                refreshing={refreshing}
+                onRefresh={handleRefresh}
+                tintColor={C.amber}
+              />
+            }
+          >
+            {groups.map((group) => (
+              <View key={group.key} style={s.group}>
+                {/* Group header */}
+                <View style={s.groupHeader}>
+                  <Text style={s.groupName}>{group.childName}</Text>
+                  <Text style={s.groupCount}>
+                    {group.scripts.length} script{group.scripts.length !== 1 ? 's' : ''}
+                  </Text>
+                </View>
 
+                {/* Script cards */}
+                {group.scripts.map((item) => (
+                  <Pressable
+                    key={item.id}
+                    onPress={() => handleOpenScript(item)}
+                    style={({ pressed }) => [
+                      s.cardWrap,
+                      pressed && { opacity: 0.92, transform: [{ scale: 0.99 }] },
+                    ]}
+                  >
+                    <View style={s.card}>
+                      <View style={s.cardTop}>
+                        <Text style={s.cardTitle} numberOfLines={1}>
+                          {item.title || 'Saved script'}
+                        </Text>
+                        <Text style={s.cardDate}>{formatDate(item.created_at)}</Text>
+                      </View>
 
- const handleBack = () => {
-   Haptics.selectionAsync();
-   if (router.canGoBack()) router.back();
-   else router.replace('/(tabs)');
- };
+                      {item.structured?.regulate?.script ? (
+                        <Text style={s.cardPreview} numberOfLines={2}>
+                          "{item.structured.regulate.script}"
+                        </Text>
+                      ) : null}
 
+                      <View style={s.cardFooter}>
+                        <View style={s.metaRow}>
+                          {item.trigger_label ? (
+                            <View style={s.metaPill}>
+                              <Text style={s.metaPillText}>{item.trigger_label}</Text>
+                            </View>
+                          ) : null}
+                        </View>
 
- const handleRetry = () => {
-   setLoading(true);
-   fetchSaved().finally(() => setLoading(false));
- };
+                        <Pressable
+                          onPress={() => handleDelete(item.id, item.title)}
+                          hitSlop={12}
+                          style={({ pressed }) => [pressed && { opacity: 0.5 }]}
+                        >
+                          <Text style={s.deleteText}>Delete</Text>
+                        </Pressable>
+                      </View>
+                    </View>
+                  </Pressable>
+                ))}
+              </View>
+            ))}
 
-
- // ─── Helpers ───
- const formatDate = (iso: string): string => {
-   const d = new Date(iso);
-   const now = new Date();
-   const diff = now.getTime() - d.getTime();
-   const days = Math.floor(diff / 86400000);
-   if (days === 0) return 'Today';
-   if (days === 1) return 'Yesterday';
-   if (days < 7) return `${days} days ago`;
-   return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
- };
-
-
- // ─── Render ───
- return (
-   <View style={s.root}>
-     <StatusBar style="dark" />
-
-
-     {/* Pastel gradient background */}
-     <LinearGradient
-       colors={[C.gradientResultTop, C.gradientResultMid1, C.gradientResultMid2, C.gradientResultMid3, C.gradientMid4, C.gradientBottom]}
-       start={{ x: 0, y: 0 }}
-       end={{ x: 1, y: 1 }}
-       style={StyleSheet.absoluteFill}
-     />
-
-
-     {/* Decorative blobs */}
-     <View style={[s.blob, s.blob1]} />
-     <View style={[s.blob, s.blob2]} />
-
-
-     <SafeAreaView style={s.safe} edges={['top', 'bottom']}>
-       {/* ─── Header ─── */}
-       <View style={s.header}>
-         <Pressable onPress={handleBack} hitSlop={12} style={s.backBtn}>
-           <Text style={s.backText}>← Back</Text>
-         </Pressable>
-       </View>
-
-
-       <View style={s.titleWrap}>
-         <Text style={s.title}>Saved Scripts</Text>
-         {!loading && scripts.length > 0 && (
-           <Text style={s.subtitle}>
-             {scripts.length} script{scripts.length !== 1 ? 's' : ''}
-             {groups.length > 1 ? ` · ${groups.length} children` : ''}
-           </Text>
-         )}
-       </View>
-
-
-       {/* ─── Content ─── */}
-       {loading ? (
-         <View style={s.center}>
-           <ActivityIndicator color={C.amber} size="large" />
-         </View>
-       ) : error ? (
-         <View style={s.center}>
-           <Text style={s.errorText}>{error}</Text>
-           <Pressable onPress={handleRetry}>
-             <Text style={s.retryText}>Try again</Text>
-           </Pressable>
-         </View>
-       ) : scripts.length === 0 ? (
-         <EmptyState />
-       ) : (
-         <ScrollView
-           contentContainerStyle={s.scroll}
-           showsVerticalScrollIndicator={false}
-           refreshControl={
-             <RefreshControl
-               refreshing={refreshing}
-               onRefresh={handleRefresh}
-               tintColor={C.amber}
-             />
-           }
-         >
-           {groups.map((group) => (
-             <View key={group.key} style={s.group}>
-               {/* Group header */}
-               <View style={s.groupHeader}>
-                 <Text style={s.groupName}>{group.childName}</Text>
-                 <Text style={s.groupCount}>
-                   {group.scripts.length} script{group.scripts.length !== 1 ? 's' : ''}
-                 </Text>
-               </View>
-
-
-               {/* Script cards */}
-               {group.scripts.map((item) => (
-                 <Pressable
-                   key={item.id}
-                   onPress={() => handleOpenScript(item)}
-                   style={({ pressed }) => [
-                     s.cardWrap,
-                     pressed && { opacity: 0.92, transform: [{ scale: 0.99 }] },
-                   ]}
-                 >
-                   <View style={s.card}>
-                     <View style={s.cardTop}>
-                       <Text style={s.cardTitle} numberOfLines={1}>
-                         {item.title || 'Saved script'}
-                       </Text>
-                       <Text style={s.cardDate}>{formatDate(item.created_at)}</Text>
-                     </View>
-
-
-                     {item.structured?.regulate?.script ? (
-                       <Text style={s.cardPreview} numberOfLines={2}>
-                         "{item.structured.regulate.script}"
-                       </Text>
-                     ) : null}
-
-
-                     <View style={s.cardFooter}>
-                       <View style={s.metaRow}>
-                         {item.trigger_label ? (
-                           <View style={s.metaPill}>
-                             <Text style={s.metaPillText}>{item.trigger_label}</Text>
-                           </View>
-                         ) : null}
-                       </View>
-
-
-                       <Pressable
-                         onPress={() => handleDelete(item.id, item.title)}
-                         hitSlop={12}
-                         style={({ pressed }) => [pressed && { opacity: 0.5 }]}
-                       >
-                         <Text style={s.deleteText}>Delete</Text>
-                       </Pressable>
-                     </View>
-                   </View>
-                 </Pressable>
-               ))}
-             </View>
-           ))}
-
-
-           <Text style={s.footnote}>Tap any script to open it again.</Text>
-         </ScrollView>
-       )}
-     </SafeAreaView>
-   </View>
- );
+            <Text style={s.footnote}>Tap any script to open it again.</Text>
+          </ScrollView>
+        )}
+      </SafeAreaView>
+    </View>
+  );
 }
-
 
 // ═══════════════════════════════════════════════
 // EMPTY STATE
 // ═══════════════════════════════════════════════
 
-
 function EmptyState() {
- return (
-   <View style={s.emptyWrap}>
-     <View style={s.emptyCard}>
-       <View style={s.emptyIconWrap}>
-         <Text style={s.emptyIcon}>🔖</Text>
-       </View>
-       <Text style={s.emptyTitle}>Nothing saved yet</Text>
-       <Text style={s.emptyBody}>
-         When a script helps, tap the bookmark to keep it here. Your saved moments group by child so you can find them easily.
-       </Text>
-     </View>
+  return (
+    <View style={s.emptyWrap}>
+      <View style={s.emptyCard}>
+        <View style={s.emptyIconWrap}>
+          <Text style={s.emptyIcon}>🔖</Text>
+        </View>
+        <Text style={s.emptyTitle}>Nothing saved yet</Text>
+        <Text style={s.emptyBody}>
+          When a script helps, tap the bookmark to keep it here. Your saved moments group by child so you can find them easily.
+        </Text>
+      </View>
 
-
-     <Pressable
-       onPress={() => {
-         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-router.push('/(tabs)');       }}
-       style={({ pressed }) => [s.emptyCta, pressed && { opacity: 0.9 }]}
-     >
-       <Text style={s.emptyCtaText}>Go to SOS</Text>
-     </Pressable>
-   </View>
- );
+      <Pressable
+        onPress={() => {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+          router.push('/(tabs)');
+        }}
+        style={({ pressed }) => [s.emptyCta, pressed && { opacity: 0.9 }]}
+      >
+        <Text style={s.emptyCtaText}>Go to SOS</Text>
+      </Pressable>
+    </View>
+  );
 }
-
 
 // ═══════════════════════════════════════════════
 // STYLES
 // ═══════════════════════════════════════════════
 
-
 const s = StyleSheet.create({
- root: { flex: 1, backgroundColor: C.background },
- safe: { flex: 1 },
+  root: { flex: 1, backgroundColor: C.background },
+  safe: { flex: 1 },
 
+  // Header
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 24,
+    paddingTop: 4,
+  },
+  backBtn: { paddingVertical: 6 },
+  backText: {
+    fontFamily: F.bodyMedium,
+    fontSize: 15,
+    color: C.textMuted,
+  },
 
- // Blobs
- blob: { position: 'absolute', borderRadius: 999 },
- blob1: {
-   top: -80, right: -60, width: 280, height: 280,
-   backgroundColor: 'rgba(253, 221, 230, 0.55)',
- },
- blob2: {
-   bottom: -60, left: -80, width: 240, height: 240,
-   backgroundColor: 'rgba(212, 232, 209, 0.50)',
- },
+  // Title
+  titleWrap: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 16, gap: 4 },
+  title: {
+    fontFamily: F.heading,
+    fontSize: 26,
+    letterSpacing: -0.3,
+    color: C.text,
+  },
+  subtitle: {
+    fontFamily: F.body,
+    fontSize: 14,
+    color: C.textSecondary,
+  },
 
+  // Loading / error
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    paddingHorizontal: 24,
+  },
+  errorText: {
+    fontFamily: F.body,
+    fontSize: 14,
+    color: C.sos,
+    textAlign: 'center',
+  },
+  retryText: {
+    fontFamily: F.bodySemi,
+    fontSize: 14,
+    color: C.sos,
+    textDecorationLine: 'underline',
+  },
 
- // Header
- header: {
-   flexDirection: 'row',
-   alignItems: 'center',
-   paddingHorizontal: 24,
-   paddingTop: 4,
- },
- backBtn: { paddingVertical: 6 },
- backText: {
-   fontFamily: F.bodyMedium,
-   fontSize: 15,
-   color: C.textMuted,
- },
+  // List
+  scroll: {
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+  },
 
+  // Group
+  group: { marginBottom: 20 },
+  groupHeader: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    paddingHorizontal: 4,
+    marginBottom: 10,
+  },
+  groupName: {
+    fontFamily: F.bodySemi,
+    fontSize: 15,
+    color: C.sos,
+    letterSpacing: 0.2,
+  },
+  groupCount: {
+    fontFamily: F.body,
+    fontSize: 12,
+    color: C.textMuted,
+  },
 
- // Title
- titleWrap: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 16, gap: 4 },
- title: {
-   fontFamily: F.heading,
-   fontSize: 26,
-   letterSpacing: -0.3,
-   color: C.text,
- },
- subtitle: {
-   fontFamily: F.body,
-   fontSize: 14,
-   color: C.textSecondary,
- },
+  // Card
+  cardWrap: { marginBottom: 10 },
+  card: {
+    borderRadius: 18,
+    padding: 16,
+    backgroundColor: C.surface,
+    borderWidth: 1,
+    borderColor: C.border,
+    gap: 8,
+  },
+  cardTop: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  cardTitle: {
+    fontFamily: F.bodySemi,
+    fontSize: 15,
+    color: C.text,
+    flex: 1,
+  },
+  cardDate: {
+    fontFamily: F.body,
+    fontSize: 12,
+    color: C.textMuted,
+  },
+  cardPreview: {
+    fontFamily: F.scriptItalic,
+    fontSize: 14,
+    color: C.textSecondary,
+    lineHeight: 21,
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 2,
+  },
+  metaRow: { flexDirection: 'row', gap: 8, flex: 1 },
+  metaPill: {
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    borderRadius: 10,
+    backgroundColor: 'rgba(247,149,102,0.10)',
+    borderWidth: 1,
+    borderColor: 'rgba(247,149,102,0.18)',
+  },
+  metaPillText: {
+    fontFamily: F.bodyMedium,
+    fontSize: 11,
+    color: C.peach,
+  },
+  deleteText: {
+    fontFamily: F.bodyMedium,
+    fontSize: 12,
+    color: C.sos,
+  },
 
+  // Footnote
+  footnote: {
+    fontFamily: F.body,
+    fontSize: 12,
+    color: C.textMuted,
+    textAlign: 'center',
+    marginTop: 8,
+  },
 
- // Loading / error
- center: {
-   flex: 1,
-   alignItems: 'center',
-   justifyContent: 'center',
-   gap: 12,
-   paddingHorizontal: 24,
- },
- errorText: {
-   fontFamily: F.body,
-   fontSize: 14,
-   color: C.sos,
-   textAlign: 'center',
- },
- retryText: {
-   fontFamily: F.bodySemi,
-   fontSize: 14,
-   color: C.sos,
-   textDecorationLine: 'underline',
- },
-
-
- // List
- scroll: {
-   paddingHorizontal: 20,
-   paddingBottom: 40,
- },
-
-
- // Group
- group: { marginBottom: 20 },
- groupHeader: {
-   flexDirection: 'row',
-   alignItems: 'baseline',
-   justifyContent: 'space-between',
-   paddingHorizontal: 4,
-   marginBottom: 10,
- },
- groupName: {
-   fontFamily: F.bodySemi,
-   fontSize: 15,
-   color: C.sos,
-   letterSpacing: 0.2,
- },
- groupCount: {
-   fontFamily: F.body,
-   fontSize: 12,
-   color: C.textMuted,
- },
-
-
- // Card
- cardWrap: { marginBottom: 10 },
- card: {
-   borderRadius: 18,
-   padding: 16,
-   backgroundColor: C.surface,
-   borderWidth: 1,
-   borderColor: C.border,
-   gap: 8,
- },
- cardTop: {
-   flexDirection: 'row',
-   alignItems: 'center',
-   justifyContent: 'space-between',
-   gap: 8,
- },
- cardTitle: {
-   fontFamily: F.bodySemi,
-   fontSize: 15,
-   color: C.text,
-   flex: 1,
- },
- cardDate: {
-   fontFamily: F.body,
-   fontSize: 12,
-   color: C.textMuted,
- },
- cardPreview: {
-   fontFamily: F.scriptItalic,
-   fontSize: 14,
-   color: C.textSecondary,
-   lineHeight: 21,
- },
- cardFooter: {
-   flexDirection: 'row',
-   alignItems: 'center',
-   justifyContent: 'space-between',
-   marginTop: 2,
- },
- metaRow: { flexDirection: 'row', gap: 8, flex: 1 },
- metaPill: {
-   paddingHorizontal: 10,
-   paddingVertical: 3,
-   borderRadius: 10,
-   backgroundColor: 'rgba(247,149,102,0.10)',
-   borderWidth: 1,
-   borderColor: 'rgba(247,149,102,0.18)',
- },
- metaPillText: {
-   fontFamily: F.bodyMedium,
-   fontSize: 11,
-   color: C.peach,
- },
- deleteText: {
-   fontFamily: F.bodyMedium,
-   fontSize: 12,
-   color: C.sos,
- },
-
-
- // Footnote
- footnote: {
-   fontFamily: F.body,
-   fontSize: 12,
-   color: C.textMuted,
-   textAlign: 'center',
-   marginTop: 8,
- },
-
-
- // Empty state
- emptyWrap: {
-   flex: 1,
-   alignItems: 'center',
-   justifyContent: 'center',
-   paddingHorizontal: 24,
-   gap: 20,
- },
- emptyCard: {
-   width: '100%',
-   backgroundColor: C.surface,
-   borderRadius: 24,
-   borderWidth: 1,
-   borderColor: C.border,
-   padding: 28,
-   alignItems: 'center',
-   gap: 12,
- },
- emptyIconWrap: {
-   width: 56,
-   height: 56,
-   borderRadius: 28,
-   backgroundColor: C.sosLight,
-   alignItems: 'center',
-   justifyContent: 'center',
-   marginBottom: 4,
- },
- emptyIcon: { fontSize: 28 },
- emptyTitle: {
-   fontFamily: F.bodySemi,
-   fontSize: 18,
-   color: C.text,
-   textAlign: 'center',
- },
- emptyBody: {
-   fontFamily: F.body,
-   fontSize: 14,
-   lineHeight: 21,
-   color: C.textSecondary,
-   textAlign: 'center',
-   maxWidth: 260,
- },
- emptyCta: {
-   backgroundColor: C.sos,
-   paddingHorizontal: 28,
-   paddingVertical: 14,
-   borderRadius: 14,
-   shadowColor: C.sos,
-   shadowOpacity: 0.22,
-   shadowRadius: 16,
-   shadowOffset: { width: 0, height: 4 },
-   elevation: 4,
- },
- emptyCtaText: {
-   fontFamily: F.bodySemi,
-   fontSize: 15,
-   color: '#FFFFFF',
-   letterSpacing: 0.2,
- },
+  // Empty state
+  emptyWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 20,
+  },
+  emptyCard: {
+    width: '100%',
+    backgroundColor: C.surface,
+    borderRadius: 24,
+    borderWidth: 1,
+    borderColor: C.border,
+    padding: 28,
+    alignItems: 'center',
+    gap: 12,
+  },
+  emptyIconWrap: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: C.sosLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 4,
+  },
+  emptyIcon: { fontSize: 28 },
+  emptyTitle: {
+    fontFamily: F.bodySemi,
+    fontSize: 18,
+    color: C.text,
+    textAlign: 'center',
+  },
+  emptyBody: {
+    fontFamily: F.body,
+    fontSize: 14,
+    lineHeight: 21,
+    color: C.textSecondary,
+    textAlign: 'center',
+    maxWidth: 260,
+  },
+  emptyCta: {
+    backgroundColor: C.sos,
+    paddingHorizontal: 28,
+    paddingVertical: 14,
+    borderRadius: 14,
+    shadowColor: C.sos,
+    shadowOpacity: 0.22,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 4,
+  },
+  emptyCtaText: {
+    fontFamily: F.bodySemi,
+    fontSize: 15,
+    color: '#FFFFFF',
+    letterSpacing: 0.2,
+  },
 });
-
-

--- a/apps/mobile/app/thought/[id].tsx
+++ b/apps/mobile/app/thought/[id].tsx
@@ -217,8 +217,8 @@ export default function ThoughtScreen() {
       <StatusBar style="dark" />
 
       <LinearGradient
-        colors={[C.gradStart, C.gradMid1, C.gradMid2, C.gradEnd]}
-        start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }}
+        colors={[C.gradientResultTop, C.gradientResultMid1, C.gradientResultMid2, C.gradientResultMid3, C.gradientMid4, C.gradientBottom]}
+        
         style={StyleSheet.absoluteFill}
       />
 
@@ -293,10 +293,10 @@ export default function ThoughtScreen() {
                       pressed && { opacity: 0.85 },
                     ]}
                   >
-                    <Text style={[s.actionIcon, isPinned && { color: C.rose }]}>
+                    <Text style={[s.actionIcon, isPinned && { color: C.sos }]}>
                       {isPinned ? '📌' : '📍'}
                     </Text>
-                    <Text style={[s.actionLabel, isPinned && { color: C.rose }]}>
+                    <Text style={[s.actionLabel, isPinned && { color: C.sos }]}>
                       {isPinned ? 'Pinned' : 'Pin'}
                     </Text>
                   </Pressable>
@@ -341,7 +341,7 @@ export default function ThoughtScreen() {
 // ═══════════════════════════════════════════════
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.base },
+  root: { flex: 1, backgroundColor: C.background },
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingBottom: 20, gap: 22 },
 
@@ -373,7 +373,7 @@ const s = StyleSheet.create({
     letterSpacing: 0.5, textTransform: 'uppercase',
   },
   promptText: {
-      fontFamily: F.scriptItalic, fontSize: 15, color: C.textSub,
+      fontFamily: F.scriptItalic, fontSize: 15, color: C.textSecondary,
       lineHeight: 22,
     },
     savedTo: {
@@ -386,7 +386,7 @@ const s = StyleSheet.create({
   responseCard: {
     padding: 24, gap: 14,
     borderRadius: 22,
-    backgroundColor: C.cardGlass,
+    backgroundColor: C.surface,
     borderWidth: 1, borderColor: C.border,
     minHeight: 200,
   },
@@ -404,14 +404,14 @@ const s = StyleSheet.create({
 
   // Error
   errorText: {
-    fontFamily: F.body, fontSize: 15, color: C.rose,
+    fontFamily: F.body, fontSize: 15, color: C.sos,
     textAlign: 'center', lineHeight: 22,
   },
   errorBackBtn: {
     alignSelf: 'center', paddingVertical: 10, paddingHorizontal: 18, marginTop: 8,
   },
   errorBackText: {
-    fontFamily: F.bodyMedium, fontSize: 14, color: C.textSub,
+    fontFamily: F.bodyMedium, fontSize: 14, color: C.textSecondary,
   },
 
   // Action row
@@ -423,7 +423,7 @@ const s = StyleSheet.create({
     paddingVertical: 14, paddingHorizontal: 8,
     alignItems: 'center', justifyContent: 'center',
     borderRadius: 14,
-    backgroundColor: C.cardGlass,
+    backgroundColor: C.surface,
     borderWidth: 1, borderColor: C.border,
   },
   actionBtnActive: {
@@ -432,6 +432,6 @@ const s = StyleSheet.create({
   },
   actionIcon: { fontSize: 20 },
   actionLabel: {
-    fontFamily: F.bodyMedium, fontSize: 12, color: C.textSub,
+    fontFamily: F.bodyMedium, fontSize: 12, color: C.textSecondary,
   },
 });

--- a/apps/mobile/app/thought/[id].tsx
+++ b/apps/mobile/app/thought/[id].tsx
@@ -214,16 +214,13 @@ export default function ThoughtScreen() {
 
   return (
     <View style={s.root}>
-      <StatusBar style="dark" />
+      <StatusBar style="light" />
 
       <LinearGradient
         colors={[C.gradientResultTop, C.gradientResultMid1, C.gradientResultMid2, C.gradientResultMid3, C.gradientMid4, C.gradientBottom]}
-        
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
         style={StyleSheet.absoluteFill}
       />
-
-      <View style={[s.blob, s.blob1]} />
-      <View style={[s.blob, s.blob2]} />
 
       <SafeAreaView style={s.safe} edges={['top']}>
         <ScrollView
@@ -345,17 +342,6 @@ const s = StyleSheet.create({
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingBottom: 20, gap: 22 },
 
-  // Blobs
-  blob: { position: 'absolute', borderRadius: 999 },
-  blob1: {
-    top: -80, right: -60, width: 280, height: 280,
-    backgroundColor: 'rgba(253, 221, 230, 0.55)',
-  },
-  blob2: {
-    bottom: -60, left: -80, width: 240, height: 240,
-    backgroundColor: 'rgba(212, 232, 209, 0.50)',
-  },
-
   // Top bar
   topBar: {
     flexDirection: 'row', alignItems: 'center',
@@ -363,7 +349,7 @@ const s = StyleSheet.create({
   },
   backBtn: { paddingVertical: 6 },
   backText: {
-    fontFamily: F.bodyMedium, fontSize: 15, color: C.textMuted,
+    fontFamily: F.bodyMedium, fontSize: 15, color: C.textSecondary,
   },
 
   // Prompt
@@ -373,7 +359,7 @@ const s = StyleSheet.create({
     letterSpacing: 0.5, textTransform: 'uppercase',
   },
   promptText: {
-      fontFamily: F.scriptItalic, fontSize: 15, color: C.textSecondary,
+      fontFamily: F.scriptItalic, fontSize: 15, color: C.text,
       lineHeight: 22,
     },
     savedTo: {
@@ -388,7 +374,13 @@ const s = StyleSheet.create({
     borderRadius: 22,
     backgroundColor: C.surface,
     borderWidth: 1, borderColor: C.border,
+    borderTopWidth: 1, borderTopColor: C.borderHi,
     minHeight: 200,
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.35,
+    shadowRadius: 20,
+    elevation: 4,
   },
   responseText: {
     fontFamily: F.body, fontSize: 17, color: C.text,
@@ -425,13 +417,14 @@ const s = StyleSheet.create({
     borderRadius: 14,
     backgroundColor: C.surface,
     borderWidth: 1, borderColor: C.border,
+    borderTopWidth: 1, borderTopColor: C.borderHi,
   },
   actionBtnActive: {
-    backgroundColor: 'rgba(201,123,99,0.10)',
-    borderColor: 'rgba(201,123,99,0.30)',
+    backgroundColor: C.sosLight,
+    borderColor: 'rgba(232,116,97,0.30)',
   },
   actionIcon: { fontSize: 20 },
   actionLabel: {
-    fontFamily: F.bodyMedium, fontSize: 12, color: C.textSecondary,
+    fontFamily: F.bodyMedium, fontSize: 12, color: C.text,
   },
 });

--- a/apps/mobile/app/upgrade.tsx
+++ b/apps/mobile/app/upgrade.tsx
@@ -21,7 +21,7 @@ import { SafeAreaView }  from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics      from 'expo-haptics';
 import { useChildProfile } from '../src/context/ChildProfileContext';
-import { fonts as F } from '../src/theme';
+import { colors as C, fonts as F } from '../src/theme';
 
 // ═══════════════════════════════════════════════
 // V3 DARK IDENTITY TOKENS (hardcoded per spec)
@@ -87,8 +87,21 @@ export default function UpgradeScreen() {
   const isYearly = selectedPlan === 'yearly';
 
   return (
-    <SafeAreaView style={s.root} edges={['top', 'bottom']}>
+    <View style={s.root}>
       <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          C.gradientResultTop,
+          C.gradientResultMid1,
+          C.gradientResultMid2,
+          C.gradientResultMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
 
       <ScrollView contentContainerStyle={s.scroll} showsVerticalScrollIndicator={false}>
         <Pressable onPress={() => router.back()} style={s.closeBtn} hitSlop={16}>
@@ -229,13 +242,14 @@ export default function UpgradeScreen() {
           <View style={{ height: 30 }} />
         </Animated.View>
       </ScrollView>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 
 const s = StyleSheet.create({
-  root:   { flex: 1, backgroundColor: BG },
+  root:   { flex: 1, backgroundColor: C.background },
   scroll: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 60 },
 
   // Close button

--- a/apps/mobile/app/welcome/index.tsx
+++ b/apps/mobile/app/welcome/index.tsx
@@ -434,11 +434,11 @@ const s = StyleSheet.create({
     width:           6,
     height:          6,
     borderRadius:    3,
-    backgroundColor: C.textMuted,
+    backgroundColor: 'rgba(255,255,255,0.35)',
   },
 
   dotActive: {
-    width:           18,
+    width:           24,
     backgroundColor: C.amber,
   },
 
@@ -447,8 +447,8 @@ const s = StyleSheet.create({
   cardWrap: {
     alignSelf:         'stretch',
     paddingHorizontal: 20,
-    paddingVertical:   20,
-    marginTop:         'auto',
+    paddingTop:        H * 0.32,
+    paddingBottom:     20,
   },
 
   card: {

--- a/apps/mobile/src/components/ui/PaywallSheet.tsx
+++ b/apps/mobile/src/components/ui/PaywallSheet.tsx
@@ -79,7 +79,7 @@ const s = StyleSheet.create({
     letterSpacing: -0.3,
   },
   body:  {
-    fontFamily: F.body, fontSize: 14, color: C.textSub, lineHeight: 21,
+    fontFamily: F.body, fontSize: 14, color: C.textSecondary, lineHeight: 21,
   },
   cta: {
     backgroundColor: C.amber,

--- a/apps/mobile/src/components/ui/ScriptCard.tsx
+++ b/apps/mobile/src/components/ui/ScriptCard.tsx
@@ -1,5 +1,6 @@
 // src/components/ui/ScriptCard.tsx
-// v5 — Journal identity: frosted glass cards, dark text, Manrope
+// v6 — Deep Warm v5.2: dark glass cards differentiated by colored
+// left-border stripe + badge pill. Numbered dot + label, expandable.
 
 import { useEffect, useRef, useState } from 'react';
 import {
@@ -12,6 +13,7 @@ import {
   UIManager,
   View,
 } from 'react-native';
+import { colors as C, fonts as F } from '../../theme/colors';
 
 if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true);
@@ -31,27 +33,40 @@ type Props = {
 };
 
 const STEP_CONFIG: Record<Step, {
-  num: string;
-  dotColor: string;
-  numBg: string;
-  cardBg: string;
-  cardBorder: string;
-  tintBg: string;
+  num:          string;
+  dotColor:     string;
+  numBg:        string;
+  cardBg:       string;
+  cardBorder:   string;
+  tintBg:       string;
+  accentBorder: string;
 }> = {
   Regulate: {
-    num: '1', dotColor: '#C97B63', numBg: '#C97B63',
-    cardBg: 'rgba(201,123,99,0.06)', cardBorder: 'rgba(201,123,99,0.15)',
-    tintBg: 'rgba(201,123,99,0.04)',
+    num: '1',
+    dotColor:     C.amber,
+    numBg:        C.amber,
+    cardBg:       C.surface,
+    cardBorder:   C.border,
+    tintBg:       C.amberBadge,
+    accentBorder: C.amberBorder,
   },
   Connect: {
-    num: '2', dotColor: '#5778A3', numBg: '#5778A3',
-    cardBg: 'rgba(87,120,163,0.06)', cardBorder: 'rgba(87,120,163,0.15)',
-    tintBg: 'rgba(87,120,163,0.04)',
+    num: '2',
+    dotColor:     C.sage,
+    numBg:        C.sage,
+    cardBg:       C.surface,
+    cardBorder:   C.border,
+    tintBg:       C.sageBadge,
+    accentBorder: C.sageBorder,
   },
   Guide: {
-    num: '3', dotColor: '#81B29A', numBg: '#81B29A',
-    cardBg: 'rgba(129,178,154,0.06)', cardBorder: 'rgba(129,178,154,0.15)',
-    tintBg: 'rgba(129,178,154,0.04)',
+    num: '3',
+    dotColor:     C.steel,
+    numBg:        C.steel,
+    cardBg:       C.surface,
+    cardBorder:   C.border,
+    tintBg:       C.steelBadge,
+    accentBorder: C.steelBorder,
   },
 };
 
@@ -82,8 +97,10 @@ export function ScriptCard({ step, parent_action, script, coaching, strategies, 
     <Animated.View style={[
       st.card,
       {
-        backgroundColor: expanded ? c.cardBg : 'rgba(255,255,255,0.5)',
-        borderColor: expanded ? c.cardBorder : 'rgba(0,0,0,0.06)',
+        backgroundColor:  c.cardBg,
+        borderColor:      c.cardBorder,
+        borderLeftWidth:  3,
+        borderLeftColor:  c.accentBorder,
       },
       { opacity, transform: [{ translateY }] },
     ]}>
@@ -93,7 +110,7 @@ export function ScriptCard({ step, parent_action, script, coaching, strategies, 
           <View style={[st.stepNum, { backgroundColor: c.numBg }]}>
             <Text style={st.stepNumText}>{c.num}</Text>
           </View>
-          <View style={st.badge}>
+          <View style={[st.badge, { backgroundColor: c.tintBg }]}>
             <View style={[st.badgeDot, { backgroundColor: c.dotColor }]} />
             <Text style={st.badgeText}>{step.toUpperCase()}</Text>
           </View>
@@ -108,7 +125,7 @@ export function ScriptCard({ step, parent_action, script, coaching, strategies, 
       {expanded ? (
         <View style={st.body}>
           <View style={st.actionWrap}>
-            <View style={[st.actionBar, { backgroundColor: `${c.dotColor}30` }]} />
+            <View style={[st.actionBar, { backgroundColor: c.dotColor, opacity: 0.4 }]} />
             <Text style={st.action}>👋 {parent_action}</Text>
           </View>
           <Text style={st.sayLabel}>SAY THIS</Text>
@@ -117,7 +134,7 @@ export function ScriptCard({ step, parent_action, script, coaching, strategies, 
           {hasCoaching ? (
             <>
               <Pressable onPress={handleCoachToggle} style={({ pressed }) => [st.coachToggle, pressed && { opacity: 0.7 }]}>
-                <View style={[st.coachIcon, { backgroundColor: `${c.dotColor}15` }]}>
+                <View style={[st.coachIcon, { backgroundColor: c.tintBg }]}>
                   <Text style={{ fontSize: 12 }}>💡</Text>
                 </View>
                 <Text style={st.coachToggleText}>Why this works</Text>
@@ -148,7 +165,16 @@ export function ScriptCard({ step, parent_action, script, coaching, strategies, 
 
 const st = StyleSheet.create({
   card: {
-    borderRadius: 20, overflow: 'hidden',
+    borderRadius:    18,
+    overflow:        'hidden',
+    borderWidth:     1,
+    borderTopColor:  C.borderHi,
+    borderTopWidth:  1,
+    shadowColor:     '#000000',
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
   },
 
   header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', padding: 16, paddingHorizontal: 18 },
@@ -157,47 +183,40 @@ const st = StyleSheet.create({
 
   stepNum: {
     width: 28, height: 28, borderRadius: 14, alignItems: 'center', justifyContent: 'center',
-    shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.15, shadowRadius: 6, elevation: 3,
   },
-  stepNumText: { fontFamily: 'Manrope-Bold', fontSize: 13, color: '#FFFFFF' },
+  stepNumText: { fontFamily: F.bold, fontSize: 13, color: '#FFFFFF' },
 
   badge: {
     flexDirection: 'row', alignItems: 'center', gap: 6,
     paddingVertical: 5, paddingHorizontal: 12, borderRadius: 10,
-    backgroundColor: 'rgba(0,0,0,0.03)', borderWidth: 1, borderColor: 'rgba(0,0,0,0.04)',
   },
-  badgeDot: {
-    width: 8, height: 8, borderRadius: 4,
-    shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.10, shadowRadius: 2, elevation: 1,
-  },
-  badgeText: { fontFamily: 'Manrope-SemiBold', fontSize: 10, letterSpacing: 0.8, color: 'rgba(42,37,32,0.45)' },
+  badgeDot: { width: 8, height: 8, borderRadius: 4 },
+  badgeText: { fontFamily: F.label, fontSize: 10, letterSpacing: 0.8, color: C.text },
 
-  preview: { fontFamily: 'Manrope-Medium', fontSize: 13, color: 'rgba(42,37,32,0.35)', maxWidth: 140 },
-  chevron: { fontSize: 10, color: 'rgba(42,37,32,0.20)' },
+  preview: { fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, maxWidth: 140 },
+  chevron: { fontSize: 10, color: C.textFaint },
 
   body: { paddingHorizontal: 18, paddingBottom: 18, gap: 10 },
 
   actionWrap: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
   actionBar: { width: 2, alignSelf: 'stretch', borderRadius: 1, marginTop: 2, marginBottom: 2 },
-  action: { fontFamily: 'Manrope-Medium', fontSize: 13, color: 'rgba(42,37,32,0.55)', lineHeight: 20, flex: 1 },
+  action: { fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 20, flex: 1, fontStyle: 'italic' },
 
-  sayLabel: { fontFamily: 'Manrope-SemiBold', fontSize: 9, letterSpacing: 0.8, color: 'rgba(42,37,32,0.25)', marginTop: 4 },
-  script: { fontFamily: 'Manrope-Medium', fontSize: 18, color: '#2A2520', lineHeight: 28 },
+  sayLabel: { fontFamily: F.label, fontSize: 9, letterSpacing: 0.8, color: C.textMuted, marginTop: 4 },
+  script: { fontFamily: F.script, fontSize: 18, color: C.text, lineHeight: 28 },
 
   coachToggle: {
     flexDirection: 'row', alignItems: 'center', gap: 8,
-    paddingTop: 14, borderTopWidth: 1, borderTopColor: 'rgba(0,0,0,0.04)', marginTop: 4,
+    paddingTop: 14, borderTopWidth: 1, borderTopColor: C.divider, marginTop: 4,
   },
   coachIcon: { width: 22, height: 22, borderRadius: 11, alignItems: 'center', justifyContent: 'center' },
-  coachToggleText: { fontFamily: 'Manrope-Medium', fontSize: 12, color: 'rgba(42,37,32,0.40)', flex: 1 },
-  coachChev: { fontSize: 8, color: 'rgba(42,37,32,0.20)' },
+  coachToggleText: { fontFamily: F.bodyMedium, fontSize: 12, color: C.textMuted, flex: 1 },
+  coachChev: { fontSize: 8, color: C.textFaint },
 
   coachBody: { gap: 8, marginTop: 4 },
-  coachText: { fontFamily: 'Manrope-Medium', fontSize: 14, color: 'rgba(42,37,32,0.60)', lineHeight: 22 },
+  coachText: { fontFamily: F.body, fontSize: 14, color: C.textSecondary, lineHeight: 22 },
   strats: { gap: 5 },
   stratRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
-  stratDot: { width: 5, height: 5, borderRadius: 3, marginTop: 7, opacity: 0.6 },
-  stratText: { fontFamily: 'Manrope-Medium', fontSize: 13, color: 'rgba(42,37,32,0.45)', lineHeight: 20, flex: 1 },
+  stratDot: { width: 5, height: 5, borderRadius: 3, marginTop: 7, opacity: 0.7 },
+  stratText: { fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 20, flex: 1 },
 });
-
-


### PR DESCRIPTION
## Summary

Coordinated migration of every remaining screen to **Deep Warm v5.2** — C-2 fast-fade gradient (`#d8d5d0 → #0C0C0C`), dark glass cards (`rgba(26,24,22,0.78)` with bright top edge + drop shadow), amber accents. Tokens come from `src/theme/colors.ts`; **routing logic and business rules are unchanged**.

Net diff: **18 files changed, 944 insertions, 684 deletions**.

## What landed

### Shared component
- **`src/components/ui/ScriptCard.tsx`** — R/C/G cards rebuilt as dark glass with colored left-stripe (`amber` / `sage` / `steel`) + badge pills. Drives every result screen.
- **`src/components/ui/PaywallSheet.tsx`** — `textSub` → `textSecondary`.

### Welcome polish (on top of PR #26)
- Cards moved up: `cardWrap.paddingTop = H * 0.32` so visual zone takes ~32%, card fills ~68%.
- Page dots: inactive `rgba(255,255,255,0.35)`, active width `18 → 24` for visibility.

### Settings
- C-2 settings gradient, dark-glass groups (no rose/sage tinting), amber section labels, divider via `C.divider`, amber upgrade chevron, account avatar on amber gradient. Sign-out kept in its own group.

### Auth
- Replaced 14 local hex constants with `C.*` tokens. Wrapped form in C-2 gradient (was solid `#0e0a10`). Form card on shared dark-glass. CTA = amber gradient with shadow; disabled = `C.disabled`. Headlines on warm zone (`textDark`).

### Result
- Result-variant gradient. ScriptCards inherit the new system. Voice / Avoid / Feedback / Footer cards on shared dark-glass mixin. Avoid X marks + safety link in `C.sos`. Voice play button stays sage. Footer fade replaced linen tint with dark (`transparent → rgba(12,12,12,0.85) → C.background`). Retry: `C.sos`. Save/Copy: dark-glass ghost.

### Child hub (`child/[id].tsx`)
- Removed `welcome-horizon.jpg` + photo dim layer; C-2 gradient. Identity (avatar, name, age) on warm zone (`textDark` / `textDarkSecondary`). Avatar amber. Textarea uses `C.inputBg` / `C.inputBorder` / `C.inputHighlight`, focus on `C.borderFocus`. Tone + intensity pills: amber selected. CTA: amber gradient when enabled, dark-glass disabled. Crisis banner: `C.sosLight` + `C.sos`. Insights/profile-link: sage-tinted.

### Child profile (`child-profile/[id].tsx`)
- Photo backdrop gone, C-2 gradient. Avatar amber. Warm-zone text. All sections dark-glass. COMING SOON pill: `C.amberBadge` + `C.amber`.

### Add child (`child/new.tsx`)
- Removed Stars + multi-stop dark gradient → single C-2. Form card flat dark-glass (no LinearGradient). Hint card amber-tinted (was sage). Save button amber gradient / `C.disabled`. Inputs use input tokens.

### Crisis
- Result-variant gradient. Warm-zone header. Cards on shared dark-glass mixin with steel-tinted borders for the "calm support" feel. Resource arrows in `C.steel`.

### Account (pause / delete / export)
- Stripped 21 local constants (`BG`/`TEXT`/`TEXT_SEC`/`TEXT_MUTED`/`CORAL`/`AMBER_DEEP`/`AMBER_LIGHT`) across the 3 files; everything now references `C.*` directly. CTA gradients tokenized to `[C.amber, C.amberMid]`.

### Upgrade
- Wrapped in result-variant gradient. Local `BG` → `C.background`.

### History
- `colors.coral` → `colors.sos`, `colors.textSub`/`textBody` → `colors.textSecondary`, `colors.danger` → `colors.sos`.

### Saved + thought/[id] + child-setup
- Token migration via batch sed (rose → sos, cardGlass → surface, base → background, textSub/textBody → textSecondary, etc.).

### Legal
- Already on tokens. No change needed.

## Out of scope (intentional)

- `src/components/ui/Card.tsx` keeps its backwards-compat `coral`/`blue`/`peach` accent aliases — they map to `primary`/`steel`/`amber` via existing tokens in `colors.ts`. Generic component, callers haven't been audited.
- `apps/mobile/assets/images/welcome/welcome-{family,horizon}.jpg` left on disk (no screen imports them now). Cleanup deferred.
- `src/theme/{colors,index}.ts` not modified — tokens locked.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `grep "C.rose|C.cardGlass|C.base|C.gradStart|C.textSub|HORIZON_PHOTO"` — no consumer matches across `apps/mobile/app` + `apps/mobile/src`
- [ ] Manual on device:
  - Welcome carousel: 5 pages with C-2 gradient, splash centered, "From chaos. / To connection.", visible amber dots, cards floating high enough
  - Auth: dark gradient, dark-glass form, amber CTA, SOS error
  - Home: pure C-2 gradient (no photo), greeting in `textDark` on warm zone, "What's happening right now?" in `sosSubtle`, icon-badge outcome grid, dark-glass children section
  - Child hub: no photo, dark-glass throughout, amber CTA, SOS crisis link
  - Result: result-variant gradient, dark-glass R/C/G with colored stripes, no light-grey cards anywhere
  - Child profile: dark-glass cards, amber COMING SOON
  - Settings: C-2 settings gradient, dark-glass cards, amber section labels, amber upgrade arrow
  - Crisis: dark gradient, calm steel cards, phone numbers tappable
  - Add child: dark-glass cards, amber age number, amber CTA
  - Account screens: pause/delete/export all on tokens, amber gradient CTAs
  - Tab bar: amber active, shadow separator (no border line)
- [ ] Unchanged: routing, AI prompts, business rules, Edge Functions, theme tokens themselves

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_