### PR TITLE
Quota V2: dual buckets, usage bars, voice gating

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -42,8 +42,9 @@ import { useAuth } from '../../src/context/AuthContext';
 import { useChildProfile } from '../../src/context/ChildProfileContext';
 import { supabase } from '../../src/lib/supabase';
 import { loadChildInsights, type ChildInsights } from '../../src/lib/loadChildInsights';
-import { getQuestionResponse, CrisisDetectedError, RateLimitError } from '../../src/lib/api';
+import { getQuestionResponse, CrisisDetectedError, RateLimitError, QuotaExceededError } from '../../src/lib/api';
 import { colors as C, fonts as F } from '../../src/theme';
+import { QuotaBar } from '../../src/components/ui/QuotaBar';
 
 // ═══════════════════════════════════════════════
 // CONSTANTS
@@ -574,6 +575,7 @@ const handleSend = async () => {
       });
       return;
     }
+    if (err instanceof QuotaExceededError) { router.push('/upgrade' as any); return; }
     if (err instanceof RateLimitError) { setError(err.message); return; }
     setError("Couldn't get a response right now. Please try again.");
   } finally {
@@ -793,6 +795,7 @@ return (
               </Pressable>
             </View>
             {error ? <Text style={s.errorText}>{error}</Text> : null}
+            <QuotaBar />
 
             {/* ─── Dashboard hook cards ─── */}
             <View style={s.hookStack}>

--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -24,7 +24,7 @@ import * as Haptics from 'expo-haptics';
 
 import { useAuth } from '../../src/context/AuthContext';
 import { useChildProfile } from '../../src/context/ChildProfileContext';
-import { getParentingScript, CrisisDetectedError, RateLimitError } from '../../src/lib/api';
+import { getParentingScript, CrisisDetectedError, RateLimitError, QuotaExceededError } from '../../src/lib/api';
 import { detectCrisis } from '../../src/hooks/useCrisisMode';
 import { loadSavedScripts, type SavedScriptRow } from '../../src/lib/loadSavedScripts';
 import { incrementScriptCount } from '../../src/utils/profileNudge';
@@ -323,6 +323,10 @@ export default function ChildHubScreen() {
           pathname: '/crisis',
           params: { crisisType: err.crisisType, riskLevel: err.riskLevel },
         });
+        return;
+      }
+      if (err instanceof QuotaExceededError) {
+        router.push('/upgrade' as any);
         return;
       }
       if (err instanceof RateLimitError) {

--- a/apps/mobile/app/result.tsx
+++ b/apps/mobile/app/result.tsx
@@ -32,6 +32,7 @@ import { saveScript }     from '../src/lib/saveScript';
 import { detectCrisis } from '../src/hooks/useCrisisMode';
 import { shouldShowProfileNudge, markNudgeShown } from '../src/utils/profileNudge';
 import { useSubscription } from '../src/hooks/useSubscription';
+import { useQuota }        from '../src/hooks/useQuota';
 import { PaywallSheet } from '../src/components/ui/PaywallSheet';
 import { colors as C, fonts as F } from '../src/theme';
 
@@ -106,6 +107,59 @@ function PulsingDot() {
   return <Animated.View style={[{ width: 6, height: 6, borderRadius: 3, backgroundColor: C.sos }, { opacity: anim }]} />;
 }
 
+// ─── Quota footer shown below footer action buttons ───
+function QuotaResultFooter({
+  mode, scriptsRemaining, questionsRemaining, isLow, resetDate,
+}: {
+  mode: string;
+  scriptsRemaining: number;
+  questionsRemaining: number;
+  isLow: boolean;
+  resetDate: string;
+}) {
+  const remaining = mode === 'question' ? questionsRemaining : scriptsRemaining;
+  const label     = mode === 'question' ? 'questions' : 'scripts';
+  const cap       = mode === 'question' ? 25 : 50;
+
+  if (!isLow && remaining > 10) {
+    return (
+      <View style={rf.root}>
+        <Text style={rf.quiet}>{remaining} {label} remaining this month</Text>
+      </View>
+    );
+  }
+
+  return (
+    <Pressable style={rf.card} onPress={() => router.push('/upgrade' as any)}>
+      <View style={rf.cardTop}>
+        <Text style={rf.cardCount}>{remaining} {label} left this month</Text>
+        <Text style={rf.cardReset}>Resets {resetDate}</Text>
+      </View>
+      <View style={rf.track}>
+        <View style={[rf.fill, { width: `${Math.round(Math.max(0, Math.min(1, remaining / cap)) * 100)}%` as any }]} />
+      </View>
+      <Text style={rf.cardCta}>
+        Unlimited scripts, more children, tone selector — <Text style={rf.ctaLink}>see Sturdy+ →</Text>
+      </Text>
+    </Pressable>
+  );
+}
+
+const rf = StyleSheet.create({
+  root:     { paddingHorizontal: 20, paddingTop: 8, paddingBottom: 4, alignItems: 'center' },
+  quiet:    { fontSize: 12, color: 'rgba(255,248,230,0.28)', fontFamily: 'DMSans_400Regular' },
+  card:     { marginHorizontal: 20, marginTop: 8, marginBottom: 4, backgroundColor: C.amberMuted,
+               borderWidth: 1, borderColor: 'rgba(200,136,58,0.15)', borderRadius: 12, padding: 14 },
+  cardTop:  { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 },
+  cardCount:{ fontSize: 13, color: C.amber, fontFamily: 'DMSans_600SemiBold' },
+  cardReset:{ fontSize: 11, color: 'rgba(200,136,58,0.5)', fontFamily: 'DMSans_400Regular' },
+  track:    { height: 3, backgroundColor: 'rgba(255,255,255,0.06)', borderRadius: 2,
+               overflow: 'hidden', marginBottom: 10 },
+  fill:     { height: '100%', backgroundColor: C.amber, borderRadius: 2 },
+  cardCta:  { fontSize: 12, color: 'rgba(200,136,58,0.7)', fontFamily: 'DMSans_400Regular', lineHeight: 18 },
+  ctaLink:  { color: C.amber, fontFamily: 'DMSans_600SemiBold' },
+});
+
 // ═══════════════════════════════════════════════
 // MAIN
 // ═══════════════════════════════════════════════
@@ -134,6 +188,12 @@ export default function ResultScreen() {
   // Voice playback gating — SOS is free for everyone; other modes
   // require Sturdy+. Free user tapping locked voice opens PaywallSheet.
   const { isPremium } = useSubscription();
+  const {
+    counts, refresh: refreshQuota,
+    scriptsRemaining, questionsRemaining,
+    isScriptsLow, isQuestionsLow,
+    loading: quotaLoading,
+  } = useQuota();
   const [voicePaywall, setVoicePaywall] = useState(false);
 
   const isFallback = !isValid(val(params.regulateScript));
@@ -169,6 +229,7 @@ export default function ResultScreen() {
     setSaved(false); setSaving(false); setSaveErr(''); setAvoidOpen(false);
     setCopied(false);
     setFeedbackGiven(false); setFeedbackStep('helpful'); setFeedbackHelpful(null);
+    refreshQuota();
     return () => { voice.stop(); };
   }, [params.regulateScript]);
 
@@ -374,6 +435,15 @@ const handleRetry = () => {
           pointerEvents="none"
         />
         <View style={s.footerContent}>
+          {!isPremium && !quotaLoading && session && (
+            <QuotaResultFooter
+              mode={mode}
+              scriptsRemaining={scriptsRemaining}
+              questionsRemaining={questionsRemaining}
+              isLow={mode === 'question' ? isQuestionsLow : isScriptsLow}
+              resetDate={counts.resetDate}
+            />
+          )}
           <View style={s.footerRow}>
             <Pressable onPress={handleSave} disabled={saved || saving} style={({ pressed }) => [s.footerGhost, pressed && { opacity: 0.7 }]}>
               <Text style={s.footerGhostText}>{saved ? '✓ Saved' : saving ? 'Saving…' : 'Save'}</Text>

--- a/apps/mobile/src/components/ui/QuotaBar.tsx
+++ b/apps/mobile/src/components/ui/QuotaBar.tsx
@@ -1,0 +1,88 @@
+// src/components/ui/QuotaBar.tsx
+// Compact dual-bar usage display shown below the Ask Sturdy pill on the home screen.
+// Visible for logged-in free users only — hidden for Sturdy+ and guests.
+
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { router }          from 'expo-router';
+import * as Haptics        from 'expo-haptics';
+import { useQuota }        from '../../hooks/useQuota';
+import { useSubscription } from '../../hooks/useSubscription';
+import { useAuth }         from '../../context/AuthContext';
+import { colors as C, fonts as F } from '../../theme';
+
+const AMBER     = C.amber;
+const AMBER_DIM = 'rgba(200,136,58,0.45)';
+const MUTED     = 'rgba(255,248,230,0.28)';
+const TRACK_BG  = 'rgba(255,255,255,0.06)';
+
+export function QuotaBar() {
+  const { session }   = useAuth();
+  const { isPremium } = useSubscription();
+  const {
+    counts, loading,
+    scriptsPct, questionsPct,
+    isScriptsLow, isQuestionsLow,
+  } = useQuota();
+
+  if (isPremium || !session || loading) return null;
+
+  const showCTA = isScriptsLow || isQuestionsLow;
+
+  const handleUpgrade = () => {
+    Haptics.selectionAsync();
+    router.push('/upgrade' as any);
+  };
+
+  return (
+    <View style={s.root}>
+      {/* Scripts bar */}
+      <View style={s.row}>
+        <Text style={[s.label, isScriptsLow && { color: AMBER }]}>
+          {counts.scriptsUsed} of {counts.scriptsCap} scripts
+        </Text>
+        {showCTA ? (
+          <Pressable onPress={handleUpgrade} hitSlop={8}>
+            <Text style={s.cta}>Unlock unlimited →</Text>
+          </Pressable>
+        ) : (
+          <Text style={s.resetLabel}>Resets {counts.resetDate}</Text>
+        )}
+      </View>
+      <View style={s.track}>
+        <View style={[
+          s.fill,
+          {
+            width: `${Math.round(scriptsPct * 100)}%` as any,
+            backgroundColor: isScriptsLow ? AMBER : AMBER_DIM,
+          },
+        ]} />
+      </View>
+
+      {/* Questions bar */}
+      <View style={[s.row, { marginTop: 8 }]}>
+        <Text style={[s.label, isQuestionsLow && { color: AMBER }]}>
+          {counts.questionsUsed} of {counts.questionsCap} questions
+        </Text>
+      </View>
+      <View style={s.track}>
+        <View style={[
+          s.fill,
+          {
+            width: `${Math.round(questionsPct * 100)}%` as any,
+            backgroundColor: isQuestionsLow ? AMBER : AMBER_DIM,
+          },
+        ]} />
+      </View>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  root:       { paddingHorizontal: 4, marginBottom: 20 },
+  row:        { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 5 },
+  label:      { fontFamily: F.body, fontSize: 11, color: MUTED },
+  resetLabel: { fontFamily: F.body, fontSize: 11, color: MUTED },
+  cta:        { fontFamily: F.bodyMedium, fontSize: 11, color: AMBER },
+  track:      { height: 3, backgroundColor: TRACK_BG, borderRadius: 2, overflow: 'hidden' },
+  fill:       { height: '100%', borderRadius: 2 },
+});

--- a/apps/mobile/src/hooks/useQuota.ts
+++ b/apps/mobile/src/hooks/useQuota.ts
@@ -1,0 +1,82 @@
+// src/hooks/useQuota.ts
+// Fetches both quota counts in one RPC call (get_quota_counts).
+// Free users only — Sturdy+ users bypass quota entirely (returns zeroed counts).
+
+import { useCallback, useEffect, useState } from 'react';
+import { supabase }       from '../lib/supabase';
+import { useAuth }        from '../context/AuthContext';
+import { useSubscription } from './useSubscription';
+
+export interface QuotaCounts {
+  scriptsUsed:   number;
+  scriptsCap:    number;
+  questionsUsed: number;
+  questionsCap:  number;
+  resetDate:     string; // "Jun 1" format
+}
+
+const EMPTY: Omit<QuotaCounts, 'resetDate'> = {
+  scriptsUsed:   0,
+  scriptsCap:    50,
+  questionsUsed: 0,
+  questionsCap:  25,
+};
+
+function getResetDate(): string {
+  const now   = new Date();
+  const reset = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  return reset.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export function useQuota() {
+  const { session }   = useAuth();
+  const { isPremium } = useSubscription();
+
+  const [counts, setCounts]   = useState<QuotaCounts>({ ...EMPTY, resetDate: getResetDate() });
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    if (!session?.user?.id || isPremium) {
+      setCounts({ ...EMPTY, resetDate: getResetDate() });
+      setLoading(false);
+      return;
+    }
+    try {
+      const { data, error } = await supabase
+        .rpc('get_quota_counts', { target_user_id: session.user.id });
+      if (error || !data) throw error ?? new Error('empty response');
+      setCounts({
+        scriptsUsed:   (data as any).scripts_used   ?? 0,
+        scriptsCap:    (data as any).scripts_cap    ?? 50,
+        questionsUsed: (data as any).questions_used ?? 0,
+        questionsCap:  (data as any).questions_cap  ?? 25,
+        resetDate:     getResetDate(),
+      });
+    } catch (err) {
+      console.warn('[QUOTA] Failed to fetch counts:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.user?.id, isPremium]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const scriptsRemaining   = Math.max(0, counts.scriptsCap   - counts.scriptsUsed);
+  const questionsRemaining = Math.max(0, counts.questionsCap - counts.questionsUsed);
+  const scriptsPct         = counts.scriptsCap   > 0 ? Math.min(1, counts.scriptsUsed   / counts.scriptsCap)   : 0;
+  const questionsPct       = counts.questionsCap > 0 ? Math.min(1, counts.questionsUsed / counts.questionsCap) : 0;
+
+  return {
+    counts,
+    loading,
+    refresh,
+    scriptsRemaining,
+    questionsRemaining,
+    scriptsPct,
+    questionsPct,
+    isScriptsLow:    !isPremium && scriptsPct   >= 0.8,
+    isQuestionsLow:  !isPremium && questionsPct >= 0.8,
+    isScriptsGone:   !isPremium && scriptsRemaining   === 0,
+    isQuestionsGone: !isPremium && questionsRemaining === 0,
+  };
+}

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -74,6 +74,17 @@ export class CrisisDetectedError extends Error {
 }
 
 
+// Thrown when the Edge Function returns 402 (monthly quota exceeded).
+// quota_type distinguishes which bucket ran out: 'scripts' or 'questions'.
+export class QuotaExceededError extends Error {
+  readonly quotaType: 'scripts' | 'questions';
+  constructor(quotaType: 'scripts' | 'questions' = 'scripts') {
+    super('quota_exceeded');
+    this.name      = 'QuotaExceededError';
+    this.quotaType = quotaType;
+  }
+}
+
 // Thrown when the Edge Function returns 429. Server-supplied message is the
 // safe one to surface to the parent. Crisis paths bypass the rate limit by
 // design, so callers don't need to special-case crisis here.
@@ -163,6 +174,11 @@ export async function getParentingScript(
       typeof (data as { error: unknown }).error === 'string'
         ? (data as { error: string }).error : 'request-failed';
     console.log('[API] Response not ok:', msg);
+    if (response.status === 402) {
+      const qt = typeof data === 'object' && data !== null && 'quota_type' in data &&
+        (data as { quota_type: unknown }).quota_type === 'questions' ? 'questions' : 'scripts';
+      throw new QuotaExceededError(qt);
+    }
     if (response.status === 429) {
       throw new RateLimitError(msg, parseRetryAfter(response));
     }
@@ -261,6 +277,9 @@ export async function getQuestionResponse(
       typeof (data as { error: unknown }).error === 'string'
         ? (data as { error: string }).error : 'request-failed';
     console.log('[API] Question response not ok:', msg);
+    if (response.status === 402) {
+      throw new QuotaExceededError('questions');
+    }
     if (response.status === 429) {
       throw new RateLimitError(msg, parseRetryAfter(response));
     }

--- a/docs/STURDY_MASTER_BLUEPRINT.md
+++ b/docs/STURDY_MASTER_BLUEPRINT.md
@@ -30,25 +30,27 @@ Sturdy is the go-to parenting companion for every parent at every level.
 
 ### The Metered Freemium Model
 
-**Free Tier:** 50 free script generations per calendar month across Question, Reconnect, Understand, and Conversation modes.
-
-**SOS is always unlimited and free.** SOS scripts are excluded from the monthly quota. The `check_monthly_quota` RPC filters on `event_meta->>'mode' != 'sos'` and only counts `script_generated`, `question_generated`, and `followup_generated` event types. This is non-negotiable per Principle 6.
+**Free Tier:**
+- Script quota: 50/month — SOS, Reconnect, Understand, Conversation, follow-ups
+- Question quota: 25/month — Question mode only
+- 1 child profile
+- Voice on SOS only
+- Crisis support: always free, never counted
 
 **Sturdy+ ($9.99/month or $69.99/year):**
-- Unlimited scripts across all modes (no monthly cap)
+- Unlimited scripts and questions (both quotas removed)
+- Unlimited child profiles
 - Tone selector (Soft / Direct)
 - Follow-up scripts
-- Saved script library (searchable)
 - Voice playback on all modes
 
 **V1 Sturdy+ does NOT include** (deferred to V2):
 - Weekly insights / reflections
 - Emerging pattern detection
-- "A Sturdy that knows your child" personalization
 
-**The Quota System:** Tracked server-side via `check_monthly_quota` RPC evaluating the `usage_events` table. Free users hit a hard paywall (`PaywallSheet.tsx`) when the non-SOS count reaches 50. Crisis paths and SOS are always exempt.
+**The Quota System:** Two separate RPCs in Supabase: `check_script_quota` (cap: 50) counts `script_generated` and `followup_generated` events where mode is not `question`. `check_question_quota` (cap: 25) counts `question_generated` events. A combined `get_quota_counts` RPC returns both buckets in one call for the mobile UI. The 402 response includes `quota_type: "scripts" | "questions"` so the client can distinguish which bucket ran out.
 
-**The Crisis Exemption:** We never paywall safety. If the safety filter returns `response_type: "crisis"`, it bypasses quota and rate limits and routes to the free `/crisis` support screen.
+**The Crisis Exemption:** We never paywall safety. If the safety filter returns `response_type: "crisis"`, it bypasses quota and rate limits entirely and routes to the free `/crisis` support screen.
 
 ### "Zero Trace" Data Safety
 
@@ -111,7 +113,7 @@ Sturdy is the go-to parenting companion for every parent at every level.
 
 Cards auto-cycle across children every 5 seconds (crossfade animation). Swipeable left/right. Amber indicator dots for 2+ children.
 
-**Quota Counter:** Tracked server-side via `check_monthly_quota` RPC — not displayed on home screen UI.
+**Quota Counter:** Displayed below the Ask Sturdy pill for free users via `QuotaBar` component. Shows two progress bars — scripts (X of 50) and questions (X of 25) — with reset date. Turns amber and shows "Unlock unlimited →" at 80%+ usage. Hidden for Sturdy+ users.
 
 ### The Child Hub (`/child/[id].tsx`)
 
@@ -163,13 +165,17 @@ Cards auto-cycle across children every 5 seconds (crossfade animation). Swipeabl
 - `child_profiles` — Child context: name, age, inferred neurotype array
 - `parent_thoughts` — Question mode Q&A, auto-tagged to children
 - `interaction_logs` — Logs R/C/G mode results, tone selected, and user follow-up
-- `usage_events` — Tracking for the freemium quota (SOS excluded from count)
+- `usage_events` — Tracking for the freemium quota (two buckets: scripts + questions)
 - `safety_events` — Logged triggers — `ON DELETE CASCADE` (no anonymized retention)
 - `child_insights` — Aggregated patterns, week_of dates, Sturdy+ content
 
 ### Key RPCs
 
-`check_monthly_quota`: Returns count of non-SOS `usage_events` for the given user in the current calendar month. Filters: `event_meta->>'mode' != 'sos'` and `event_type in ('script_generated', 'question_generated', 'followup_generated')`.
+`check_script_quota`: Returns count of script-mode `usage_events` for the given user in the current calendar month. Filters: `event_type in ('script_generated', 'followup_generated')` and `mode != 'question'`. Cap: 50.
+
+`check_question_quota`: Returns count of `question_generated` events for the given user in the current calendar month. Cap: 25.
+
+`get_quota_counts`: Returns both counts in one call as JSON `{ scripts_used, scripts_cap, questions_used, questions_cap }`. Used by the mobile `useQuota` hook for the home screen usage bars.
 
 ---
 

--- a/supabase/functions/chat-parenting-assistant/index.ts
+++ b/supabase/functions/chat-parenting-assistant/index.ts
@@ -34,12 +34,13 @@ function jsonRes(body: unknown, status = 200, extraHeaders: Record<string, strin
   });
 }
 
-const MONTHLY_SCRIPT_LIMIT = 50;
+const SCRIPT_QUOTA_LIMIT   = 50;
+const QUESTION_QUOTA_LIMIT = 25;
 
-async function checkQuota(userId: string): Promise<boolean> {
+async function checkScriptQuota(userId: string): Promise<boolean> {
   if (!SUPABASE_URL || !SUPABASE_KEY) return false;
   try {
-    const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/check_monthly_quota`, {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/check_script_quota`, {
       method:  "POST",
       headers: {
         "Content-Type":  "application/json",
@@ -48,9 +49,29 @@ async function checkQuota(userId: string): Promise<boolean> {
       },
       body: JSON.stringify({ target_user_id: userId }),
     });
-    if (!res.ok) return false; // fail open — never block on infra error
+    if (!res.ok) return false;
     const count = await res.json();
-    return typeof count === "number" && count >= MONTHLY_SCRIPT_LIMIT;
+    return typeof count === "number" && count >= SCRIPT_QUOTA_LIMIT;
+  } catch {
+    return false; // fail open
+  }
+}
+
+async function checkQuestionQuota(userId: string): Promise<boolean> {
+  if (!SUPABASE_URL || !SUPABASE_KEY) return false;
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/check_question_quota`, {
+      method:  "POST",
+      headers: {
+        "Content-Type":  "application/json",
+        "apikey":        SUPABASE_KEY,
+        "Authorization": `Bearer ${SUPABASE_KEY}`,
+      },
+      body: JSON.stringify({ target_user_id: userId }),
+    });
+    if (!res.ok) return false;
+    const count = await res.json();
+    return typeof count === "number" && count >= QUESTION_QUOTA_LIMIT;
   } catch {
     return false; // fail open
   }
@@ -278,11 +299,19 @@ serve(async (req) => {
   //     never paywalled, regardless of how many scripts the user has used.
   //     Fails open (never blocks) on infra errors so a DB hiccup doesn't
   //     lock a parent out mid-moment.
+  //     Two buckets: 50 scripts/month (all directed modes) + 25 questions/month.
   //     TODO: skip for Sturdy+ users once RevenueCat billing is live. ───
   if (input.userId) {
-    const exceeded = await checkQuota(input.userId);
-    if (exceeded) {
-      return jsonRes({ error: "quota_exceeded" }, 402);
+    if (input.mode === 'question') {
+      const exceeded = await checkQuestionQuota(input.userId);
+      if (exceeded) {
+        return jsonRes({ error: "quota_exceeded", quota_type: "questions" }, 402);
+      }
+    } else {
+      const exceeded = await checkScriptQuota(input.userId);
+      if (exceeded) {
+        return jsonRes({ error: "quota_exceeded", quota_type: "scripts" }, 402);
+      }
     }
   }
 

--- a/supabase/migrations/20260521_009_dual_quota_buckets.sql
+++ b/supabase/migrations/20260521_009_dual_quota_buckets.sql
@@ -1,0 +1,86 @@
+-- 20260521_009_dual_quota_buckets.sql
+--
+-- Replaces check_monthly_quota with two separate quota RPCs:
+--   check_script_quota   — SOS, Reconnect, Understand, Conversation, follow-ups (cap: 50)
+--   check_question_quota — Question mode only (cap: 25)
+--
+-- Also adds get_quota_counts — returns both counts in one call for the mobile UI.
+--
+-- Rollback: re-apply check_monthly_quota from migration 20260521_008 and
+-- drop check_script_quota, check_question_quota, get_quota_counts.
+
+begin;
+
+-- ─── Script quota (all directed modes including SOS) ───
+create or replace function public.check_script_quota(target_user_id uuid)
+returns int
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  script_count int;
+begin
+  select count(*) into script_count
+  from usage_events
+  where user_id = target_user_id
+    and date_trunc('month', created_at) = date_trunc('month', current_date)
+    and event_type in ('script_generated', 'followup_generated')
+    and coalesce(event_meta->>'mode', 'sos') != 'question';
+  return script_count;
+end;
+$$;
+
+-- ─── Question quota ───
+create or replace function public.check_question_quota(target_user_id uuid)
+returns int
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  question_count int;
+begin
+  select count(*) into question_count
+  from usage_events
+  where user_id = target_user_id
+    and date_trunc('month', created_at) = date_trunc('month', current_date)
+    and event_type = 'question_generated';
+  return question_count;
+end;
+$$;
+
+-- ─── Combined counts for mobile UI (one DB round-trip) ───
+create or replace function public.get_quota_counts(target_user_id uuid)
+returns json
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  s_count int;
+  q_count int;
+begin
+  select count(*) into s_count
+  from usage_events
+  where user_id = target_user_id
+    and date_trunc('month', created_at) = date_trunc('month', current_date)
+    and event_type in ('script_generated', 'followup_generated')
+    and coalesce(event_meta->>'mode', 'sos') != 'question';
+
+  select count(*) into q_count
+  from usage_events
+  where user_id = target_user_id
+    and date_trunc('month', created_at) = date_trunc('month', current_date)
+    and event_type = 'question_generated';
+
+  return json_build_object(
+    'scripts_used',   s_count,
+    'scripts_cap',    50,
+    'questions_used', q_count,
+    'questions_cap',  25
+  );
+end;
+$$;
+
+commit;


### PR DESCRIPTION
## Summary

Implements the agreed Strategy 1+4 freemium model with two separate quota buckets and live usage display.

- **Dual quota buckets**: 50 scripts/month (SOS, Reconnect, Understand, Conversation, follow-ups) + 25 questions/month (Question mode). Three new Supabase RPCs: `check_script_quota`, `check_question_quota`, `get_quota_counts`
- **QuotaExceededError**: New error class in `api.ts` with `quotaType: 'scripts' | 'questions'`. Both `getParentingScript` and `getQuestionResponse` throw it on 402. Child hub and home screen route to `/upgrade` on this error
- **useQuota hook**: Fetches both counts in one `get_quota_counts` RPC call. Returns remaining counts, percentages, low-usage flags, and reset date
- **Home screen usage bars** (`QuotaBar` component): Shows below the Ask Sturdy pill for free users. Two progress bars (scripts + questions). Turns amber + shows "Unlock unlimited →" at ≥80% usage. Hidden for Sturdy+ and guests
- **Result screen quota footer** (`QuotaResultFooter`): Shows remaining count below Save/Copy/Retry buttons. Quiet text when >10 remaining; amber card with upgrade CTA when ≤10 or low
- **Voice gating confirmed**: `voiceLocked = mode !== 'sos' && !isPremium` — existing logic is correct, no change needed
- **Master Blueprint updated**: Dual quota model, new RPCs, usage display documented

## Test plan

- [ ] `npm test` in `apps/mobile/` — 36 tests pass
- [ ] Home screen shows two progress bars below Ask Sturdy pill for a free logged-in user
- [ ] Bars hidden for Sturdy+ users and guests
- [ ] At ≥80% on either bar, amber color + "Unlock unlimited →" appears
- [ ] After generating a script, result screen shows remaining count in footer
- [ ] At ≤10 remaining, amber card with upgrade CTA appears
- [ ] Generating a script past quota routes to `/upgrade` (not a toast error)
- [ ] Question mode quota exceeded also routes to `/upgrade`
- [ ] Crisis flow unaffected (safety filter bypasses quota check)
- [ ] Migration `20260521_009_dual_quota_buckets.sql` applied in Supabase SQL Editor — `select proname from pg_proc where proname in ('check_script_quota', 'check_question_quota', 'get_quota_counts')` returns 3 rows

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPGoVyW91PxZUrBPtKxvPG)_