### PR TITLE
chore(theme): Deep Warm v5.2 cleanup sweep — A1-A7

### DIFF
--- a/apps/mobile/app/account/_layout.tsx
+++ b/apps/mobile/app/account/_layout.tsx
@@ -3,13 +3,14 @@
 // Headers are hidden — each screen renders its own back button.
 
 import { Stack } from 'expo-router';
+import { colors } from '../../src/theme/colors';
 
 export default function AccountLayout() {
   return (
     <Stack
       screenOptions={{
         headerShown: false,
-        contentStyle: { backgroundColor: '#0e0a10' },
+        contentStyle: { backgroundColor: colors.background },
       }}
     />
   );

--- a/apps/mobile/app/account/delete.tsx
+++ b/apps/mobile/app/account/delete.tsx
@@ -7,10 +7,11 @@
 
 import { useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { router }   from 'expo-router';
-import { StatusBar }   from 'expo-status-bar';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import AsyncStorage  from '@react-native-async-storage/async-storage';
+import { router }    from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaView }   from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
 import { colors as C, fonts as F } from '../../src/theme';
 import { supabase } from '../../src/lib/supabase';
@@ -66,8 +67,21 @@ export default function DeleteAccountScreen() {
   };
 
   return (
-    <SafeAreaView style={s.root} edges={['top', 'bottom']}>
+    <View style={s.root}>
       <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          C.gradientResultTop,
+          C.gradientResultMid1,
+          C.gradientResultMid2,
+          C.gradientResultMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={s.safe} edges={['top', 'bottom']}>
       <ScrollView contentContainerStyle={s.scroll} keyboardShouldPersistTaps="handled">
         <Pressable onPress={() => router.back()} style={s.closeBtn} hitSlop={16}>
           <Text style={s.closeText}>‹ Back</Text>
@@ -121,12 +135,14 @@ export default function DeleteAccountScreen() {
           </Pressable>
         </View>
       </ScrollView>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 const s = StyleSheet.create({
   root:   { flex: 1, backgroundColor: C.background },
+  safe:   { flex: 1, backgroundColor: 'transparent' },
   scroll: { padding: 24, paddingBottom: 40, gap: 24 },
 
   closeBtn:  { alignSelf: 'flex-start', paddingVertical: 8 },

--- a/apps/mobile/app/account/export.tsx
+++ b/apps/mobile/app/account/export.tsx
@@ -46,8 +46,21 @@ export default function ExportAccountScreen() {
   };
 
   return (
-    <SafeAreaView style={s.root} edges={['top', 'bottom']}>
+    <View style={s.root}>
       <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          C.gradientResultTop,
+          C.gradientResultMid1,
+          C.gradientResultMid2,
+          C.gradientResultMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={s.safe} edges={['top', 'bottom']}>
       <ScrollView contentContainerStyle={s.scroll}>
         <Pressable onPress={() => router.back()} style={s.closeBtn} hitSlop={16}>
           <Text style={s.closeText}>‹ Back</Text>
@@ -91,12 +104,14 @@ export default function ExportAccountScreen() {
           </Pressable>
         </View>
       </ScrollView>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 const s = StyleSheet.create({
   root:   { flex: 1, backgroundColor: C.background },
+  safe:   { flex: 1, backgroundColor: 'transparent' },
   scroll: { padding: 24, paddingBottom: 40, gap: 24 },
 
   closeBtn:  { alignSelf: 'flex-start', paddingVertical: 8 },

--- a/apps/mobile/app/account/pause.tsx
+++ b/apps/mobile/app/account/pause.tsx
@@ -7,9 +7,9 @@
 import { useState } from 'react';
 import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { router }   from 'expo-router';
-import { StatusBar }   from 'expo-status-bar';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { router }    from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaView }   from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
 import { colors as C, fonts as F } from '../../src/theme';
@@ -64,8 +64,21 @@ export default function PauseAccountScreen() {
   };
 
   return (
-    <SafeAreaView style={s.root} edges={['top', 'bottom']}>
+    <View style={s.root}>
       <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          C.gradientResultTop,
+          C.gradientResultMid1,
+          C.gradientResultMid2,
+          C.gradientResultMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={s.safe} edges={['top', 'bottom']}>
       <ScrollView contentContainerStyle={s.scroll}>
         <Pressable onPress={() => router.back()} style={s.closeBtn} hitSlop={16}>
           <Text style={s.closeText}>‹ Back</Text>
@@ -104,12 +117,14 @@ export default function PauseAccountScreen() {
           </Pressable>
         </View>
       </ScrollView>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 const s = StyleSheet.create({
   root:   { flex: 1, backgroundColor: C.background },
+  safe:   { flex: 1, backgroundColor: 'transparent' },
   scroll: { padding: 24, paddingBottom: 40, gap: 24 },
 
   closeBtn:  { alignSelf: 'flex-start', paddingVertical: 8 },

--- a/apps/mobile/app/child-setup.tsx
+++ b/apps/mobile/app/child-setup.tsx
@@ -118,8 +118,15 @@ router.replace('/(tabs)');
       <StatusBar style="light" />
 
       <LinearGradient
-        colors={['#0e0a10', '#14101a', '#1a1622', '#1e1a28', '#201c2a', '#1e1a24', '#1a1620', '#18141e', '#14101a']}
-        locations={[0, 0.10, 0.22, 0.35, 0.48, 0.60, 0.72, 0.85, 1]}
+        colors={[
+          C.gradientResultTop,
+          C.gradientResultMid1,
+          C.gradientResultMid2,
+          C.gradientResultMid3,
+          C.gradientMid4,
+          C.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
         style={StyleSheet.absoluteFill}
       />
       <Stars />
@@ -202,7 +209,7 @@ router.replace('/(tabs)');
             <View style={s.sliderWrap}>
               <View style={s.sliderTrack}>
                 <LinearGradient
-                  colors={[C.amber, C.peach]}
+                  colors={[C.amber, C.amberMid]}
                   start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
                   style={[s.sliderFill, { width: `${sliderProgress}%` as any }]}
                 />
@@ -231,8 +238,7 @@ router.replace('/(tabs)');
           ]}
         >
           <LinearGradient
-            colors={canContinue ? ['#C8883A', '#E8A855'] : ['rgba(255,255,255,0.06)', 'rgba(255,255,255,0.04)']}
-            
+            colors={canContinue ? [C.amber, C.amberMid] : ['rgba(255,255,255,0.06)', 'rgba(255,255,255,0.04)']}
             style={s.ctaBtn}
           >
             <Text style={[s.ctaText, !canContinue && { color: 'rgba(255,255,255,0.20)' }]}>
@@ -255,7 +261,7 @@ router.replace('/(tabs)');
 }
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: '#0e0a10' },
+  root: { flex: 1, backgroundColor: C.background },
   content: { paddingHorizontal: 28, paddingTop: 24, paddingBottom: 40, gap: 24 },
 
   logoWrap: { alignItems: 'center' },

--- a/apps/mobile/app/legal/ai-limitations.tsx
+++ b/apps/mobile/app/legal/ai-limitations.tsx
@@ -1,13 +1,27 @@
-import { Pressable, ScrollView, StyleSheet, Text } from 'react-native';
-import { router }       from 'expo-router';
-import { StatusBar }    from 'expo-status-bar';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { router }        from 'expo-router';
+import { StatusBar }     from 'expo-status-bar';
+import { SafeAreaView }  from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
 import { colors, spacing, type } from '../../src/theme';
 
 export default function AILimitationsScreen() {
   return (
-    <SafeAreaView style={styles.root} edges={['top', 'bottom']}>
-      <StatusBar style="dark" />
+    <View style={styles.root}>
+      <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          colors.gradientResultTop,
+          colors.gradientResultMid1,
+          colors.gradientResultMid2,
+          colors.gradientResultMid3,
+          colors.gradientMid4,
+          colors.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
       <ScrollView contentContainerStyle={styles.content}>
         <Pressable
           onPress={() =>
@@ -41,12 +55,14 @@ export default function AILimitationsScreen() {
           decisions you make.
         </Text>
       </ScrollView>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   root:    { flex: 1, backgroundColor: colors.background },
+  safe:    { flex: 1, backgroundColor: 'transparent' },
   content: {
     paddingHorizontal: spacing.lg,
     paddingTop:        spacing.md,

--- a/apps/mobile/app/legal/medical-safety.tsx
+++ b/apps/mobile/app/legal/medical-safety.tsx
@@ -1,13 +1,27 @@
-import { Pressable, ScrollView, StyleSheet, Text } from 'react-native';
-import { router }       from 'expo-router';
-import { StatusBar }    from 'expo-status-bar';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { router }        from 'expo-router';
+import { StatusBar }     from 'expo-status-bar';
+import { SafeAreaView }  from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
 import { colors, spacing, type } from '../../src/theme';
 
 export default function MedicalSafetyScreen() {
   return (
-    <SafeAreaView style={styles.root} edges={['top', 'bottom']}>
-      <StatusBar style="dark" />
+    <View style={styles.root}>
+      <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          colors.gradientResultTop,
+          colors.gradientResultMid1,
+          colors.gradientResultMid2,
+          colors.gradientResultMid3,
+          colors.gradientMid4,
+          colors.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
       <ScrollView contentContainerStyle={styles.content}>
         <Pressable
           onPress={() =>
@@ -38,12 +52,14 @@ export default function MedicalSafetyScreen() {
           mental health, please consult a qualified healthcare professional.
         </Text>
       </ScrollView>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   root:    { flex: 1, backgroundColor: colors.background },
+  safe:    { flex: 1, backgroundColor: 'transparent' },
   content: {
     paddingHorizontal: spacing.lg,
     paddingTop:        spacing.md,

--- a/apps/mobile/app/legal/privacy-policy.tsx
+++ b/apps/mobile/app/legal/privacy-policy.tsx
@@ -1,13 +1,27 @@
-import { Pressable, ScrollView, StyleSheet, Text } from 'react-native';
-import { router }       from 'expo-router';
-import { StatusBar }    from 'expo-status-bar';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { router }        from 'expo-router';
+import { StatusBar }     from 'expo-status-bar';
+import { SafeAreaView }  from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
 import { colors, spacing, type } from '../../src/theme';
 
 export default function PrivacyScreen() {
   return (
-    <SafeAreaView style={styles.root} edges={['top', 'bottom']}>
-      <StatusBar style="dark" />
+    <View style={styles.root}>
+      <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          colors.gradientResultTop,
+          colors.gradientResultMid1,
+          colors.gradientResultMid2,
+          colors.gradientResultMid3,
+          colors.gradientMid4,
+          colors.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
       <ScrollView contentContainerStyle={styles.content}>
         <Pressable
           onPress={() =>
@@ -36,12 +50,14 @@ export default function PrivacyScreen() {
           at any time by contacting support.
         </Text>
       </ScrollView>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   root:    { flex: 1, backgroundColor: colors.background },
+  safe:    { flex: 1, backgroundColor: 'transparent' },
   content: {
     paddingHorizontal: spacing.lg,
     paddingTop:        spacing.md,

--- a/apps/mobile/app/legal/terms-of-service.tsx
+++ b/apps/mobile/app/legal/terms-of-service.tsx
@@ -1,13 +1,27 @@
-import { Pressable, ScrollView, StyleSheet, Text } from 'react-native';
-import { router }       from 'expo-router';
-import { StatusBar }    from 'expo-status-bar';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { router }        from 'expo-router';
+import { StatusBar }     from 'expo-status-bar';
+import { SafeAreaView }  from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
 import { colors, spacing, type } from '../../src/theme';
 
 export default function TermsScreen() {
   return (
-    <SafeAreaView style={styles.root} edges={['top', 'bottom']}>
-      <StatusBar style="dark" />
+    <View style={styles.root}>
+      <StatusBar style="light" />
+      <LinearGradient
+        colors={[
+          colors.gradientResultTop,
+          colors.gradientResultMid1,
+          colors.gradientResultMid2,
+          colors.gradientResultMid3,
+          colors.gradientMid4,
+          colors.gradientBottom,
+        ]}
+        locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
       <ScrollView contentContainerStyle={styles.content}>
         <Pressable
           onPress={() =>
@@ -35,12 +49,14 @@ export default function TermsScreen() {
           Do not rely on Sturdy in an emergency.
         </Text>
       </ScrollView>
-    </SafeAreaView>
+      </SafeAreaView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   root:    { flex: 1, backgroundColor: colors.background },
+  safe:    { flex: 1, backgroundColor: 'transparent' },
   content: {
     paddingHorizontal: spacing.lg,
     paddingTop:        spacing.md,

--- a/apps/mobile/app/saved.tsx
+++ b/apps/mobile/app/saved.tsx
@@ -465,7 +465,7 @@ const s = StyleSheet.create({
   metaPillText: {
     fontFamily: F.bodyMedium,
     fontSize: 11,
-    color: C.peach,
+    color: C.amber,
   },
   deleteText: {
     fontFamily: F.bodyMedium,

--- a/apps/mobile/app/upgrade.tsx
+++ b/apps/mobile/app/upgrade.tsx
@@ -1,6 +1,7 @@
 // app/upgrade.tsx
-// v3 — Dark identity: solid #0e0a10 base, glass cards, amber gradient CTA.
-// Replaces the v2 Journal pastel-gradient + rose-coral accents.
+// v4 — Deep Warm v5.2: C-2 fast-fade gradient backdrop, glass cards,
+// amber gradient CTA. All accent colors now sourced from theme tokens
+// (C.amber / C.amberMid) rather than file-local hex constants.
 //
 // Pricing (locked):
 //   Monthly  $9.99/month   · 3-day free trial
@@ -24,19 +25,17 @@ import { useChildProfile } from '../src/context/ChildProfileContext';
 import { colors as C, fonts as F } from '../src/theme';
 
 // ═══════════════════════════════════════════════
-// V3 DARK IDENTITY TOKENS (hardcoded per spec)
+// File-local non-theme tokens (rgb-glass surfaces specific to this screen).
+// Brand colors come from `C.*` (theme) so the paywall stays in sync with
+// the rest of the Deep Warm v5.2 system.
 // ═══════════════════════════════════════════════
 
-const BG          = '#0e0a10';
 const SURFACE     = 'rgba(255,255,255,0.055)';
 const BORDER      = 'rgba(255,255,255,0.07)';
 const BORDER_HI   = 'rgba(255,255,255,0.13)';
 const TEXT        = 'rgba(255,255,255,0.92)';
 const TEXT_SEC    = 'rgba(255,255,255,0.52)';
 const TEXT_MUTED  = 'rgba(255,255,255,0.28)';
-const AMBER       = '#D4944A';                       // selected-plan accents
-const AMBER_DEEP  = '#C8883A';                       // CTA gradient start
-const AMBER_LIGHT = '#E8A855';                       // CTA gradient end
 const SAGE        = '#8DB89A';                       // checkmarks + savings badge
 const SAGE_BG     = 'rgba(141,184,154,0.12)';
 
@@ -161,7 +160,7 @@ export default function UpgradeScreen() {
                     {isYearly ? <View style={s.radioDot} /> : null}
                   </View>
                   <View style={{ flex: 1, gap: 2 }}>
-                    <Text style={[s.planName, isYearly && { color: AMBER }]}>Yearly</Text>
+                    <Text style={[s.planName, isYearly && { color: C.amber }]}>Yearly</Text>
                     <Text style={s.planPrice}>$69.99/year · $5.83/mo</Text>
                   </View>
                   <View style={s.trialBadge}>
@@ -187,7 +186,7 @@ export default function UpgradeScreen() {
                     {!isYearly ? <View style={s.radioDot} /> : null}
                   </View>
                   <View style={{ flex: 1, gap: 2 }}>
-                    <Text style={[s.planName, !isYearly && { color: AMBER }]}>Monthly</Text>
+                    <Text style={[s.planName, !isYearly && { color: C.amber }]}>Monthly</Text>
                     <Text style={s.planPrice}>$9.99/month</Text>
                   </View>
                   <View style={s.trialBadge}>
@@ -205,7 +204,7 @@ export default function UpgradeScreen() {
             style={({ pressed }) => [pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] }]}
           >
             <LinearGradient
-              colors={[AMBER_DEEP, AMBER_LIGHT]}
+              colors={[C.amber, C.amberMid]}
               start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
               style={s.ctaBtn}
             >
@@ -265,7 +264,7 @@ const s = StyleSheet.create({
 
   // Hero
   hero:      { alignItems: 'center', gap: 8, paddingVertical: 16 },
-  heroIcon:  { fontSize: 32, color: AMBER, marginBottom: 4 },
+  heroIcon:  { fontSize: 32, color: C.amber, marginBottom: 4 },
   heroTitle: { fontFamily: F.heading, fontSize: 36, color: TEXT, letterSpacing: -0.5 },
   heroSub:   { fontFamily: F.body, fontSize: 16, color: TEXT_SEC, textAlign: 'center', lineHeight: 24, maxWidth: 320 },
 
@@ -275,7 +274,7 @@ const s = StyleSheet.create({
     backgroundColor: SURFACE,
     borderWidth: 1, borderColor: BORDER,
   },
-  featuresTitle: { fontFamily: F.label, fontSize: 11, letterSpacing: 0.8, color: AMBER },
+  featuresTitle: { fontFamily: F.label, fontSize: 11, letterSpacing: 0.8, color: C.amber },
   featureRow:    { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
   featureIcon:   { fontSize: 18, marginTop: 1 },
   featureLabel:  { fontFamily: F.bodySemi, fontSize: 15, color: TEXT },
@@ -297,8 +296,8 @@ const s = StyleSheet.create({
     borderWidth: 1, borderColor: BORDER,
   },
   planCardActive: {
-    borderColor: 'rgba(212,148,74,0.45)',
-    backgroundColor: 'rgba(212,148,74,0.06)',
+    borderColor: C.amberBorder,
+    backgroundColor: 'rgba(200,136,58,0.06)',
   },
   planRow:   { flexDirection: 'row', alignItems: 'center', gap: 12 },
   planName:  { fontFamily: F.bodySemi, fontSize: 16, color: TEXT },
@@ -310,8 +309,8 @@ const s = StyleSheet.create({
     borderWidth: 2, borderColor: BORDER_HI,
     alignItems: 'center', justifyContent: 'center',
   },
-  radioActive: { borderColor: AMBER },
-  radioDot:    { width: 10, height: 10, borderRadius: 5, backgroundColor: AMBER },
+  radioActive: { borderColor: C.amber },
+  radioDot:    { width: 10, height: 10, borderRadius: 5, backgroundColor: C.amber },
 
   // Trial / savings badges
   trialBadge: {


### PR DESCRIPTION
## Summary

Mechanical cleanup of token usage + StatusBar + gradient backdrops to align legacy screens with Deep Warm v5.2. No new features, no business logic changes — pure visual consistency work.

## Group 1 — Token sweep (5 files)

| File | Change |
|---|---|
| `account/_layout.tsx` | `'#0e0a10'` → `colors.background` |
| `upgrade.tsx` | Delete unused `BG`; replace local `AMBER`/`AMBER_DEEP`/`AMBER_LIGHT` constants and `rgba(212,148,74,...)` derivatives with `C.amber` / `C.amberMid` / `C.amberBorder` |
| `child-setup.tsx` | 9-stop hardcoded gradient → C-2 fast-fade tokens; CTA hardcodes → `C.amber` / `C.amberMid`; slider `C.peach` → `C.amberMid`; root `'#0e0a10'` → `C.background` |
| `saved.tsx` | meta pill text `C.peach` → `C.amber` (zero visual change — `C.peach` is just an alias for `C.amber`) |

## Group 2 — StatusBar + C-2 gradient backdrop (7 files)

Each screen wrapped in `<View>` → `<StatusBar light>` → `<LinearGradient absoluteFill>` → transparent `<SafeAreaView>` → `<ScrollView>`. New `safe` style added with `backgroundColor: 'transparent'`.

| File | Changes |
|---|---|
| `legal/privacy-policy.tsx` | StatusBar `dark` → `light`. Add C-2 backdrop. |
| `legal/terms-of-service.tsx` | Same |
| `legal/ai-limitations.tsx` | Same |
| `legal/medical-safety.tsx` | Same |
| `account/pause.tsx` | Add C-2 backdrop (StatusBar already light) |
| `account/delete.tsx` | Same |
| `account/export.tsx` | Same |

Uses the `gradientResultTop` variant of the C-2 fast-fade (`#b5b1ac → #0C0C0C`) since these screens have no greeting zone — a darker top stop reads better when the first thing you see is the back button rather than a greeting.

## Verified

- ✅ `cd apps/mobile && npx tsc --noEmit` — clean.
- ✅ Diff: 11 files, +181 / -65 lines.

## Out of scope (separate work)

- `history.tsx` — uses `Screen` component which renders its own older 2-stop gradient; upgrading `Screen.tsx` touches every consumer and is deferred.
- `TypingDemo.tsx` + `data/scenarios.ts` dead code — separate cleanup.
- `Card.tsx` legacy `borderTopColor` policy — informational only, no blocker.
- Watercolor PNG cleanup — separate.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] **On-device visual smoke** (recommended before merge):
  - [ ] `/upgrade` paywall — selected-plan accent and CTA gradient look right
  - [ ] `/child-setup` — gradient backdrop and slider fill amber→amberMid
  - [ ] `/legal/privacy-policy` — gradient backdrop visible, white status bar icons
  - [ ] `/account/pause`, `/account/delete`, `/account/export` — gradient backdrops
  - [ ] `/saved` — meta pill text reads as expected color
- [ ] CI Deno + Jest jobs pass

https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_