### PR TITLE
launch: per-user rate limit + pause-cleanup cron + SOS safety filter

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -39,7 +39,7 @@ import * as Haptics from 'expo-haptics';
 import { useAuth } from '../../src/context/AuthContext';
 import { useChildProfile } from '../../src/context/ChildProfileContext';
 import { supabase } from '../../src/lib/supabase';
-import { getQuestionResponse, CrisisDetectedError } from '../../src/lib/api';
+import { getQuestionResponse, CrisisDetectedError, RateLimitError } from '../../src/lib/api';
 import { colors as C, fonts as F } from '../../src/theme';
 
 // ═══════════════════════════════════════════════
@@ -237,6 +237,10 @@ export default function HomeScreen() {
           pathname: '/crisis',
           params: { crisisType: err.crisisType, riskLevel: err.riskLevel },
         });
+        return;
+      }
+      if (err instanceof RateLimitError) {
+        setError(err.message);
         return;
       }
       setError("Couldn't get a response right now. Please try again.");

--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -24,7 +24,7 @@ import * as Haptics from 'expo-haptics';
 
 import { useAuth } from '../../src/context/AuthContext';
 import { useChildProfile } from '../../src/context/ChildProfileContext';
-import { getParentingScript, CrisisDetectedError } from '../../src/lib/api';
+import { getParentingScript, CrisisDetectedError, RateLimitError } from '../../src/lib/api';
 import { detectCrisis } from '../../src/hooks/useCrisisMode';
 import { loadSavedScripts, type SavedScriptRow } from '../../src/lib/loadSavedScripts';
 import { incrementScriptCount } from '../../src/utils/profileNudge';
@@ -303,6 +303,10 @@ export default function ChildHubScreen() {
           pathname: '/crisis',
           params: { crisisType: err.crisisType, riskLevel: err.riskLevel },
         });
+        return;
+      }
+      if (err instanceof RateLimitError) {
+        setError(err.message);
         return;
       }
       setError("Couldn't get a script right now. Please try again.");

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -74,6 +74,27 @@ export class CrisisDetectedError extends Error {
 }
 
 
+// Thrown when the Edge Function returns 429. Server-supplied message is the
+// safe one to surface to the parent. Crisis paths bypass the rate limit by
+// design, so callers don't need to special-case crisis here.
+export class RateLimitError extends Error {
+  readonly retryAfterSeconds: number | null;
+  constructor(message: string, retryAfterSeconds: number | null) {
+    super(message);
+    this.name              = 'RateLimitError';
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+
+function parseRetryAfter(response: Response): number | null {
+  const raw = response.headers.get('Retry-After');
+  if (!raw) return null;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+
 function isValidStep(v: unknown): v is ScriptStep {
   if (!v || typeof v !== 'object') return false;
   const s = v as Record<string, unknown>;
@@ -142,6 +163,9 @@ export async function getParentingScript(
       typeof (data as { error: unknown }).error === 'string'
         ? (data as { error: string }).error : 'request-failed';
     console.log('[API] Response not ok:', msg);
+    if (response.status === 429) {
+      throw new RateLimitError(msg, parseRetryAfter(response));
+    }
     throw new Error(msg);
   }
 
@@ -236,6 +260,9 @@ export async function getQuestionResponse(
       typeof (data as { error: unknown }).error === 'string'
         ? (data as { error: string }).error : 'request-failed';
     console.log('[API] Question response not ok:', msg);
+    if (response.status === 429) {
+      throw new RateLimitError(msg, parseRetryAfter(response));
+    }
     throw new Error(msg);
   }
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -427,3 +427,121 @@ that were a workaround for the missing FKs PR 19 fixed at the source.
 The export update closes a real gap — exporting a parent's account
 without their saved scripts would not have honoured the "Export your
 data first" promise in the privacy policy.
+
+### 2026-05-06 — Anthropic rate limit + scheduled-pause-cleanup cron + SOS safety filter fix
+
+**Context:** Pre-launch audit identified two production-readiness gaps and
+one latent safety bug:
+
+1. The `chat-parenting-assistant` Edge Function had no per-user rate limit.
+   A single user (or bot) could call the SOS or Question endpoints in a
+   tight loop, billing real Anthropic spend with no ceiling. CLAUDE.md
+   warns about this scenario explicitly and the FEATURE_INVENTORY flagged
+   it. Real launch risk.
+2. `scheduled-pause-cleanup` was deployed in the Edge Functions runtime
+   and declared in `supabase/config.toml`, but the cron schedule itself
+   was never wired. Without it, paused accounts never auto-delete at the
+   30-day mark — a privacy-policy promise that wouldn't be kept.
+3. While reviewing the code, the safety filter was found running ONLY on
+   the `mode === 'question'` branch. The SOS path (the larger, more common
+   path) bypassed it entirely. CLAUDE.md says "Safety filter precedes
+   Claude. Don't bypass it for the question path — questions can carry
+   crisis content." The current state was the inverse — the SOS path was
+   the bypassed one. A parent describing a crisis on SOS would get a
+   normal R/C/G script back instead of being routed to /crisis.
+
+**Decision:** Fixed all three in a single PR.
+
+1. Added `supabase/functions/_shared/rateLimit.ts` with two abuse-prevention
+   caps that are deliberately above any real parent's usage. Both are
+   counted from the existing `usage_events` table — no new tables, single
+   PostgREST round-trip per request:
+
+   | Window | Cap | Why |
+   |---|---|---|
+   | 60 s burst | 10 events | covers retries + follow-ups during a hard moment |
+   | 24 h daily | 100 events | ~5x the heaviest plausible parent-day |
+
+   Counted event types: `script_generated`, `followup_generated`,
+   `question_generated`. The crisis path bypasses the limit entirely
+   (Principle 4 — crisis is always free). On any DB error the helper
+   fails OPEN (returns `ok: true` with a console.warn) so a transient
+   Supabase outage doesn't block real parents during a hard moment;
+   Anthropic-side billing alerts are the real cost ceiling.
+
+2. Lifted `runSafetyFilter(input.message)` out of the `mode === 'question'`
+   branch in `chat-parenting-assistant/index.ts` so it runs on every path
+   before any Anthropic call. Crisis short-circuits with the same 200
+   crisis envelope the question path used. The rate limit then runs only
+   for the safe path (so crisis is never blocked).
+
+3. Created migration `20260506_005_schedule_pause_cleanup_cron.sql` that
+   enables `pg_cron` + `pg_net` extensions and registers a daily 03:00 UTC
+   job calling `/scheduled-pause-cleanup` over HTTPS. The URL and bearer
+   secret are pulled from runtime database settings the operator sets
+   once per environment — see "Operator setup" below.
+
+   Mobile-side, `RateLimitError` is added to `apps/mobile/src/lib/api.ts`
+   and surfaced in both Home (Question) and child hub (SOS) handlers,
+   showing the server-supplied message ("Sturdy needs a brief breather…"
+   or "You've hit Sturdy's daily limit. It resets in 24 hours.") inline
+   instead of the generic "couldn't get a response" copy.
+
+**Operator setup (one-time per environment, run via Supabase SQL Editor as
+superuser, NOT in a migration since values are environment-specific):**
+
+```
+alter database postgres set app.functions_url
+  = 'https://<project-ref>.supabase.co/functions/v1';
+alter database postgres set app.cron_secret
+  = '<value-of-CRON_SHARED_SECRET-set-via-supabase-secrets>';
+```
+
+**Verification:**
+
+```sql
+-- Cron job registered
+select jobid, jobname, schedule, active from cron.job
+ where jobname = 'scheduled-pause-cleanup';
+
+-- After the first scheduled tick (or manual trigger):
+select status, return_message, start_time, end_time
+  from cron.job_run_details
+ where jobid = (select jobid from cron.job
+                 where jobname = 'scheduled-pause-cleanup')
+ order by start_time desc limit 5;
+```
+
+```bash
+# Rate limit smoke test (replace <USER_JWT> with a real authenticated user):
+for i in $(seq 1 12); do
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -X POST "$PROJECT_URL/functions/v1/chat-parenting-assistant" \
+    -H "Authorization: Bearer $ANON_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{"childName":"Test","childAge":5,"message":"hi","userId":"<USER_ID>"}'
+done
+# Expect: first ~10 return 200; the 11th returns 429 with Retry-After: 60.
+```
+
+**Rollback:**
+- Migration: `select cron.unschedule('scheduled-pause-cleanup');`
+- Rate limit: revert `_shared/rateLimit.ts` import + the safety/rate
+  block in `chat-parenting-assistant/index.ts`. Mobile `RateLimitError`
+  branches are no-ops if the server stops returning 429.
+
+**Reasoning:** The two pre-launch gaps were single-user cost exposure and
+an unkept privacy-policy promise — both real, both solvable with one PR.
+The SOS safety filter bypass was found during the rate-limit insertion
+work and is severe enough that it would have shipped at launch
+otherwise. Folding the fix in here means CLAUDE.md's "safety precedes
+Claude" rule is finally enforced on every path.
+
+**Out of scope (logged for follow-up):**
+- JWT validation in `chat-parenting-assistant` (closes the userId-rotation
+  rate-limit bypass; needs mobile client coordination).
+- Anthropic retry/backoff for transient 429/5xx (S4 from the launch audit).
+- Sentry breadcrumb for rate-limit hits (will land with H8 / Sentry wiring).
+- Composite index on `usage_events(user_id, created_at)` (S6) — works on
+  the existing single-column indexes today; revisit when usage scales past
+  ~100k events/user.

--- a/supabase/functions/_shared/rateLimit.ts
+++ b/supabase/functions/_shared/rateLimit.ts
@@ -1,0 +1,154 @@
+// supabase/functions/_shared/rateLimit.ts
+//
+// Per-user abuse-prevention rate limit on the Anthropic-backed paths in
+// chat-parenting-assistant. Caps below are deliberately above any real
+// parent's usage — they exist to prevent runaway cost from spam or bots,
+// not to gate features (Principle 6 forbids quotas as feature gates).
+//
+// Counts hits in the `usage_events` table, where the existing logUsageEvent
+// writes after every Anthropic call (script_generated, followup_generated,
+// question_generated). Both windows are checked in a single round-trip.
+//
+// Crisis-routed responses bypass the limit entirely (Principle 4 — crisis
+// is always free) and are not counted because the crisis path returns
+// before logUsageEvent.
+//
+// Auth note: the function trusts `userId` from the request body, so the
+// rate-limit attaches to whoever the client claims to be. A determined
+// attacker rotating user_ids could bypass — JWT validation is a follow-up
+// and would close that gap. For honest abuse + accidental loops this is
+// already enough to prevent billing shock.
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SUPABASE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+
+// ─── Caps ─────────────────────────────────────────────────────────────────────
+//
+// Tuned for a real parent's usage patterns:
+//   - 5-10 SOS scripts during a single hard moment is plausible (retries,
+//     follow-ups). 10/minute leaves headroom without blocking anyone real.
+//   - 100/day is ~5x the heaviest plausible day. Anything past that is
+//     a bot or a stuck retry loop.
+
+const BURST_WINDOW_SECONDS = 60;
+const BURST_MAX             = 10;
+
+const DAILY_WINDOW_SECONDS = 24 * 60 * 60;
+const DAILY_MAX             = 100;
+
+// ─── Result type ──────────────────────────────────────────────────────────────
+
+export type RateLimitResult =
+  | { ok: true }
+  | { ok: false; status: 401 | 429; error: string; retryAfterSeconds?: number };
+
+// ─── Counted event types ──────────────────────────────────────────────────────
+
+const COUNTED_EVENT_TYPES = [
+  "script_generated",
+  "followup_generated",
+  "question_generated",
+];
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns ok=false if the user has exceeded a window. Caller should return
+ * the included status + error directly to the client and skip the Anthropic
+ * call.
+ *
+ * On any DB error this fails OPEN (returns ok: true) so a transient Supabase
+ * outage doesn't block real parents from getting a script during a hard
+ * moment. The cost ceiling is preserved by Anthropic-side billing alerts —
+ * which this function complements, not replaces.
+ */
+export async function checkAnthropicRateLimit(
+  userId: string | null,
+): Promise<RateLimitResult> {
+  if (!userId) {
+    return {
+      ok:     false,
+      status: 401,
+      error:  "Sign in to continue.",
+    };
+  }
+
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    // No DB — fail open; logged so the operator notices.
+    console.warn("[STURDY_RATELIMIT] missing SUPABASE_URL/KEY; failing open");
+    return { ok: true };
+  }
+
+  // Single PostgREST query with two conditional aggregates.
+  // PostgREST can't do `count(*) FILTER (WHERE ...)` directly, so we use
+  // an RPC-style approach: we pull the most recent N rows (where N >
+  // DAILY_MAX so we know we'd hit the cap) and bucket them in JS. This
+  // avoids needing a database function while staying cheap (the
+  // (user_id, created_at) range query is index-friendly).
+  const sinceIso = new Date(Date.now() - DAILY_WINDOW_SECONDS * 1000).toISOString();
+  const eventTypeIn = COUNTED_EVENT_TYPES.map((t) => `"${t}"`).join(",");
+
+  const url =
+    `${SUPABASE_URL}/rest/v1/usage_events` +
+    `?select=created_at` +
+    `&user_id=eq.${userId}` +
+    `&event_type=in.(${eventTypeIn})` +
+    `&created_at=gte.${encodeURIComponent(sinceIso)}` +
+    `&order=created_at.desc` +
+    `&limit=${DAILY_MAX + 5}`;
+
+  let rows: Array<{ created_at: string }>;
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        "apikey":        SUPABASE_KEY,
+        "Authorization": `Bearer ${SUPABASE_KEY}`,
+        "Accept":        "application/json",
+      },
+    });
+    if (!res.ok) {
+      console.warn("[STURDY_RATELIMIT] PostgREST non-OK", res.status);
+      return { ok: true };
+    }
+    rows = await res.json();
+  } catch (err) {
+    console.warn("[STURDY_RATELIMIT] fetch failed; failing open", err);
+    return { ok: true };
+  }
+
+  const now      = Date.now();
+  const burstCutoff = now - BURST_WINDOW_SECONDS * 1000;
+
+  let burstCount = 0;
+  for (const r of rows) {
+    if (Date.parse(r.created_at) >= burstCutoff) burstCount += 1;
+  }
+  const dailyCount = rows.length; // already filtered by since=daily-cutoff
+
+  if (burstCount >= BURST_MAX) {
+    return {
+      ok:                false,
+      status:            429,
+      error:             "Sturdy needs a brief breather. Try again in a minute.",
+      retryAfterSeconds: BURST_WINDOW_SECONDS,
+    };
+  }
+
+  if (dailyCount >= DAILY_MAX) {
+    return {
+      ok:                false,
+      status:            429,
+      error:             "You've hit Sturdy's daily limit. It resets in 24 hours.",
+      retryAfterSeconds: DAILY_WINDOW_SECONDS,
+    };
+  }
+
+  return { ok: true };
+}
+
+// Exported for tests + the Operations log.
+export const RATE_LIMIT_CAPS = {
+  burst: { windowSeconds: BURST_WINDOW_SECONDS, max: BURST_MAX },
+  daily: { windowSeconds: DAILY_WINDOW_SECONDS, max: DAILY_MAX },
+} as const;

--- a/supabase/functions/chat-parenting-assistant/index.ts
+++ b/supabase/functions/chat-parenting-assistant/index.ts
@@ -8,6 +8,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { buildPrompt }              from "../_shared/buildPrompt.ts";
 import { validateResponse }         from "../_shared/validateResponse.ts";
 import { runSafetyFilter }          from "../_shared/safetyFilter.ts";
+import { checkAnthropicRateLimit }  from "../_shared/rateLimit.ts";
 import { classifyTrigger }          from "../_shared/triggerClassifier.ts";
 import { buildQuestionPrompt }      from "../_shared/prompts/question.ts";
 import { validateQuestionResponse } from "../_shared/validateQuestionResponse.ts";
@@ -26,10 +27,10 @@ function cors() {
   };
 }
 
-function jsonRes(body: unknown, status = 200) {
+function jsonRes(body: unknown, status = 200, extraHeaders: Record<string, string> = {}) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...cors(), "Content-Type": "application/json" },
+    headers: { ...cors(), "Content-Type": "application/json", ...extraHeaders },
   });
 }
 
@@ -230,14 +231,36 @@ serve(async (req) => {
   try { input = validateInput(body); }
   catch (e) { return jsonRes({ error: e instanceof Error ? e.message : "Invalid request." }, 400); }
 
-// Safety filter — also for question mode (questions can carry crisis content too)
-      if (input.mode === 'question') {
-        const safety = runSafetyFilter(input.message);
-        if (!safety.isSafe) {
-          logSafetyEvent({ userId: input.userId, childProfileId: input.childProfileId, messageExcerpt: input.message, riskLevel: safety.riskLevel, policyRoute: safety.policyRoute, crisisType: safety.crisisType });
-          return jsonRes({ response_type: "crisis", crisis_type: safety.crisisType, risk_level: safety.riskLevel, policy_route: safety.policyRoute }, 200);
-        }
-      }
+  // ─── Safety filter — runs on every path before any Anthropic call.
+  //     Crisis short-circuits with a 200 + crisis envelope; never counted
+  //     against the rate limit (Principle 4 — crisis is always free). ───
+  const safety = runSafetyFilter(input.message);
+  if (!safety.isSafe) {
+    logSafetyEvent({
+      userId:         input.userId,
+      childProfileId: input.childProfileId,
+      messageExcerpt: input.message,
+      riskLevel:      safety.riskLevel,
+      policyRoute:    safety.policyRoute,
+      crisisType:     safety.crisisType,
+    });
+    return jsonRes({
+      response_type: "crisis",
+      crisis_type:   safety.crisisType,
+      risk_level:    safety.riskLevel,
+      policy_route:  safety.policyRoute,
+    }, 200);
+  }
+
+  // ─── Rate limit — abuse prevention only. Caps live in _shared/rateLimit.ts. ───
+  const rate = await checkAnthropicRateLimit(input.userId);
+  if (!rate.ok) {
+    const headers: Record<string, string> = {};
+    if (rate.retryAfterSeconds) {
+      headers["Retry-After"] = String(rate.retryAfterSeconds);
+    }
+    return jsonRes({ error: rate.error }, rate.status, headers);
+  }
 
       // ─── Question mode branch ───
       if (input.mode === 'question') {

--- a/supabase/migrations/20260506_005_schedule_pause_cleanup_cron.sql
+++ b/supabase/migrations/20260506_005_schedule_pause_cleanup_cron.sql
@@ -1,0 +1,88 @@
+-- 20260506_005_schedule_pause_cleanup_cron.sql
+--
+-- Schedules the daily cron job that triggers the scheduled-pause-cleanup
+-- Edge Function. Without this migration, paused accounts never get
+-- automatically deleted at the 30-day mark — which means the privacy
+-- policy promise ("auto-deleted after 30 days") would not be kept.
+--
+-- The Edge Function itself was shipped in PR #18 (account-deletion-flow)
+-- and re-asserted in OPERATIONS.md. This migration only wires the schedule.
+--
+-- ─────────────────────────────────────────────────────────────────────────
+-- OPERATOR SETUP (must run once per environment, NOT in this migration —
+-- the values are environment-specific and should not be checked into git):
+-- ─────────────────────────────────────────────────────────────────────────
+--
+--   alter database postgres set app.functions_url
+--     = 'https://<project-ref>.supabase.co/functions/v1';
+--   alter database postgres set app.cron_secret
+--     = '<value-of-CRON_SHARED_SECRET-set-via-supabase-secrets>';
+--
+-- The `app.cron_secret` value must match `CRON_SHARED_SECRET` set on the
+-- Edge Function (used by `_shared/accountAuth.ts:requireSystemCaller`).
+-- ─────────────────────────────────────────────────────────────────────────
+
+begin;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 1. Extensions
+-- ─────────────────────────────────────────────────────────────────────────
+-- pg_cron schedules SQL statements at fixed cron expressions.
+-- pg_net lets us invoke the Edge Function over HTTPS from inside SQL.
+-- Both ship with managed Supabase. On self-hosted Postgres these may need
+-- to be installed manually.
+
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- 2. Schedule
+-- ─────────────────────────────────────────────────────────────────────────
+-- Runs daily at 03:00 UTC — a low-traffic window. The job calls
+-- /scheduled-pause-cleanup which queries for paused_at < (now - 30 days),
+-- iterates each, and calls account-delete with confirmationText
+-- "PAUSE_EXPIRED".
+--
+-- The cron job is idempotent: re-running this migration is safe because
+-- cron.schedule replaces an existing job with the same name.
+
+select cron.schedule(
+  'scheduled-pause-cleanup',
+  '0 3 * * *',
+  $$
+  select net.http_post(
+    url     := current_setting('app.functions_url') || '/scheduled-pause-cleanup',
+    headers := jsonb_build_object(
+      'Authorization', 'Bearer ' || current_setting('app.cron_secret'),
+      'Content-Type',  'application/json'
+    ),
+    body    := '{}'::jsonb
+  );
+  $$
+);
+
+commit;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- VERIFICATION (run after the operator setup commands above):
+-- ─────────────────────────────────────────────────────────────────────────
+--
+--   -- The job should appear:
+--   select jobid, jobname, schedule, active, command
+--     from cron.job where jobname = 'scheduled-pause-cleanup';
+--
+--   -- Recent runs (after the first scheduled tick):
+--   select jobid, status, return_message, start_time, end_time
+--     from cron.job_run_details
+--     where jobid = (select jobid from cron.job where jobname = 'scheduled-pause-cleanup')
+--     order by start_time desc limit 5;
+--
+-- ─────────────────────────────────────────────────────────────────────────
+-- ROLLBACK
+-- ─────────────────────────────────────────────────────────────────────────
+--
+--   begin;
+--     select cron.unschedule('scheduled-pause-cleanup');
+--   commit;
+--
+-- (Extensions are left installed — other migrations may rely on them.)


### PR DESCRIPTION
## Summary

Closes the two scariest pre-launch gaps + a latent safety bug discovered during the work.

| # | What | Why critical for launch |
|---|---|---|
| **H6** | Per-user Anthropic rate limit | Without it, a single user (or bot) calling SOS in a tight loop bills real Anthropic spend with no ceiling. **Real launch risk.** |
| **H7** | `scheduled-pause-cleanup` cron actually scheduled | The privacy policy promises "auto-deleted after 30 days." Without the cron firing, that promise wasn't kept. |
| **Safety bug** | `runSafetyFilter` was running **only on the question path** | CLAUDE.md says safety precedes Claude on every path. SOS was bypassing it. A crisis-content SOS message would get a normal R/C/G script instead of being routed to /crisis. |

## What's in

### H6 — Per-user rate limit
- New **`supabase/functions/_shared/rateLimit.ts`** with two abuse-prevention caps:

  | Window | Cap | Reasoning |
  |---|---|---|
  | **60 s** | 10 events | covers retries + follow-ups during a hard moment |
  | **24 h** | 100 events | ~5x the heaviest plausible parent-day; catches bot/abuse |

- Counted event types: `script_generated`, `followup_generated`, `question_generated`. Crisis path bypasses (Principle 4 — crisis is always free).
- Single PostgREST round-trip per request against `usage_events`. Fails **open** on DB error (transient Supabase outage doesn't block real parents during a hard moment; Anthropic billing alerts are the real cost ceiling).
- Mobile-side **`RateLimitError`** surfaces the server-supplied 429 message inline ("Sturdy needs a brief breather…" / "You've hit Sturdy's daily limit. It resets in 24 hours.") in both Home (Question) and child hub (SOS) handlers.

### H7 — Pg_cron schedule
- New migration `20260506_005_schedule_pause_cleanup_cron.sql`: enables `pg_cron` + `pg_net`, registers a daily 03:00 UTC job calling `/scheduled-pause-cleanup` via `net.http_post`.
- URL + bearer secret read from runtime DB settings (`app.functions_url`, `app.cron_secret`) — the operator sets these once per environment via SQL Editor (NOT in migration; values are environment-specific).

### Safety-first ordering
- `runSafetyFilter` now runs **before** the mode branch, so SOS + Question both go through it.
- Order in `chat-parenting-assistant/index.ts`:
  ```
  preflight → JSON parse → validateInput → runSafetyFilter → 
    crisis? → return 200 crisis envelope (free, never rate-limited)
    safe? → checkAnthropicRateLimit → 
      ok? → mode branch → Anthropic → log → return
      blocked? → return 429 + Retry-After
  ```

## Operator setup (must run once per environment)

```sql
-- via Supabase SQL Editor as superuser
alter database postgres set app.functions_url
  = 'https://<project-ref>.supabase.co/functions/v1';
alter database postgres set app.cron_secret
  = '<value-of-CRON_SHARED_SECRET-set-via-supabase-secrets>';
```

`app.cron_secret` matches `CRON_SHARED_SECRET` already used by `_shared/accountAuth.ts:requireSystemCaller`.

## Test plan

- [x] `cd apps/mobile && npx tsc --noEmit` clean
- [ ] **Apply migration on staging:**
  ```sql
  select jobid, jobname, schedule, active from cron.job
   where jobname = 'scheduled-pause-cleanup';
  -- expect: 1 row, schedule='0 3 * * *', active=true
  ```
- [ ] **Rate-limit smoke test on staging:**
  ```bash
  for i in $(seq 1 12); do
    curl -s -o /dev/null -w "%{http_code}\n" \
      -X POST "$PROJECT_URL/functions/v1/chat-parenting-assistant" \
      -H "Authorization: Bearer $ANON_KEY" \
      -H "Content-Type: application/json" \
      -d '{"childName":"Test","childAge":5,"message":"hi","userId":"<USER_ID>"}'
  done
  # expect: first ~10 return 200, 11th returns 429 with Retry-After: 60
  ```
- [ ] **Safety filter on SOS:**
  ```bash
  # Send a crisis-content SOS message, verify response_type === "crisis"
  # (was previously returning a normal R/C/G script — bug fixed)
  ```
- [ ] **Cron tick (manual):**
  ```sql
  -- Force the job to run now (don't wait 24h)
  select cron.schedule_job_now('scheduled-pause-cleanup');
  -- View result
  select status, return_message, start_time, end_time
    from cron.job_run_details
   where jobid = (select jobid from cron.job where jobname = 'scheduled-pause-cleanup')
   order by start_time desc limit 1;
  -- expect: status='succeeded', return_message contains a request_id (pg_net)
  ```

## Out of scope (logged for follow-up)

- **JWT validation** in `chat-parenting-assistant` — current `userId` comes from request body, so a determined attacker rotating user_ids could bypass the per-user cap. Closes that gap but needs mobile-client coordination. Tracked as a follow-up.
- Anthropic retry/backoff for transient 429/5xx (S4 from launch audit).
- Sentry breadcrumb for rate-limit hits (will land with H8 / Sentry wiring).
- Composite index on `usage_events(user_id, created_at)` (S6) — single-column indexes are sufficient today; revisit at scale.

## Files

```
supabase/functions/_shared/rateLimit.ts                    (new, 130 LOC)
supabase/functions/chat-parenting-assistant/index.ts       (safety-first + rate-limit + jsonRes extraHeaders)
supabase/migrations/20260506_005_schedule_pause_cleanup_cron.sql  (new)
apps/mobile/src/lib/api.ts                                 (RateLimitError + 429 branches × 2)
apps/mobile/app/(tabs)/index.tsx                           (Question handler)
apps/mobile/app/child/[id].tsx                             (SOS handler)
docs/OPERATIONS.md                                         (2026-05-06 entry — full reasoning + verification)
```

Net: **7 files changed, 430 insertions, 12 deletions**.

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_