### PR TITLE
Fix Android keyboard blocking auth inputs

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -20,6 +20,7 @@
       "supportsTablet": true
     },
     "android": {
+      "softwareKeyboardLayoutMode": "pan",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/android-icon-foreground.png",

--- a/apps/mobile/app/auth/forgot-password.tsx
+++ b/apps/mobile/app/auth/forgot-password.tsx
@@ -61,7 +61,7 @@ export default function ForgotPasswordScreen() {
       />
       <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
         <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
           style={{ flex: 1 }}
         >
         <ScrollView

--- a/apps/mobile/app/auth/index.tsx
+++ b/apps/mobile/app/auth/index.tsx
@@ -139,9 +139,8 @@ export default function AuthScreen() {
       <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
 
       <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={{ flex: 1 }}
-        keyboardVerticalOffset={0}
       >
       <ScrollView
         contentContainerStyle={s.content}

--- a/apps/mobile/app/auth/reset-password.tsx
+++ b/apps/mobile/app/auth/reset-password.tsx
@@ -78,7 +78,7 @@ export default function ResetPasswordScreen() {
       />
       <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
         <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
           style={{ flex: 1 }}
         >
         <ScrollView


### PR DESCRIPTION
On Android with New Architecture, KeyboardAvoidingView behavior="height" collapses the view height incorrectly. Switch to behavior=undefined on Android so the system handles it natively.

Also add softwareKeyboardLayoutMode: "pan" to app.json — this pans the screen up to the focused input on Android rather than resizing, which is more reliable with scrollable forms.

https://claude.ai/code/session_01AzqgFj32VQ6XiDrTqgjtRQ