### PR TITLE
Fix keyboard not reacting on auth screens

### DIFF
--- a/apps/mobile/app/auth/forgot-password.tsx
+++ b/apps/mobile/app/auth/forgot-password.tsx
@@ -3,6 +3,8 @@
 
 import { useState } from 'react';
 import {
+  KeyboardAvoidingView,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -58,6 +60,10 @@ export default function ForgotPasswordScreen() {
         style={StyleSheet.absoluteFill}
       />
       <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={{ flex: 1 }}
+        >
         <ScrollView
           contentContainerStyle={s.content}
           keyboardShouldPersistTaps="handled"
@@ -124,6 +130,7 @@ export default function ForgotPasswordScreen() {
             </>
           )}
         </ScrollView>
+        </KeyboardAvoidingView>
 
         {!sent && (
           <View style={s.stickyWrap}>

--- a/apps/mobile/app/auth/index.tsx
+++ b/apps/mobile/app/auth/index.tsx
@@ -7,6 +7,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useState } from 'react';
 import {
+  KeyboardAvoidingView,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -136,6 +138,11 @@ export default function AuthScreen() {
       />
       <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
 
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={{ flex: 1 }}
+        keyboardVerticalOffset={0}
+      >
       <ScrollView
         contentContainerStyle={s.content}
         keyboardShouldPersistTaps="handled"
@@ -261,6 +268,7 @@ export default function AuthScreen() {
           </>
         )}
       </ScrollView>
+      </KeyboardAvoidingView>
 
       {/* Sticky CTA — hidden on confirm-email screen */}
       {screenState !== 'confirm-email' && <View style={s.stickyWrap}>

--- a/apps/mobile/app/auth/reset-password.tsx
+++ b/apps/mobile/app/auth/reset-password.tsx
@@ -6,6 +6,8 @@
 
 import { useState } from 'react';
 import {
+  KeyboardAvoidingView,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -75,6 +77,10 @@ export default function ResetPasswordScreen() {
         style={StyleSheet.absoluteFill}
       />
       <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={{ flex: 1 }}
+        >
         <ScrollView
           contentContainerStyle={s.content}
           keyboardShouldPersistTaps="handled"
@@ -160,6 +166,7 @@ export default function ResetPasswordScreen() {
             </>
           )}
         </ScrollView>
+        </KeyboardAvoidingView>
 
         {hasTokens && (
           <View style={s.stickyWrap}>


### PR DESCRIPTION
Add KeyboardAvoidingView (behavior: padding on iOS, height on Android) to all three auth screens — sign-in/up, forgot-password, reset-password. Without it, the keyboard slides up over the inputs on iOS making typing appear broken.

https://claude.ai/code/session_01AzqgFj32VQ6XiDrTqgjtRQ