### PR TITLE
fix: home dashboard hooks + Family tab

### DIFF
--- a/apps/mobile/app/(tabs)/family.tsx
+++ b/apps/mobile/app/(tabs)/family.tsx
@@ -1,19 +1,244 @@
-import { SafeAreaView, View, Text } from 'react-native';
-import { colors as C, fonts as F } from '../../src/theme/colors';
+import { useCallback, useState } from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { router, useFocusEffect } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import * as Haptics from 'expo-haptics';
+
+import { useChildProfile } from '../../src/context/ChildProfileContext';
+import { loadChildInsights, type ChildInsights } from '../../src/lib/loadChildInsights';
+import { colors as C, fonts as F } from '../../src/theme';
+
+const CHILD_GRADIENTS: Array<[string, string]> = [
+  [C.iconTalkStart, C.iconTalkEnd],
+  [C.iconSosStart, C.iconSosEnd],
+  [C.iconUnderstandStart, C.iconUnderstandEnd],
+  [C.iconRepairStart, C.iconRepairEnd],
+];
 
 export default function FamilyScreen() {
+  const { children } = useChildProfile() as any;
+  const kidList = Array.isArray(children) ? children : [];
+  const [childInsights, setChildInsights] = useState<Record<string, ChildInsights>>({});
+
+  useFocusEffect(
+    useCallback(() => {
+      const load = async () => {
+        const results: Record<string, ChildInsights> = {};
+        await Promise.all(
+          kidList.map(async (kid: any) => {
+            const insights = await loadChildInsights(kid.id);
+            results[kid.id] = insights;
+          })
+        );
+        setChildInsights(results);
+      };
+      load();
+    }, [kidList]),
+  );
+
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: C.background }}>
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-        <Text style={{
-          fontFamily: F.heading,
-          fontSize: 28,
-          color: 'rgba(255,248,231,0.92)',
-          letterSpacing: -0.5,
-        }}>
-          Family Hub
-        </Text>
-      </View>
-    </SafeAreaView>
+    <View style={s.root}>
+      <SafeAreaView style={s.safe} edges={['top']}>
+        <ScrollView
+          contentContainerStyle={s.scroll}
+          showsVerticalScrollIndicator={false}
+        >
+          <Text style={s.header}>Your family</Text>
+
+          {kidList.map((kid: any, index: number) => {
+            const grad = CHILD_GRADIENTS[index % CHILD_GRADIENTS.length] as [string, string];
+            const initial = (kid?.name?.trim()?.[0] ?? '?').toUpperCase();
+            const insights = childInsights[kid.id];
+            const topTrigger = insights?.topTriggers?.[0] ?? null;
+            const totalSessions = insights?.totalInteractions ?? 0;
+
+            return (
+              <Pressable
+                key={kid.id}
+                onPress={() => {
+                  Haptics.selectionAsync();
+                  router.push(`/child/${kid.id}` as any);
+                }}
+                style={({ pressed }) => [s.card, pressed && { opacity: 0.85 }]}
+                accessibilityRole="button"
+                accessibilityLabel={`View ${kid.name}'s profile`}
+              >
+                <View style={s.cardRow}>
+                  <LinearGradient
+                    colors={grad}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 1 }}
+                    style={s.avatar}
+                  >
+                    <Text style={s.avatarInitial}>{initial}</Text>
+                  </LinearGradient>
+
+                  <View style={s.cardInfo}>
+                    <View style={s.nameRow}>
+                      <Text style={s.childName}>{kid.name}</Text>
+                      {topTrigger ? (
+                        <View style={s.triggerBadge}>
+                          <Text style={s.triggerBadgeText}>{topTrigger.label}</Text>
+                        </View>
+                      ) : null}
+                    </View>
+                    <Text style={s.childMeta}>
+                      Age {kid.childAge}
+                      {totalSessions > 0
+                        ? `  ·  ${totalSessions} session${totalSessions === 1 ? '' : 's'}`
+                        : ''}
+                    </Text>
+                  </View>
+
+                  <Text style={s.chevron}>›</Text>
+                </View>
+              </Pressable>
+            );
+          })}
+
+          {kidList.length === 0 && (
+            <View style={s.emptyWrap}>
+              <Text style={s.emptyText}>No children added yet.</Text>
+            </View>
+          )}
+        </ScrollView>
+
+        <View style={s.footer}>
+          <Pressable
+            onPress={() => {
+              Haptics.selectionAsync();
+              router.push('/child/new');
+            }}
+            style={({ pressed }) => [pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] }]}
+          >
+            <LinearGradient
+              colors={[C.amber, C.amberMid]}
+              start={{ x: 0, y: 0 }}
+              end={{ x: 1, y: 0 }}
+              style={s.addBtn}
+            >
+              <Text style={s.addBtnText}>Add a child</Text>
+            </LinearGradient>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    </View>
   );
 }
+
+const s = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#1E1D25',
+  },
+  safe: { flex: 1 },
+  scroll: {
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 24,
+  },
+  header: {
+    fontFamily: F.headingItalic,
+    fontSize: 30,
+    color: 'rgba(255,248,230,0.92)',
+    letterSpacing: -0.5,
+    marginBottom: 24,
+  },
+  card: {
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    borderColor: 'rgba(255,255,255,0.07)',
+    borderRadius: 14,
+    borderWidth: 1,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  cardRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarInitial: {
+    fontFamily: F.heading,
+    fontSize: 20,
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+  cardInfo: {
+    flex: 1,
+    gap: 4,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  childName: {
+    fontFamily: F.bodySemi,
+    fontSize: 15,
+    color: 'rgba(255,248,230,0.92)',
+  },
+  triggerBadge: {
+    backgroundColor: 'rgba(200,136,58,0.22)',
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  triggerBadgeText: {
+    fontFamily: F.body,
+    fontSize: 11,
+    color: C.amberMid,
+  },
+  childMeta: {
+    fontFamily: F.body,
+    fontSize: 13,
+    color: 'rgba(255,255,255,0.40)',
+  },
+  chevron: {
+    fontSize: 20,
+    color: 'rgba(255,255,255,0.20)',
+    lineHeight: 24,
+  },
+  emptyWrap: {
+    paddingTop: 60,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontFamily: F.body,
+    fontSize: 14,
+    color: 'rgba(255,255,255,0.30)',
+    fontStyle: 'italic',
+  },
+  footer: {
+    paddingHorizontal: 24,
+    paddingBottom: 24,
+    paddingTop: 8,
+  },
+  addBtn: {
+    borderRadius: 14,
+    minHeight: 52,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addBtnText: {
+    fontFamily: F.subheading,
+    fontSize: 15,
+    color: '#140f0a',
+    letterSpacing: 0.3,
+  },
+});

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -472,7 +472,7 @@ const fetchChildInsights = useCallback(async () => {
     })
   );
   setChildInsights(results);
-}, [kidList.length]);
+}, [kidList]);
 
 // ─── Focus effect ───
 useFocusEffect(
@@ -800,7 +800,8 @@ return (
 {(() => {
   const activeKid = kidList[activeSessionIndex];
   const log = activeKid ? recentLogsByChild[activeKid.id] : null;
-  const summary = log?.situation_summary ?? 'Leaving the park — screaming';
+  const triggerLabel = log?.trigger_category ? (RECENT_TRIGGER_LABELS[log.trigger_category] ?? log.trigger_category) : null;
+  const summary = log?.situation_summary ?? triggerLabel ?? 'No recent sessions yet';
   const truncated = summary.length > 60 ? summary.slice(0, 60) + '...' : summary;
   const timestamp = log ? formatTimeAgo(log.created_at) : '2 hours ago';
 
@@ -900,16 +901,13 @@ return (
 <Text style={[s.hookSubheader, { marginTop: 22, color: 'rgba(200,136,58,0.55)' }]}>STURDY+</Text>
 {(() => {
   const activeKid = kidList[activeSessionIndex];
-  const mockInsights: Record<string, string> = {};
-  kidList.forEach((kid: any) => {
-    const triggers = childInsights[kid.id]?.topTriggers ?? [];
-    if (triggers.length > 0) {
-      mockInsights[kid.id] = `${triggers[0].label} is the pattern — but it's not really about ${triggers[0].label.toLowerCase()}...`;
-    } else {
-      mockInsights[kid.id] = 'A weekly pattern insight will appear here soon...';
-    }
-  });
-  const quote = activeKid ? (mockInsights[activeKid.id] ?? 'A weekly pattern insight will appear here soon...') : 'A weekly pattern insight will appear here soon...';
+  const triggers = activeKid ? (childInsights[activeKid.id]?.topTriggers ?? []) : [];
+  let quote: string;
+  if (triggers.length > 0) {
+    quote = `${triggers[0].label} keeps coming up for ${activeKid?.name ?? 'your child'} — unlock the full pattern read.`;
+  } else {
+    quote = 'Patterns are building — check back after a few more sessions.';
+  }
 
   return (
     <Pressable


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Last Session fallback chain**: card now falls through `situation_summary` → `RECENT_TRIGGER_LABELS[trigger_category]` → raw `trigger_category` → `'No recent sessions yet'`, replacing the hardcoded mock string "Leaving the park — screaming"
- **Weekly Insight teaser**: replaced the `mockInsights` map-build with a direct read of `childInsights[activeKid.id]?.topTriggers`; quote is now `"<TopTrigger> keeps coming up for <Name> — unlock the full pattern read."` or an empty-state fallback
- **Stale dependency fix**: `fetchChildInsights` useCallback dep changed from `[kidList.length]` to `[kidList]` so it re-runs when child data actually changes, not just the count
- **Family tab**: fully built — `#1E1D25` background, Fraunces italic header, glass card per child with avatar gradient circle, top trigger amber badge pill, age + session count, `useFocusEffect` insights refresh on every focus, amber gradient "Add a child" footer button

## Test plan

- [ ] Last Session card shows `situation_summary` when present; falls back to trigger label for older rows; shows "No recent sessions yet" for children with no logs
- [ ] Weekly Insight teaser shows the child's top trigger by name; shows pattern-building copy when no triggers exist
- [ ] Adding or removing a child updates the insights panel without needing a full restart
- [ ] Family tab renders all children with correct avatars, trigger badges (hidden when no triggers), and session counts
- [ ] Tapping a child card on Family tab navigates to `/child/<id>`
- [ ] "Add a child" button on Family tab navigates to `/child/new`
- [ ] Family tab insights refresh every time the tab is focused

https://claude.ai/code/session_01TpSbPjDPGKEjytCnKU9cNP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpSbPjDPGKEjytCnKU9cNP)_