### PR TITLE
fix(cron): scheduled-pause-cleanup auth — X-Cron-Secret + Vault

### DIFF
--- a/supabase/migrations/20260506_005a_fix_pause_cleanup_cron_auth.sql
+++ b/supabase/migrations/20260506_005a_fix_pause_cleanup_cron_auth.sql
@@ -2,57 +2,78 @@
 --
 -- Corrective migration for 20260506_005_schedule_pause_cleanup_cron.sql.
 --
--- The original migration sent the cron secret in the Authorization header
--- as `Bearer <secret>`. But _shared/accountAuth.ts:requireSystemCaller only
--- accepts that bearer pattern when the value equals SUPABASE_SERVICE_ROLE_KEY
--- (lines 85-88). For a dedicated cron secret, the function expects the
--- value in an `X-Cron-Secret` header (lines 82, 90-91).
+-- Two issues with the original:
 --
--- As wired pre-fix, every cron tick would have failed 401, so paused
--- accounts would never be auto-deleted at the 30-day mark — breaking
--- the privacy-policy promise.
+-- 1. Auth header mismatch. The original sent `Authorization: Bearer <secret>`,
+--    but _shared/accountAuth.ts:requireSystemCaller only accepts the bearer
+--    pattern when the value equals SUPABASE_SERVICE_ROLE_KEY (lines 85-88).
+--    For a dedicated cron secret, the function expects an `X-Cron-Secret`
+--    header (lines 82, 90-91). As wired pre-fix, every cron tick failed 401
+--    so paused accounts never auto-deleted at the 30-day mark — breaking
+--    the privacy-policy promise.
 --
--- This migration re-issues cron.schedule() with the corrected header.
--- cron.schedule replaces any existing job with the same name, so this
--- is idempotent and supersedes the original schedule.
+-- 2. The original used `current_setting('app.cron_secret')` which requires
+--    `ALTER DATABASE postgres SET app.cron_secret = '...'`. That SQL kept
+--    failing with paste artifacts in the Supabase SQL Editor. We pivot to
+--    Supabase Vault — the recommended pattern for storing cron secrets on
+--    Supabase Cloud.
+--
+-- This migration:
+--   - Reads the secret from `vault.decrypted_secrets` instead of GUCs.
+--   - Hardcodes the functions URL (not sensitive — appears in mobile app
+--     bundle as EXPO_PUBLIC_SUPABASE_URL).
+--   - Sends X-Cron-Secret header instead of Authorization: Bearer.
+--
+-- cron.schedule() with the same job name replaces the prior schedule, so
+-- this migration is idempotent and supersedes 20260506_005.
 --
 -- ─────────────────────────────────────────────────────────────────────────
--- OPERATOR SETUP (must be in place before this migration takes effect):
+-- OPERATOR SETUP (must be in place BEFORE applying this migration):
 -- ─────────────────────────────────────────────────────────────────────────
 --
--- 1. Generate a random secret value:
---      select encode(gen_random_bytes(32), 'hex');
+-- 1. Set the Edge Function secret CRON_SHARED_SECRET in the Supabase
+--    Dashboard → Project Settings → Edge Functions → Secrets.
+--    Use a 64-char hex value: `select encode(gen_random_bytes(32), 'hex');`
 --
--- 2. Add that exact value as Edge Function secret in the Supabase Dashboard
---    (Project Settings → Edge Functions → Secrets) with name CRON_SHARED_SECRET.
+-- 2. Store the SAME hex value in Supabase Vault. Run in SQL Editor (type
+--    the SQL by hand — pasting can introduce non-breaking-space artifacts):
 --
--- 3. Set the matching DB settings:
---      alter database postgres
---        set app.functions_url = 'https://<project-ref>.supabase.co/functions/v1';
---      alter database postgres
---        set app.cron_secret   = '<the-hex-value-from-step-1>';
+--      select vault.create_secret(
+--        'PASTE_THE_64_CHAR_HEX_HERE',
+--        'cron_shared_secret',
+--        'Matches CRON_SHARED_SECRET Edge Function env. Used by scheduled-pause-cleanup cron.'
+--      );
 --
--- The two values (Edge Function secret + DB setting) MUST match exactly.
+-- 3. Verify before applying this migration:
+--
+--      select name, length(decrypted_secret) as secret_len
+--        from vault.decrypted_secrets
+--        where name = 'cron_shared_secret';
+--
+--    Expect 1 row, secret_len = 64.
+--
 -- ─────────────────────────────────────────────────────────────────────────
 
 begin;
 
--- Extensions are already installed by the original migration; we re-assert
--- with `if not exists` so this migration is safe to apply on environments
--- where the original was rolled back.
+-- Ensure required extensions are present. Idempotent — safe on environments
+-- where the original 20260506_005 migration was already applied or rolled
+-- back. supabase_vault is asserted defensively; on managed Supabase it
+-- is normally present out of the box.
 create extension if not exists pg_cron;
 create extension if not exists pg_net;
+create extension if not exists "supabase_vault";
 
--- Re-register the cron job with the corrected auth header.
--- Same job name → replaces the prior schedule.
+-- Re-register the cron job with the corrected auth header and Vault-based
+-- secret read. Same job name → replaces the prior schedule from 20260506_005.
 select cron.schedule(
   'scheduled-pause-cleanup',
   '0 3 * * *',
   $$
   select net.http_post(
-    url     := current_setting('app.functions_url') || '/scheduled-pause-cleanup',
+    url     := 'https://lwmzfhigommayvmvqzvf.supabase.co/functions/v1/scheduled-pause-cleanup',
     headers := jsonb_build_object(
-      'X-Cron-Secret', current_setting('app.cron_secret'),
+      'X-Cron-Secret', (select decrypted_secret from vault.decrypted_secrets where name = 'cron_shared_secret'),
       'Content-Type',  'application/json'
     ),
     body    := '{}'::jsonb
@@ -63,35 +84,31 @@ select cron.schedule(
 commit;
 
 -- ─────────────────────────────────────────────────────────────────────────
--- VERIFICATION:
+-- VERIFICATION (run after applying):
 -- ─────────────────────────────────────────────────────────────────────────
 --
--- 1. Confirm the schedule is using the new header:
+-- 1. Confirm the schedule is using the new pattern:
 --      select jobname, schedule, active, command
 --        from cron.job
 --        where jobname = 'scheduled-pause-cleanup';
---    The `command` column should contain the string 'X-Cron-Secret'.
+--    Command should contain both 'X-Cron-Secret' and 'vault.decrypted_secrets'.
 --
--- 2. Confirm DB settings are populated:
---      select current_setting('app.functions_url')      as url,
---             length(current_setting('app.cron_secret')) as secret_len;
---    Expect a URL ending in /functions/v1 and secret_len = 64
---    (32 random bytes hex-encoded).
---
--- 3. Live smoke test — invoke the same call the cron will make:
+-- 2. Live smoke test — invoke the same call the cron will make:
 --      select net.http_post(
---        url     := current_setting('app.functions_url') || '/scheduled-pause-cleanup',
+--        url     := 'https://lwmzfhigommayvmvqzvf.supabase.co/functions/v1/scheduled-pause-cleanup',
 --        headers := jsonb_build_object(
---          'X-Cron-Secret', current_setting('app.cron_secret'),
+--          'X-Cron-Secret', (select decrypted_secret from vault.decrypted_secrets where name = 'cron_shared_secret'),
 --          'Content-Type',  'application/json'
 --        ),
 --        body    := '{}'::jsonb
 --      );
---      -- then read the response:
+--
+--      -- read the response:
 --      select id, status_code, content::text
 --        from net._http_response
 --        order by id desc
 --        limit 1;
+--
 --    Expect status_code = 200. Pre-fix this returned 401.
 --
 -- ─────────────────────────────────────────────────────────────────────────
@@ -102,6 +119,4 @@ commit;
 --     select cron.unschedule('scheduled-pause-cleanup');
 --   commit;
 --
--- (To revert to the broken pre-fix state, re-apply 20260506_005 — but there
--- is no good reason to do this; the original migration's auth header was
--- a bug, not a deliberate design choice.)
+-- (Re-applying 20260506_005 would re-introduce the 401 auth bug — don't.)

--- a/supabase/migrations/20260506_005a_fix_pause_cleanup_cron_auth.sql
+++ b/supabase/migrations/20260506_005a_fix_pause_cleanup_cron_auth.sql
@@ -1,0 +1,107 @@
+-- 20260506_005a_fix_pause_cleanup_cron_auth.sql
+--
+-- Corrective migration for 20260506_005_schedule_pause_cleanup_cron.sql.
+--
+-- The original migration sent the cron secret in the Authorization header
+-- as `Bearer <secret>`. But _shared/accountAuth.ts:requireSystemCaller only
+-- accepts that bearer pattern when the value equals SUPABASE_SERVICE_ROLE_KEY
+-- (lines 85-88). For a dedicated cron secret, the function expects the
+-- value in an `X-Cron-Secret` header (lines 82, 90-91).
+--
+-- As wired pre-fix, every cron tick would have failed 401, so paused
+-- accounts would never be auto-deleted at the 30-day mark — breaking
+-- the privacy-policy promise.
+--
+-- This migration re-issues cron.schedule() with the corrected header.
+-- cron.schedule replaces any existing job with the same name, so this
+-- is idempotent and supersedes the original schedule.
+--
+-- ─────────────────────────────────────────────────────────────────────────
+-- OPERATOR SETUP (must be in place before this migration takes effect):
+-- ─────────────────────────────────────────────────────────────────────────
+--
+-- 1. Generate a random secret value:
+--      select encode(gen_random_bytes(32), 'hex');
+--
+-- 2. Add that exact value as Edge Function secret in the Supabase Dashboard
+--    (Project Settings → Edge Functions → Secrets) with name CRON_SHARED_SECRET.
+--
+-- 3. Set the matching DB settings:
+--      alter database postgres
+--        set app.functions_url = 'https://<project-ref>.supabase.co/functions/v1';
+--      alter database postgres
+--        set app.cron_secret   = '<the-hex-value-from-step-1>';
+--
+-- The two values (Edge Function secret + DB setting) MUST match exactly.
+-- ─────────────────────────────────────────────────────────────────────────
+
+begin;
+
+-- Extensions are already installed by the original migration; we re-assert
+-- with `if not exists` so this migration is safe to apply on environments
+-- where the original was rolled back.
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- Re-register the cron job with the corrected auth header.
+-- Same job name → replaces the prior schedule.
+select cron.schedule(
+  'scheduled-pause-cleanup',
+  '0 3 * * *',
+  $$
+  select net.http_post(
+    url     := current_setting('app.functions_url') || '/scheduled-pause-cleanup',
+    headers := jsonb_build_object(
+      'X-Cron-Secret', current_setting('app.cron_secret'),
+      'Content-Type',  'application/json'
+    ),
+    body    := '{}'::jsonb
+  );
+  $$
+);
+
+commit;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- VERIFICATION:
+-- ─────────────────────────────────────────────────────────────────────────
+--
+-- 1. Confirm the schedule is using the new header:
+--      select jobname, schedule, active, command
+--        from cron.job
+--        where jobname = 'scheduled-pause-cleanup';
+--    The `command` column should contain the string 'X-Cron-Secret'.
+--
+-- 2. Confirm DB settings are populated:
+--      select current_setting('app.functions_url')      as url,
+--             length(current_setting('app.cron_secret')) as secret_len;
+--    Expect a URL ending in /functions/v1 and secret_len = 64
+--    (32 random bytes hex-encoded).
+--
+-- 3. Live smoke test — invoke the same call the cron will make:
+--      select net.http_post(
+--        url     := current_setting('app.functions_url') || '/scheduled-pause-cleanup',
+--        headers := jsonb_build_object(
+--          'X-Cron-Secret', current_setting('app.cron_secret'),
+--          'Content-Type',  'application/json'
+--        ),
+--        body    := '{}'::jsonb
+--      );
+--      -- then read the response:
+--      select id, status_code, content::text
+--        from net._http_response
+--        order by id desc
+--        limit 1;
+--    Expect status_code = 200. Pre-fix this returned 401.
+--
+-- ─────────────────────────────────────────────────────────────────────────
+-- ROLLBACK:
+-- ─────────────────────────────────────────────────────────────────────────
+--
+--   begin;
+--     select cron.unschedule('scheduled-pause-cleanup');
+--   commit;
+--
+-- (To revert to the broken pre-fix state, re-apply 20260506_005 — but there
+-- is no good reason to do this; the original migration's auth header was
+-- a bug, not a deliberate design choice.)


### PR DESCRIPTION
## Summary

Corrective migration for `20260506_005_schedule_pause_cleanup_cron.sql` (PR #29). Two bugs fixed:

- **Auth header was wrong.** The original sent `Authorization: Bearer <secret>`, but `_shared/accountAuth.ts:79` (`requireSystemCaller`) only accepts that bearer pattern when the value equals `SUPABASE_SERVICE_ROLE_KEY`. For a dedicated cron secret, the function expects `X-Cron-Secret`. Pre-fix every cron tick would have failed 401, so paused accounts never auto-deleted at the 30-day mark — breaking the privacy-policy promise.
- **Operator setup was fragile.** `ALTER DATABASE postgres SET ...` kept failing on non-breaking-space paste artifacts in the SQL Editor. Pivoted to **Supabase Vault** — the recommended pattern. Operator setup is now one `vault.create_secret(...)` call.

`cron.schedule()` is idempotent — same job name replaces the prior schedule from PR #29.

## What changed

- New migration: `supabase/migrations/20260506_005a_fix_pause_cleanup_cron_auth.sql`
  - URL hardcoded inline (not sensitive — already exposed as `EXPO_PUBLIC_SUPABASE_URL` in the mobile bundle).
  - Secret read from `vault.decrypted_secrets` instead of `current_setting('app.cron_secret')`.
  - Auth header switched from `Authorization: Bearer` to `X-Cron-Secret`.
  - Defensive `create extension if not exists "supabase_vault"`.
  - Inline operator setup + verification + rollback documented.

## Verified end-to-end (production)

- ✅ Vault secret stored with `secret_len = 64`.
- ✅ `cron.job` command contains `'X-Cron-Secret'` AND `'vault.decrypted_secrets'`.
- ✅ Live smoke test via `net.http_post` returned **200** with `{"ok":true,"cutoff":"2026-04-07T...","candidates":0,"deleted":0,"failed":0}`.
- ✅ `CRON_SHARED_SECRET` Edge Function env var matches the Vault value.

## Test plan

- [x] Migration applied to production DB
- [x] Vault `cron_shared_secret` exists with correct length
- [x] Cron job updated (verified via `select * from cron.job`)
- [x] Live smoke test returns 200 (not 401)
- [ ] Watch first scheduled run at 03:00 UTC tomorrow — should appear in `cron.job_run_details` with `status = 'succeeded'`

## Operator notes

For replicating to a new environment (staging, fresh project):

1. Add `CRON_SHARED_SECRET` to Edge Function secrets (Dashboard → Project Settings → Edge Functions → Secrets). Value: 64-char hex from `select encode(gen_random_bytes(32), 'hex');`.
2. Store same value in Vault: `select vault.create_secret('<hex>', 'cron_shared_secret', '...');`.
3. Apply this migration.

Documented in the migration file header.

https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_