### PR TITLE
fix(home+children): readable greeting + free-tier 1-child gate

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -578,14 +578,14 @@ const s = StyleSheet.create({
   greeting: {
     fontFamily:    F.heading,
     fontSize:      32,
-    color:         C.text,
+    color:         C.textDark,
     letterSpacing: -0.5,
     lineHeight:    38,
   },
   subGreeting: {
     fontFamily: F.body,
     fontSize:   16,
-    color:      'rgba(232,116,97,0.90)',
+    color:      C.textDarkSecondary,
     lineHeight: 22,
   },
 

--- a/apps/mobile/app/child/new.tsx
+++ b/apps/mobile/app/child/new.tsx
@@ -23,6 +23,7 @@ import { LinearGradient }   from 'expo-linear-gradient';
 import * as Haptics         from 'expo-haptics';
 import { useAuth }          from '../../src/context/AuthContext';
 import { useChildProfile }  from '../../src/context/ChildProfileContext';
+import { useSubscription }  from '../../src/hooks/useSubscription';
 import { supabase }         from '../../src/lib/supabase';
 import { colors as C, fonts as F } from '../../src/theme/colors';
 
@@ -44,8 +45,9 @@ function getAgeHint(age: number): string {
 
 // ─── Main ───
 export default function NewChildScreen() {
-  const { session }        = useAuth();
-  const { reloadChild }    = useChildProfile();
+  const { session }              = useAuth();
+  const { children, reloadChild } = useChildProfile();
+  const { isPremium }            = useSubscription();
   const [name, setName]    = useState('');
   const [age, setAge]      = useState(5);
   const [notes, setNotes]  = useState('');
@@ -66,6 +68,15 @@ export default function NewChildScreen() {
 
   const handleSave = async () => {
     if (!canSave || saving || !session) return;
+
+    // Free-tier 1-child cap. First child setup goes through child-setup.tsx,
+    // so reaching this screen with children.length >= 1 means an extra child.
+    if (!isPremium && children.length >= 1) {
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+      router.replace('/upgrade');
+      return;
+    }
+
     setSaving(true); setError('');
     try {
       const preferences: Record<string, string> = {};


### PR DESCRIPTION
## Summary

Two surgical mobile-only fixes. Both ship clean and don't get thrown away when tomorrow's bigger Children-tab restructure lands (planned separately).

## Changes

### 1. Home greeting readability

The greeting (`Hello, {name}.`) and subgreeting (`What's happening right now?`) on the home tab were rendering in light/coral text on the **warm parchment top** of the C-2 fast-fade gradient (`#d8d5d0`). Light text on light background = poor contrast, hard to read.

- `apps/mobile/app/(tabs)/index.tsx` L581 — `s.greeting.color`: `C.text` → `C.textDark` (`#2a2520` — the token explicitly intended for warm-gradient surfaces per `colors.ts:99`).
- `apps/mobile/app/(tabs)/index.tsx` L588 — `s.subGreeting.color`: `rgba(232,116,97,0.90)` → `C.textDarkSecondary` (`rgba(42,37,32,0.50)`). Preserves visual hierarchy with greeting; readable on parchment.

### 2. Free-tier 1-child gate

`apps/mobile/app/child/new.tsx` is the only path for adding subsequent children (initial setup goes through `child-setup.tsx` which only runs when `children.length === 0`). Guard at the top of `handleSave`:

```ts
if (!isPremium && children.length >= 1) {
  Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
  router.replace('/upgrade');
  return;
}
```

Wires `useSubscription` + `children` list from `useChildProfile`. Mock subscription returns `isPremium: false` today, so any free user attempting a 2nd child is redirected to upgrade.

## Verified

- ✅ `cd apps/mobile && npx tsc --noEmit` clean
- ✅ Diff: 2 files, +15 / -4 lines

## Test plan

- [x] tsc clean
- [ ] **On-device smoke (recommended before merge):**
  - [ ] Home greeting + subgreeting now readable on warm parchment top
  - [ ] Visual hierarchy preserved (greeting darker than subgreeting)
  - [ ] With 1 child + free user → tapping "Add a child" CTA on `/child/new` redirects to `/upgrade`
  - [ ] With 0 children → `/child/new` works normally (initial onboarding flows fine)

## Server-side enforcement (deferred)

Postgres trigger to enforce the 1-child cap server-side is deferred until RevenueCat lands and the `subscriptions` table is populated with real plan data. Client-side gate is sufficient for free-only soft launch.

## Out of scope (in tomorrow's lockdown plan)

- **Children tab restructure** — 3-tab nav (Home / Children / Settings). Children tab subsumes the home picker, manage-children scope, insight teaser, and conversion surface. Bigger work, ~3-5h, fresh session.
- **Insights generation** — the `child_insights` table is dormant; nothing writes to it. Static "COMING SOON" cards on `child-profile/[id].tsx`. Will land alongside the Children tab.
- **Export Edge Function rewrite** — organized JSON/CSV/MD with folder structure. ~2-3h, separate session.

https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL1g1PL1bM9LY19Z4tMMj)_