### PR TITLE
Add password reset flow and auto-mode message classification

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -41,7 +41,7 @@ import { ImageBackground } from 'react-native';
 import { useAuth } from '../../src/context/AuthContext';
 import { useChildProfile } from '../../src/context/ChildProfileContext';
 import { supabase } from '../../src/lib/supabase';
-import { getQuestionResponse, CrisisDetectedError, RateLimitError } from '../../src/lib/api';
+import { getAutoResponse, CrisisDetectedError, RateLimitError } from '../../src/lib/api';
 import { colors as C, fonts as F } from '../../src/theme';
 
 // ═══════════════════════════════════════════════
@@ -382,29 +382,60 @@ export default function HomeScreen() {
     setSending(true);
 
     try {
-      const detectedChildId = detectChildFromMessage(msg, kidList);
-      const result = await getQuestionResponse({
-        message: msg,
-        userId: session?.user?.id,
-        childName: null,
-        childAge: null,
-        childProfileId: detectedChildId,
-      } as any);
+      const detectedChild = detectChildFromMessage(msg, kidList)
+        ? kidList.find((k: any) => k.id === detectChildFromMessage(msg, kidList))
+        : kidList.length === 1 ? kidList[0] : null;
+
+      const result = await getAutoResponse({
+        message:        msg,
+        userId:         session?.user?.id,
+        childName:      detectedChild?.name ?? null,
+        childAge:       detectedChild?.childAge ?? null,
+        childProfileId: detectedChild?.id ?? null,
+      });
 
       setQuestion('');
-      const responsePayload = (result as any).response ?? '';
-      const thoughtId = (result as any).thought_id ?? null;
 
-      if (thoughtId) {
+      if (result.response_type === 'normal') {
+        // Script response — route to result screen with params
+        const r = result as any;
         router.push({
-          pathname: `/thought/${thoughtId}` as any,
-          params: { fallbackResponse: responsePayload, prompt: msg },
+          pathname: '/result' as any,
+          params: {
+            situationSummary:   r.situation_summary ?? '',
+            regulateAction:     r.regulate?.parent_action ?? '',
+            regulateScript:     r.regulate?.script ?? '',
+            regulateCoaching:   r.regulate?.coaching ?? '',
+            regulateStrategies: JSON.stringify(r.regulate?.strategies ?? []),
+            connectAction:      r.connect?.parent_action ?? '',
+            connectScript:      r.connect?.script ?? '',
+            connectCoaching:    r.connect?.coaching ?? '',
+            connectStrategies:  JSON.stringify(r.connect?.strategies ?? []),
+            guideAction:        r.guide?.parent_action ?? '',
+            guideScript:        r.guide?.script ?? '',
+            guideCoaching:      r.guide?.coaching ?? '',
+            guideStrategies:    JSON.stringify(r.guide?.strategies ?? []),
+            avoid:              JSON.stringify(r.avoid ?? []),
+            childMessage:       msg,
+            mode:               r.detected_mode ?? 'sos',
+            childId:            detectedChild?.id ?? '',
+          },
         });
       } else {
-        router.push({
-          pathname: '/thought/inline' as any,
-          params: { fallbackResponse: responsePayload, prompt: msg },
-        });
+        // Prose response — route to thought screen
+        const responsePayload = result.response ?? '';
+        const thoughtId = (result as any).thought_id ?? null;
+        if (thoughtId) {
+          router.push({
+            pathname: `/thought/${thoughtId}` as any,
+            params: { fallbackResponse: responsePayload, prompt: msg },
+          });
+        } else {
+          router.push({
+            pathname: '/thought/inline' as any,
+            params: { fallbackResponse: responsePayload, prompt: msg },
+          });
+        }
       }
     } catch (err) {
       if (err instanceof CrisisDetectedError) {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Platform, Text, TextInput } from 'react-native';
 import { Stack, router } from 'expo-router';
+import * as Linking from 'expo-linking';
 import * as SplashScreen from 'expo-splash-screen';
 import { useFonts } from 'expo-font';
 import {
@@ -128,7 +129,34 @@ function AuthGate() {
   return null;
 }
 
+// ── Password-reset deep link handler ─────────────────────────────────────
+// Supabase sends: sturdy://password-reset#access_token=...&type=recovery
+// We parse the hash manually (React Native does not process URL fragments)
+// and navigate to the reset-password screen with the tokens as params.
+function usePasswordResetDeepLink() {
+  useEffect(() => {
+    const handleUrl = (url: string) => {
+      const hash = url.split('#')[1];
+      if (!hash) return;
+      const params = new URLSearchParams(hash);
+      if (params.get('type') !== 'recovery') return;
+      const accessToken  = params.get('access_token');
+      const refreshToken = params.get('refresh_token');
+      if (!accessToken || !refreshToken) return;
+      router.push({
+        pathname: '/auth/reset-password' as any,
+        params:   { accessToken, refreshToken },
+      });
+    };
+
+    Linking.getInitialURL().then((url) => { if (url) handleUrl(url); });
+    const sub = Linking.addEventListener('url', ({ url }) => handleUrl(url));
+    return () => sub.remove();
+  }, []);
+}
+
 export default function RootLayout() {
+  usePasswordResetDeepLink();
   const [fontsLoaded] = useFonts({
     // Fraunces (serif) — headings, hero, AI script text
     Fraunces_600SemiBold,

--- a/apps/mobile/app/auth/forgot-password.tsx
+++ b/apps/mobile/app/auth/forgot-password.tsx
@@ -1,0 +1,262 @@
+// app/auth/forgot-password.tsx
+// Forgot password — email form → "check your inbox" confirmation state.
+
+import { useState } from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { router } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import { supabase } from '../../src/lib/supabase';
+import { colors as C, fonts as F } from '../../src/theme/colors';
+
+export default function ForgotPasswordScreen() {
+  const [email, setEmail]     = useState('');
+  const [focused, setFocused] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent]       = useState(false);
+  const [error, setError]     = useState('');
+
+  const canSubmit = email.trim().length > 0 && !loading;
+
+  const handleSend = async () => {
+    if (!canSubmit) return;
+    setError('');
+    setLoading(true);
+    try {
+      const { error: authErr } = await supabase.auth.resetPasswordForEmail(
+        email.trim().toLowerCase(),
+        { redirectTo: 'sturdy://password-reset' },
+      );
+      if (authErr) throw authErr;
+      setSent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong. Try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBack = () => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/auth?mode=signin' as any);
+  };
+
+  return (
+    <View style={s.root}>
+      <StatusBar style="light" />
+      <LinearGradient
+        colors={[C.gradientTop, C.gradientMid1, C.gradientMid2, C.gradientMid3, C.gradientMid4, C.gradientBottom]}
+        locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
+        <ScrollView
+          contentContainerStyle={s.content}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Pressable onPress={handleBack} style={s.back} hitSlop={8}>
+            <Text style={s.backText}>← Back</Text>
+          </Pressable>
+
+          {sent ? (
+            <View style={s.sentWrap}>
+              <Text style={s.sentIcon}>📬</Text>
+              <Text style={s.headline}>Check your inbox</Text>
+              <Text style={s.headlineSub}>
+                We sent a reset link to{'\n'}
+                <Text style={s.emailDisplay}>{email.trim()}</Text>
+              </Text>
+              <Text style={s.hint}>
+                Tap the link in the email and you'll be taken back to set a new password.
+                Check your spam folder if you don't see it within a minute.
+              </Text>
+              <Pressable
+                onPress={() => router.replace('/auth?mode=signin' as any)}
+                style={({ pressed }) => [s.signinLink, pressed && { opacity: 0.6 }]}
+              >
+                <Text style={s.signinLinkText}>Back to sign in</Text>
+              </Pressable>
+            </View>
+          ) : (
+            <>
+              <View style={s.hlArea}>
+                <Text style={s.headline}>Reset your password</Text>
+                <Text style={s.headlineSub}>
+                  Enter your email and we'll send a reset link.
+                </Text>
+              </View>
+
+              <View style={s.formCard}>
+                <View style={s.field}>
+                  <Text style={s.fieldLabel}>EMAIL</Text>
+                  <View style={[s.inputWrap, focused && s.inputFocused]}>
+                    <TextInput
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      keyboardType="email-address"
+                      autoComplete="email"
+                      autoFocus
+                      placeholder="you@example.com"
+                      placeholderTextColor={C.inputPlaceholder}
+                      value={email}
+                      onChangeText={(v) => { setEmail(v); if (error) setError(''); }}
+                      onFocus={() => setFocused(true)}
+                      onBlur={() => setFocused(false)}
+                      style={s.input}
+                      editable={!loading}
+                      returnKeyType="send"
+                      onSubmitEditing={handleSend}
+                    />
+                  </View>
+                </View>
+              </View>
+
+              {error ? <Text style={s.errorText}>{error}</Text> : null}
+            </>
+          )}
+        </ScrollView>
+
+        {!sent && (
+          <View style={s.stickyWrap}>
+            <LinearGradient
+              colors={['transparent', 'rgba(12,12,12,0.85)', C.background]}
+              locations={[0, 0.45, 0.85]}
+              style={s.stickyFade}
+              pointerEvents="none"
+            />
+            <View style={s.stickyContent}>
+              <Pressable
+                onPress={handleSend}
+                disabled={!canSubmit}
+                style={({ pressed }) => [
+                  pressed && canSubmit && { opacity: 0.92, transform: [{ scale: 0.98 }] },
+                ]}
+                accessibilityRole="button"
+              >
+                {!canSubmit || loading ? (
+                  <View style={[s.ctaBase, s.ctaDisabled]}>
+                    <Text style={[s.ctaText, { color: C.disabledText }]}>
+                      {loading ? 'Sending…' : 'Send reset link'}
+                    </Text>
+                  </View>
+                ) : (
+                  <LinearGradient
+                    colors={[C.amber, C.amberMid]}
+                    start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
+                    style={s.ctaBase}
+                  >
+                    <Text style={s.ctaText}>Send reset link</Text>
+                  </LinearGradient>
+                )}
+              </Pressable>
+            </View>
+          </View>
+        )}
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  root:    { flex: 1, backgroundColor: C.background },
+  content: { paddingHorizontal: 28, paddingTop: 12, paddingBottom: 110, gap: 20 },
+
+  back:     { alignSelf: 'flex-start', paddingVertical: 6 },
+  backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textSecondary },
+
+  hlArea:      { alignItems: 'center', gap: 8, paddingVertical: 16 },
+  headline:    { fontFamily: F.heading, fontSize: 26, color: C.text, textAlign: 'center', letterSpacing: -0.3 },
+  headlineSub: { fontFamily: F.body, fontSize: 14, color: C.textSecondary, textAlign: 'center', lineHeight: 20 },
+
+  formCard: {
+    borderRadius:    20,
+    padding:         22,
+    gap:             18,
+    backgroundColor: C.surface,
+    borderWidth:     1,
+    borderColor:     C.border,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
+    shadowColor:     '#000000',
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
+  },
+  field:      { gap: 6 },
+  fieldLabel: {
+    fontFamily:    F.label,
+    fontSize:      11,
+    letterSpacing: 0.8,
+    color:         C.textMuted,
+    textTransform: 'uppercase',
+  },
+  inputWrap: {
+    borderRadius:    14,
+    backgroundColor: C.inputBg,
+    borderWidth:     1,
+    borderColor:     C.inputBorder,
+    borderTopWidth:  1,
+    borderTopColor:  C.inputHighlight,
+  },
+  inputFocused: { borderColor: C.borderFocus },
+  input: {
+    fontFamily:        F.body,
+    fontSize:          16,
+    color:             C.text,
+    paddingHorizontal: 16,
+    paddingVertical:   14,
+  },
+
+  errorText: { fontFamily: F.body, fontSize: 14, color: C.sos, textAlign: 'center' },
+
+  // ─── Sent state ───
+  sentWrap: {
+    flex: 1,
+    alignItems: 'center',
+    paddingTop: 32,
+    gap: 16,
+  },
+  sentIcon: { fontSize: 48, lineHeight: 56 },
+  emailDisplay: {
+    fontFamily: F.bodySemi,
+    color:      C.amberLight,
+  },
+  hint: {
+    fontFamily:  F.body,
+    fontSize:    14,
+    color:       C.textSecondary,
+    textAlign:   'center',
+    lineHeight:  21,
+    paddingHorizontal: 8,
+  },
+  signinLink:     { marginTop: 8, paddingVertical: 10 },
+  signinLinkText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.amberLight, textDecorationLine: 'underline' },
+
+  // ─── Sticky CTA ───
+  stickyWrap:    { position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 },
+  stickyFade:    { height: 36 },
+  stickyContent: { backgroundColor: C.background, paddingHorizontal: 28, paddingTop: 4, paddingBottom: 28 },
+  ctaBase: {
+    borderRadius:   18,
+    minHeight:      56,
+    alignItems:     'center',
+    justifyContent: 'center',
+    shadowColor:    C.amber,
+    shadowOffset:   { width: 0, height: 6 },
+    shadowOpacity:  0.35,
+    shadowRadius:   20,
+    elevation:      4,
+  },
+  ctaDisabled: { backgroundColor: C.disabled, shadowOpacity: 0, elevation: 0 },
+  ctaText:     { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
+});

--- a/apps/mobile/app/auth/index.tsx
+++ b/apps/mobile/app/auth/index.tsx
@@ -31,6 +31,8 @@ function isMode(v: unknown): v is Mode {
   return v === 'signup' || v === 'signin';
 }
 
+type ScreenState = 'form' | 'confirm-email';
+
 export default function AuthScreen() {
   const params = useLocalSearchParams<{ mode?: string }>();
   const initialMode: Mode = isMode(params.mode) ? params.mode : 'signup';
@@ -38,6 +40,7 @@ export default function AuthScreen() {
   const { signInWithEmail } = useAuth();
 
   const [mode, setMode]         = useState<Mode>(initialMode);
+  const [screenState, setScreenState] = useState<ScreenState>('form');
   const [email, setEmail]       = useState('');
   const [password, setPassword] = useState('');
   const [showPw, setShowPw]     = useState(false);
@@ -57,7 +60,7 @@ export default function AuthScreen() {
     try {
       const e = email.trim().toLowerCase();
       if (isSignup) {
-        const { error: authErr } = await supabase.auth.signUp({ email: e, password });
+        const { data: signUpData, error: authErr } = await supabase.auth.signUp({ email: e, password });
         if (authErr) throw authErr;
 
         // Pending-child migration — preserved verbatim from sign-up.tsx.
@@ -81,8 +84,14 @@ export default function AuthScreen() {
         } catch { /* non-blocking */ }
 
         await markOnboardingComplete();
-        // No router.replace here — AuthGate in _layout.tsx handles
-        // post-signup routing once the session lands.
+
+        // If email confirmation is required, session will be null.
+        // Show a "check your inbox" screen instead of leaving the user hanging.
+        if (!signUpData.session) {
+          setScreenState('confirm-email');
+          return;
+        }
+        // Session present (confirmation disabled) — AuthGate routes to /(tabs).
       } else {
         await signInWithEmail(e, password);
         await markOnboardingComplete();
@@ -132,90 +141,129 @@ export default function AuthScreen() {
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
       >
-        <Pressable onPress={handleBack} style={s.back} hitSlop={8}>
-          <Text style={s.backText}>← Back</Text>
-        </Pressable>
-
-        <View style={s.hlArea}>
-          <Text style={s.headline}>
-            {isSignup ? 'Create account' : 'Welcome back'}
-          </Text>
-          <Text style={s.headlineSub}>
-            {isSignup ? 'Save scripts and personalise for your child.' : 'Sign in to continue'}
-          </Text>
-        </View>
-
-        <View style={s.formCard}>
-          <View style={s.field}>
-            <Text style={s.fieldLabel}>EMAIL</Text>
-            <View style={[s.inputWrap, emailFocused && s.inputFocused]}>
-              <TextInput
-                autoCapitalize="none"
-                autoCorrect={false}
-                keyboardType="email-address"
-                autoComplete="email"
-                placeholder="you@example.com"
-                placeholderTextColor={C.inputPlaceholder}
-                value={email}
-                onChangeText={(v) => { setEmail(v); if (error) setError(''); }}
-                onFocus={() => setEmailFocused(true)}
-                onBlur={() => setEmailFocused(false)}
-                style={s.input}
-                editable={!loading}
-              />
-            </View>
-          </View>
-
-          <View style={s.field}>
-            <Text style={s.fieldLabel}>PASSWORD</Text>
-            <View style={[s.inputWrap, pwFocused && s.inputFocused, s.inputRow]}>
-              <TextInput
-                secureTextEntry={!showPw}
-                autoCapitalize="none"
-                autoCorrect={false}
-                autoComplete={isSignup ? 'password-new' : 'password'}
-                placeholder={isSignup ? 'Choose a password' : 'Enter your password'}
-                placeholderTextColor={C.inputPlaceholder}
-                value={password}
-                onChangeText={(v) => { setPassword(v); if (error) setError(''); }}
-                onFocus={() => setPwFocused(true)}
-                onBlur={() => setPwFocused(false)}
-                style={[s.input, { flex: 1 }]}
-                editable={!loading}
-                returnKeyType="go"
-                onSubmitEditing={handleSubmit}
-              />
+        {screenState === 'confirm-email' ? (
+          // ─── Post-signup: email confirmation required ───
+          <>
+            <View style={s.confirmWrap}>
+              <Text style={s.confirmIcon}>📬</Text>
+              <Text style={s.headline}>Check your inbox</Text>
+              <Text style={s.headlineSub}>
+                We sent a confirmation link to{'\n'}
+                <Text style={s.emailDisplay}>{email.trim()}</Text>
+              </Text>
+              <Text style={s.confirmHint}>
+                Tap the link in the email to activate your account, then come back and sign in.
+                Check spam if you don't see it.
+              </Text>
               <Pressable
-                onPress={() => setShowPw((v) => !v)}
-                style={s.eyeBtn}
-                hitSlop={8}
-                accessibilityRole="button"
-                accessibilityLabel={showPw ? 'Hide password' : 'Show password'}
+                onPress={() => { setScreenState('form'); switchMode('signin'); }}
+                style={({ pressed }) => [s.linkBtn, pressed && { opacity: 0.6 }]}
               >
-                <Text style={s.eyeIcon}>{showPw ? '🙈' : '👁'}</Text>
+                <Text style={s.linkText}>
+                  Already confirmed? <Text style={s.linkAccent}>Sign in</Text>
+                </Text>
               </Pressable>
             </View>
-            {isSignup ? <Text style={s.pwHint}>Use at least 6 characters.</Text> : null}
-          </View>
-        </View>
+          </>
+        ) : (
+          // ─── Normal sign-in / sign-up form ───
+          <>
+            <Pressable onPress={handleBack} style={s.back} hitSlop={8}>
+              <Text style={s.backText}>← Back</Text>
+            </Pressable>
 
-        {error ? <Text style={s.errorText}>{error}</Text> : null}
+            <View style={s.hlArea}>
+              <Text style={s.headline}>
+                {isSignup ? 'Create account' : 'Welcome back'}
+              </Text>
+              <Text style={s.headlineSub}>
+                {isSignup ? 'Save scripts and personalise for your child.' : 'Sign in to continue'}
+              </Text>
+            </View>
 
-        <Pressable
-          onPress={() => switchMode(isSignup ? 'signin' : 'signup')}
-          style={({ pressed }) => [s.linkBtn, pressed && { opacity: 0.6 }]}
-          accessibilityRole="button"
-          disabled={loading}
-        >
-          <Text style={s.linkText}>
-            {isSignup ? "Already have an account? " : "Don't have an account? "}
-            <Text style={s.linkAccent}>{isSignup ? 'Sign in' : 'Sign up free'}</Text>
-          </Text>
-        </Pressable>
+            <View style={s.formCard}>
+              <View style={s.field}>
+                <Text style={s.fieldLabel}>EMAIL</Text>
+                <View style={[s.inputWrap, emailFocused && s.inputFocused]}>
+                  <TextInput
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    keyboardType="email-address"
+                    autoComplete="email"
+                    placeholder="you@example.com"
+                    placeholderTextColor={C.inputPlaceholder}
+                    value={email}
+                    onChangeText={(v) => { setEmail(v); if (error) setError(''); }}
+                    onFocus={() => setEmailFocused(true)}
+                    onBlur={() => setEmailFocused(false)}
+                    style={s.input}
+                    editable={!loading}
+                  />
+                </View>
+              </View>
+
+              <View style={s.field}>
+                <Text style={s.fieldLabel}>PASSWORD</Text>
+                <View style={[s.inputWrap, pwFocused && s.inputFocused, s.inputRow]}>
+                  <TextInput
+                    secureTextEntry={!showPw}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    autoComplete={isSignup ? 'password-new' : 'password'}
+                    placeholder={isSignup ? 'Choose a password' : 'Enter your password'}
+                    placeholderTextColor={C.inputPlaceholder}
+                    value={password}
+                    onChangeText={(v) => { setPassword(v); if (error) setError(''); }}
+                    onFocus={() => setPwFocused(true)}
+                    onBlur={() => setPwFocused(false)}
+                    style={[s.input, { flex: 1 }]}
+                    editable={!loading}
+                    returnKeyType="go"
+                    onSubmitEditing={handleSubmit}
+                  />
+                  <Pressable
+                    onPress={() => setShowPw((v) => !v)}
+                    style={s.eyeBtn}
+                    hitSlop={8}
+                    accessibilityRole="button"
+                    accessibilityLabel={showPw ? 'Hide password' : 'Show password'}
+                  >
+                    <Text style={s.eyeIcon}>{showPw ? '🙈' : '👁'}</Text>
+                  </Pressable>
+                </View>
+                {isSignup ? <Text style={s.pwHint}>Use at least 6 characters.</Text> : null}
+              </View>
+            </View>
+
+            {error ? <Text style={s.errorText}>{error}</Text> : null}
+
+            {!isSignup && (
+              <Pressable
+                onPress={() => router.push('/auth/forgot-password' as any)}
+                style={({ pressed }) => [s.forgotBtn, pressed && { opacity: 0.6 }]}
+                accessibilityRole="button"
+              >
+                <Text style={s.forgotText}>Forgot password?</Text>
+              </Pressable>
+            )}
+
+            <Pressable
+              onPress={() => switchMode(isSignup ? 'signin' : 'signup')}
+              style={({ pressed }) => [s.linkBtn, pressed && { opacity: 0.6 }]}
+              accessibilityRole="button"
+              disabled={loading}
+            >
+              <Text style={s.linkText}>
+                {isSignup ? "Already have an account? " : "Don't have an account? "}
+                <Text style={s.linkAccent}>{isSignup ? 'Sign in' : 'Sign up free'}</Text>
+              </Text>
+            </Pressable>
+          </>
+        )}
       </ScrollView>
 
-      {/* Sticky CTA with gradient fade into the dark base */}
-      <View style={s.stickyWrap}>
+      {/* Sticky CTA — hidden on confirm-email screen */}
+      {screenState !== 'confirm-email' && <View style={s.stickyWrap}>
         <LinearGradient
           colors={['transparent', 'rgba(12,12,12,0.85)', C.background]}
           locations={[0, 0.45, 0.85]}
@@ -253,7 +301,7 @@ export default function AuthScreen() {
             )}
           </Pressable>
         </View>
-      </View>
+      </View>}
       </SafeAreaView>
     </View>
   );
@@ -316,9 +364,25 @@ const s = StyleSheet.create({
 
   errorText: { fontFamily: F.body, fontSize: 14, color: C.sos, textAlign: 'center' },
 
+  forgotBtn:  { alignSelf: 'center', paddingVertical: 4 },
+  forgotText: { fontFamily: F.bodyMedium, fontSize: 13, color: C.textSecondary, textDecorationLine: 'underline' },
+
   linkBtn:    { alignSelf: 'center', paddingVertical: 8 },
   linkText:   { fontFamily: F.body, fontSize: 14, color: C.textSecondary, textAlign: 'center' },
   linkAccent: { fontFamily: F.bodySemi, color: C.amberLight },
+
+  // ─── Confirm-email state ───
+  confirmWrap: { flex: 1, alignItems: 'center', paddingTop: 48, gap: 16 },
+  confirmIcon: { fontSize: 48, lineHeight: 56 },
+  emailDisplay: { fontFamily: F.bodySemi, color: C.amberLight },
+  confirmHint: {
+    fontFamily:        F.body,
+    fontSize:          14,
+    color:             C.textSecondary,
+    textAlign:         'center',
+    lineHeight:        21,
+    paddingHorizontal: 8,
+  },
 
   stickyWrap: { position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 },
   stickyFade: { height: 36 },

--- a/apps/mobile/app/auth/reset-password.tsx
+++ b/apps/mobile/app/auth/reset-password.tsx
@@ -1,0 +1,281 @@
+// app/auth/reset-password.tsx
+// New password form — shown after the user taps the reset link in their email.
+// The deep link handler in app/_layout.tsx detects the recovery URL and
+// navigates here with accessToken + refreshToken as params.
+// On submit we establish the session then immediately update the password.
+
+import { useState } from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import { supabase } from '../../src/lib/supabase';
+import { colors as C, fonts as F } from '../../src/theme/colors';
+
+export default function ResetPasswordScreen() {
+  const { accessToken, refreshToken } = useLocalSearchParams<{
+    accessToken?: string;
+    refreshToken?: string;
+  }>();
+
+  const [password, setPassword]             = useState('');
+  const [confirm, setConfirm]               = useState('');
+  const [showPw, setShowPw]                 = useState(false);
+  const [pwFocused, setPwFocused]           = useState(false);
+  const [confirmFocused, setConfirmFocused] = useState(false);
+  const [loading, setLoading]               = useState(false);
+  const [error, setError]                   = useState('');
+
+  const mismatch  = confirm.length > 0 && password !== confirm;
+  const canSubmit = password.length >= 6 && password === confirm && !loading;
+
+  const handleSet = async () => {
+    if (!canSubmit) return;
+    setError('');
+    setLoading(true);
+    try {
+      if (!accessToken || !refreshToken) {
+        throw new Error('Reset link is invalid or has expired. Request a new one.');
+      }
+
+      const { error: sessionErr } = await supabase.auth.setSession({
+        access_token:  accessToken,
+        refresh_token: refreshToken,
+      });
+      if (sessionErr) throw sessionErr;
+
+      const { error: updateErr } = await supabase.auth.updateUser({ password });
+      if (updateErr) throw updateErr;
+
+      // Session is now established with the new password — AuthGate routes to /(tabs).
+      router.replace('/(tabs)' as any);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not update password. Try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const hasTokens = !!accessToken && !!refreshToken;
+
+  return (
+    <View style={s.root}>
+      <StatusBar style="light" />
+      <LinearGradient
+        colors={[C.gradientTop, C.gradientMid1, C.gradientMid2, C.gradientMid3, C.gradientMid4, C.gradientBottom]}
+        locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+      <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
+        <ScrollView
+          contentContainerStyle={s.content}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {!hasTokens ? (
+            <View style={s.invalidWrap}>
+              <Text style={s.headline}>Link expired</Text>
+              <Text style={s.headlineSub}>
+                This reset link is no longer valid. Request a new one from the sign-in screen.
+              </Text>
+              <Pressable
+                onPress={() => router.replace('/auth?mode=signin' as any)}
+                style={({ pressed }) => [s.backLink, pressed && { opacity: 0.6 }]}
+              >
+                <Text style={s.backLinkText}>Back to sign in</Text>
+              </Pressable>
+            </View>
+          ) : (
+            <>
+              <View style={s.hlArea}>
+                <Text style={s.headline}>Set new password</Text>
+                <Text style={s.headlineSub}>Choose something you'll remember.</Text>
+              </View>
+
+              <View style={s.formCard}>
+                <View style={s.field}>
+                  <Text style={s.fieldLabel}>NEW PASSWORD</Text>
+                  <View style={[s.inputWrap, pwFocused && s.inputFocused, s.inputRow]}>
+                    <TextInput
+                      secureTextEntry={!showPw}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      autoComplete="password-new"
+                      autoFocus
+                      placeholder="At least 6 characters"
+                      placeholderTextColor={C.inputPlaceholder}
+                      value={password}
+                      onChangeText={(v) => { setPassword(v); if (error) setError(''); }}
+                      onFocus={() => setPwFocused(true)}
+                      onBlur={() => setPwFocused(false)}
+                      style={[s.input, { flex: 1 }]}
+                      editable={!loading}
+                    />
+                    <Pressable
+                      onPress={() => setShowPw(v => !v)}
+                      style={s.eyeBtn}
+                      hitSlop={8}
+                      accessibilityRole="button"
+                      accessibilityLabel={showPw ? 'Hide password' : 'Show password'}
+                    >
+                      <Text style={s.eyeIcon}>{showPw ? '🙈' : '👁'}</Text>
+                    </Pressable>
+                  </View>
+                  <Text style={s.pwHint}>Use at least 6 characters.</Text>
+                </View>
+
+                <View style={s.field}>
+                  <Text style={s.fieldLabel}>CONFIRM PASSWORD</Text>
+                  <View style={[s.inputWrap, confirmFocused && s.inputFocused, mismatch && s.inputError]}>
+                    <TextInput
+                      secureTextEntry={!showPw}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      autoComplete="password-new"
+                      placeholder="Repeat password"
+                      placeholderTextColor={C.inputPlaceholder}
+                      value={confirm}
+                      onChangeText={(v) => { setConfirm(v); if (error) setError(''); }}
+                      onFocus={() => setConfirmFocused(true)}
+                      onBlur={() => setConfirmFocused(false)}
+                      style={s.input}
+                      editable={!loading}
+                      returnKeyType="go"
+                      onSubmitEditing={handleSet}
+                    />
+                  </View>
+                  {mismatch ? <Text style={s.mismatchText}>Passwords don't match.</Text> : null}
+                </View>
+              </View>
+
+              {error ? <Text style={s.errorText}>{error}</Text> : null}
+            </>
+          )}
+        </ScrollView>
+
+        {hasTokens && (
+          <View style={s.stickyWrap}>
+            <LinearGradient
+              colors={['transparent', 'rgba(12,12,12,0.85)', C.background]}
+              locations={[0, 0.45, 0.85]}
+              style={s.stickyFade}
+              pointerEvents="none"
+            />
+            <View style={s.stickyContent}>
+              <Pressable
+                onPress={handleSet}
+                disabled={!canSubmit}
+                style={({ pressed }) => [
+                  pressed && canSubmit && { opacity: 0.92, transform: [{ scale: 0.98 }] },
+                ]}
+                accessibilityRole="button"
+              >
+                {!canSubmit || loading ? (
+                  <View style={[s.ctaBase, s.ctaDisabled]}>
+                    <Text style={[s.ctaText, { color: C.disabledText }]}>
+                      {loading ? 'Setting password…' : 'Set new password'}
+                    </Text>
+                  </View>
+                ) : (
+                  <LinearGradient
+                    colors={[C.amber, C.amberMid]}
+                    start={{ x: 0, y: 0 }} end={{ x: 1, y: 0 }}
+                    style={s.ctaBase}
+                  >
+                    <Text style={s.ctaText}>Set new password</Text>
+                  </LinearGradient>
+                )}
+              </Pressable>
+            </View>
+          </View>
+        )}
+      </SafeAreaView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  root:    { flex: 1, backgroundColor: C.background },
+  content: { paddingHorizontal: 28, paddingTop: 12, paddingBottom: 110, gap: 20 },
+
+  hlArea:      { alignItems: 'center', gap: 8, paddingVertical: 16 },
+  headline:    { fontFamily: F.heading, fontSize: 26, color: C.text, textAlign: 'center', letterSpacing: -0.3 },
+  headlineSub: { fontFamily: F.body, fontSize: 14, color: C.textSecondary, textAlign: 'center', lineHeight: 20 },
+
+  invalidWrap: { flex: 1, alignItems: 'center', paddingTop: 60, gap: 16 },
+  backLink:    { marginTop: 8, paddingVertical: 10 },
+  backLinkText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.amberLight, textDecorationLine: 'underline' },
+
+  formCard: {
+    borderRadius:    20,
+    padding:         22,
+    gap:             18,
+    backgroundColor: C.surface,
+    borderWidth:     1,
+    borderColor:     C.border,
+    borderTopWidth:  1,
+    borderTopColor:  C.borderHi,
+    shadowColor:     '#000000',
+    shadowOffset:    { width: 0, height: 6 },
+    shadowOpacity:   0.35,
+    shadowRadius:    20,
+    elevation:       4,
+  },
+  field:      { gap: 6 },
+  fieldLabel: {
+    fontFamily:    F.label,
+    fontSize:      11,
+    letterSpacing: 0.8,
+    color:         C.textMuted,
+    textTransform: 'uppercase',
+  },
+  inputWrap: {
+    borderRadius:    14,
+    backgroundColor: C.inputBg,
+    borderWidth:     1,
+    borderColor:     C.inputBorder,
+    borderTopWidth:  1,
+    borderTopColor:  C.inputHighlight,
+  },
+  inputRow:     { flexDirection: 'row', alignItems: 'center' },
+  inputFocused: { borderColor: C.borderFocus },
+  inputError:   { borderColor: C.sos },
+  input: {
+    fontFamily:        F.body,
+    fontSize:          16,
+    color:             C.text,
+    paddingHorizontal: 16,
+    paddingVertical:   14,
+  },
+  eyeBtn:      { paddingHorizontal: 14, paddingVertical: 12 },
+  eyeIcon:     { fontSize: 18, opacity: 0.5 },
+  pwHint:      { fontFamily: F.body, fontSize: 12, color: C.textMuted },
+  mismatchText: { fontFamily: F.body, fontSize: 12, color: C.sos },
+
+  errorText: { fontFamily: F.body, fontSize: 14, color: C.sos, textAlign: 'center' },
+
+  stickyWrap:    { position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 },
+  stickyFade:    { height: 36 },
+  stickyContent: { backgroundColor: C.background, paddingHorizontal: 28, paddingTop: 4, paddingBottom: 28 },
+  ctaBase: {
+    borderRadius:   18,
+    minHeight:      56,
+    alignItems:     'center',
+    justifyContent: 'center',
+    shadowColor:    C.amber,
+    shadowOffset:   { width: 0, height: 6 },
+    shadowOpacity:  0.35,
+    shadowRadius:   20,
+    elevation:      4,
+  },
+  ctaDisabled: { backgroundColor: C.disabled, shadowOpacity: 0, elevation: 0 },
+  ctaText:     { fontFamily: F.subheading, fontSize: 16, color: '#FFFFFF', letterSpacing: 0.3 },
+});

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -202,13 +202,105 @@ export type QuestionRequest = {
 };
 
 export type QuestionResponse = {
-  response: string;
+  response:  string;
+  thought_id?: string | null;
 };
+
+// ═══════════════════════════════════════════════
+// Auto mode — home screen sends this; backend
+// classifies the message and returns either a
+// script (response_type: "normal") or a prose
+// response (response_type: "question").
+// ═══════════════════════════════════════════════
+
+export type AutoRequest = {
+  childName?:      string | null;
+  childAge?:       number | null;
+  childProfileId?: string | null;
+  message:         string;
+  userId?:         string;
+  tone?:           'soft' | 'gentle' | 'direct';
+};
+
+export type AutoResponse =
+  | (ParentingScriptResponse & { response_type: 'normal'; detected_mode: string })
+  | (QuestionResponse        & { response_type: 'question'; detected_mode: string });
 
 function isValidQuestionResponse(value: unknown): value is QuestionResponse {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   return typeof v.response === 'string' && v.response.trim().length > 0;
+}
+
+export async function getAutoResponse(
+  input: AutoRequest,
+): Promise<AutoResponse> {
+  let response: Response;
+
+  console.log('[API] Sending auto-mode request');
+
+  try {
+    response = await fetch(PARENTING_SCRIPT_URL, {
+      method:  'POST',
+      headers: HEADERS,
+      body:    JSON.stringify({
+        childName:      input.childName ?? null,
+        childAge:       input.childAge  ?? null,
+        childProfileId: input.childProfileId ?? null,
+        message:        input.message,
+        userId:         input.userId,
+        tone:           input.tone,
+        mode:           'auto',
+      }),
+    });
+  } catch (e) {
+    console.log('[API] Network error:', e);
+    throw new Error('network-error');
+  }
+
+  console.log('[API] Auto response status:', response.status);
+
+  let rawText = '';
+  try {
+    rawText = await response.text();
+  } catch (e) {
+    throw new Error('read-error');
+  }
+
+  let data: unknown = null;
+  try {
+    data = JSON.parse(rawText);
+  } catch (e) {
+    throw new Error('parse-error');
+  }
+
+  if (!response.ok) {
+    const msg = typeof data === 'object' && data !== null && 'error' in data &&
+      typeof (data as { error: unknown }).error === 'string'
+        ? (data as { error: string }).error : 'request-failed';
+    if (response.status === 429) throw new RateLimitError(msg, parseRetryAfter(response));
+    throw new Error(msg);
+  }
+
+  if (
+    typeof data === 'object' && data !== null && 'response_type' in data &&
+    (data as { response_type: unknown }).response_type === 'crisis'
+  ) {
+    const c = data as { crisis_type?: string; risk_level?: string };
+    throw new CrisisDetectedError(c.crisis_type ?? 'unknown', c.risk_level ?? 'ELEVATED_RISK');
+  }
+
+  const d = data as Record<string, unknown>;
+  if (d.response_type === 'question') {
+    if (typeof d.response !== 'string' || !d.response.trim()) throw new Error('invalid-response');
+    return data as AutoResponse;
+  }
+  if (d.response_type === 'normal') {
+    if (!isParentingScriptResponse(data)) throw new Error('invalid-response');
+    return data as AutoResponse;
+  }
+
+  throw new Error('invalid-response');
 }
 
 export async function getQuestionResponse(

--- a/supabase/functions/_shared/requestHelpers.ts
+++ b/supabase/functions/_shared/requestHelpers.ts
@@ -66,8 +66,9 @@ export function validateInput(body: RequestBody): ValidatedInput {
     ? body.originalScript as ValidatedInput["originalScript"]
     : null;
 
-  // SOS mode requires child context. Question mode does not (auto-detection elsewhere).
-  if (mode !== 'question') {
+  // SOS / Reconnect / Understand / Conversation modes require child context.
+  // Question mode and auto mode do not (auto-mode child context is optional).
+  if (mode !== 'question' && mode !== 'auto') {
     if (!childName)    throw new Error("childName is required.");
     if (!Number.isFinite(childAge) || childAge < 2 || childAge > 17) {
       throw new Error("childAge must be between 2 and 17.");

--- a/supabase/functions/chat-parenting-assistant/index.ts
+++ b/supabase/functions/chat-parenting-assistant/index.ts
@@ -129,6 +129,45 @@ async function logInteractionEvent(data: {
     }
   }
 
+// ─── Auto-mode classifier ─────────────────────────────────────────────────
+// Heuristic: present-tense urgency → SOS script. Reflective/question → prose.
+// Keyword lists tuned against SCRIPT QUALITY STANDARDS scenarios.
+// Replace with an LLM classification call if heuristic accuracy proves
+// insufficient in production.
+const SOS_PATTERNS = [
+  /\bright\s*now\b/i,
+  /\bwon'?t\s+stop\b/i,
+  /\bwon'?t\s+(calm|listen|come|sleep|eat|get)\b/i,
+  /\b(is|are|keeps?|keeps?\s+on)\s+(scream|hit|throw|bite|kick|crying|tantrum|melt|refus)\w*/i,
+  /\b(scream|meltdown|tantrum|losing\s+it|losing\s+my\s+(mind|it)|melting\s+down)\b/i,
+  /\b(threw|hit|kicked|bit|spit|slapped)\b/i,
+  /\b(ca?n'?t\s+(calm|stop|get)\b)/i,
+  /\brefusing\s+to\b/i,
+  /\bfreaking\s+out\b/i,
+  /\bsnap(ped)?\b/i,
+  /\bshut\s+down\b/i,
+  /\bhaving\s+a\s+(meltdown|tantrum|fit)\b/i,
+  /\bspiraling\b/i,
+  /\bhelp\s+me\s+(through|right\s+now)\b/i,
+];
+
+const QUESTION_STARTERS = [
+  /^(why|how|what|when|should|is\s+it|am\s+i|are\s+they|do\s+i|does\s+he|does\s+she|does\s+my|can\s+i|could\s+i)\b/i,
+  /\b(normal|typical|worried|wonder(ing)?|advice|think\s+i\s+(should|need)|pattern|lately|always|never|keep\s+doing|keeps\s+doing)\b/i,
+];
+
+function classifyAutoMode(message: string): 'sos' | 'question' {
+  const lower = message.trim();
+  for (const pattern of SOS_PATTERNS) {
+    if (pattern.test(lower)) return 'sos';
+  }
+  for (const pattern of QUESTION_STARTERS) {
+    if (pattern.test(lower)) return 'question';
+  }
+  // Default: shorter messages with no question markers lean SOS; longer lean question
+  return lower.split(/\s+/).length <= 20 ? 'sos' : 'question';
+}
+
 async function generateScript(prompt: string) {
   if (!ANTHROPIC_API_KEY) throw new Error("Missing ANTHROPIC_API_KEY.");
 
@@ -261,6 +300,109 @@ serve(async (req) => {
     }
     return jsonRes({ error: rate.error }, rate.status, headers);
   }
+
+      // ─── Auto-mode classification ───
+      // Heuristic: present-tense urgency signals → SOS script.
+      // All other inputs → Question/thinking-partner response.
+      // Child context (name + age) is optional for auto mode; if provided
+      // the SOS prompt uses it, otherwise Question mode handles gracefully.
+      if (input.mode === 'auto') {
+        const detectedMode = classifyAutoMode(input.message);
+        if (detectedMode === 'question') {
+          try {
+            const questionPrompt = buildQuestionPrompt({
+              childName:  input.childName || null,
+              childAge:   Number.isFinite(input.childAge) ? input.childAge : null,
+              message:    input.message,
+              parentName: null,
+            });
+            const result = await generateQuestionResponse(questionPrompt) as { response: string };
+            const thoughtId = await logParentThought({
+              userId:         input.userId,
+              childProfileId: input.childProfileId,
+              promptText:     input.message,
+              responseText:   result.response,
+            });
+            logUsageEvent({
+              userId:         input.userId,
+              childProfileId: input.childProfileId,
+              eventType:      "question_generated",
+              eventMeta:      { mode: 'auto:question', model: ANTHROPIC_MODEL },
+            });
+            return jsonRes({ response_type: "question", response: result.response, thought_id: thoughtId, detected_mode: 'question' }, 200);
+          } catch (err) {
+            console.error("[STURDY_ERROR]", err);
+            return jsonRes({ error: "Couldn't generate a response right now." }, 500);
+          }
+        }
+
+        // SOS-type auto path — requires child context. If missing, fall back to question.
+        if (!input.childName || !Number.isFinite(input.childAge)) {
+          try {
+            const questionPrompt = buildQuestionPrompt({
+              childName:  null,
+              childAge:   null,
+              message:    input.message,
+              parentName: null,
+            });
+            const result = await generateQuestionResponse(questionPrompt) as { response: string };
+            const thoughtId = await logParentThought({
+              userId:         input.userId,
+              childProfileId: input.childProfileId,
+              promptText:     input.message,
+              responseText:   result.response,
+            });
+            logUsageEvent({
+              userId:         input.userId,
+              childProfileId: input.childProfileId,
+              eventType:      "question_generated",
+              eventMeta:      { mode: 'auto:question_fallback', model: ANTHROPIC_MODEL },
+            });
+            return jsonRes({ response_type: "question", response: result.response, thought_id: thoughtId, detected_mode: 'question' }, 200);
+          } catch (err) {
+            console.error("[STURDY_ERROR]", err);
+            return jsonRes({ error: "Couldn't generate a response right now." }, 500);
+          }
+        }
+
+        // SOS path with child context
+        try {
+          const prompt = buildPrompt({
+            childName:      input.childName,
+            childAge:       input.childAge,
+            message:        input.message,
+            intensity:      null,
+            mode:           detectedMode,
+            tone:           input.tone,
+            isFollowUp:     false,
+            followUpType:   null,
+            originalScript: null,
+          });
+          const result = await generateScript(prompt);
+          const triggerCategory = classifyTrigger(input.message);
+          const messageLength = input.message.trim().split(/\s+/).length;
+          logUsageEvent({
+            userId:         input.userId,
+            childProfileId: input.childProfileId,
+            eventType:      "script_generated",
+            eventMeta:      { mode: `auto:${detectedMode}`, child_age: input.childAge, model: ANTHROPIC_MODEL },
+          });
+          logInteractionEvent({
+            userId:            input.userId,
+            childProfileId:    input.childProfileId,
+            mode:              detectedMode,
+            triggerCategory,
+            intensityInferred: null,
+            isFollowup:        false,
+            situationSummary:  (result as any).situation_summary ?? "",
+            messageLength,
+          });
+          return jsonRes({ response_type: "normal", detected_mode: detectedMode, ...result as object }, 200);
+        } catch (err) {
+          console.error("[STURDY_ERROR]", err);
+          return jsonRes({ error: "Couldn't generate a script right now." }, 500);
+        }
+      }
 
       // ─── Question mode branch ───
       if (input.mode === 'question') {


### PR DESCRIPTION
## Summary

This PR implements a complete password reset flow for authenticated users and adds intelligent message classification to the home screen, allowing the backend to automatically detect whether a parent's message requires an SOS script or a reflective question-mode response.

## Key Changes

### Password Reset Flow
- **New screen: `apps/mobile/app/auth/reset-password.tsx`** — Allows users to set a new password after clicking a reset link in their email. Validates token presence, establishes session, and updates password via Supabase auth.
- **New screen: `apps/mobile/app/auth/forgot-password.tsx`** — Email entry form that triggers a password reset email with a deep link (`sturdy://password-reset`). Shows a "check your inbox" confirmation state after sending.
- **Deep link handler in `apps/mobile/app/_layout.tsx`** — `usePasswordResetDeepLink()` parses the recovery URL hash (Supabase sends `#access_token=...&type=recovery&refresh_token=...`), extracts tokens, and navigates to the reset-password screen.
- **Sign-in screen update (`apps/mobile/app/auth/index.tsx`)** — Added "Forgot password?" link on the sign-in tab and email confirmation state ("Check your inbox") when sign-up requires email verification.

### Auto-Mode Message Classification
- **Backend classifier in `supabase/functions/chat-parenting-assistant/index.ts`** — New `classifyAutoMode()` function uses heuristic pattern matching (SOS_PATTERNS for urgency keywords like "right now", "won't stop", "screaming"; QUESTION_STARTERS for reflective language) to detect message intent. Falls back to message length if no patterns match.
- **Auto-mode endpoint logic** — When `mode: 'auto'` is sent, the function classifies the message and routes to either SOS script generation (if child context is provided) or question-mode prose response. Gracefully falls back to question mode if child name/age are missing.
- **API client update (`apps/mobile/src/lib/api.ts`)** — New `getAutoResponse()` function and `AutoRequest`/`AutoResponse` types. Returns a union type that includes `response_type` ('normal' for scripts, 'question' for prose) and `detected_mode` for analytics.
- **Home screen integration (`apps/mobile/app/(tabs)/index.tsx`)** — Replaced `getQuestionResponse()` call with `getAutoResponse()`. Now passes child name and age (detected from message or selected child) to enable SOS classification. Routes script responses to `/result` and question responses to `/thought/[id]`.

## Implementation Details

- **Token handling:** Reset tokens are passed as URL params through the deep link and stored in local state only during the reset flow; they are not persisted.
- **Fallback behavior:** If a message is classified as SOS but child context is missing, the backend falls back to question mode rather than failing.
- **Email confirmation UX:** Sign-up now shows a "Check your inbox" screen if the backend returns no session (indicating email verification is required), allowing users to understand the next step without being left hanging.
- **Pattern tuning:** SOS patterns are tuned against the SCRIPT QUALITY STANDARDS scenarios and can be replaced with an LLM classification call if heuristic accuracy proves insufficient in production.

https://claude.ai/code/session_01AzqgFj32VQ6XiDrTqgjtRQ