### PR TITLE
fix(frontend): resolve layout & mobile safe-area issues (audit fixes)

### DIFF
--- a/apps/mobile/app/(tabs)/family.tsx
+++ b/apps/mobile/app/(tabs)/family.tsx
@@ -13,7 +13,7 @@ import * as Haptics from 'expo-haptics';
 
 import { useChildProfile } from '../../src/context/ChildProfileContext';
 import { loadChildInsights, type ChildInsights } from '../../src/lib/loadChildInsights';
-import { colors as C, fonts as F } from '../../src/theme';
+import { colors as C, fonts as F, TAB_BAR_HEIGHT } from '../../src/theme';
 
 const CHILD_GRADIENTS: Array<[string, string]> = [
   [C.iconTalkStart, C.iconTalkEnd],
@@ -45,7 +45,7 @@ export default function FamilyScreen() {
 
   return (
     <View style={s.root}>
-      <SafeAreaView style={s.safe} edges={['top']}>
+      <SafeAreaView style={s.safe} edges={['top', 'bottom']}>
         <ScrollView
           contentContainerStyle={s.scroll}
           showsVerticalScrollIndicator={false}
@@ -226,8 +226,9 @@ const s = StyleSheet.create({
   },
   footer: {
     paddingHorizontal: 24,
-    paddingBottom: 24,
+    paddingBottom: 8,
     paddingTop: 8,
+    marginBottom: TAB_BAR_HEIGHT,
   },
   addBtn: {
     borderRadius: 14,

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -34,7 +34,7 @@ import { useAuth } from '../../src/context/AuthContext';
 import { useChildProfile } from '../../src/context/ChildProfileContext';
 import { supabase } from '../../src/lib/supabase';
 import { getQuestionResponse, CrisisDetectedError, RateLimitError, QuotaExceededError } from '../../src/lib/api';
-import { colors as C, fonts as F } from '../../src/theme';
+import { colors as C, fonts as F, TAB_BAR_HEIGHT } from '../../src/theme';
 import { TrafficDots } from '../../src/components/ui/TrafficDots';
 import { useSubscription } from '../../src/hooks/useSubscription';
 import { getTone as loadTone, setTone as saveTone, type Tone, TONE_DEFAULT } from '../../src/utils/tone';
@@ -741,7 +741,7 @@ export default function HomeScreen() {
               </View>
 
               <Text style={s.freeFooter}>Always free · No paywall</Text>
-              <View style={{ height: 40 }} />
+              <View style={{ height: TAB_BAR_HEIGHT }} />
 
             </Animated.View>
           </ScrollView>
@@ -841,7 +841,7 @@ const s = StyleSheet.create({
   },
   thinkingSendBtn: {
     width: 56,
-    height: 40,
+    height: 44,
     borderRadius: 12,
     alignItems: 'center',
     justifyContent: 'center',
@@ -872,7 +872,8 @@ const s = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
-    padding: 4,
+    paddingVertical: 10,
+    paddingLeft: 8,
     paddingRight: 12,
     borderRadius: 100,
     borderWidth: 1,
@@ -983,7 +984,7 @@ const s = StyleSheet.create({
   },
   getScriptBtn: {
     paddingHorizontal: 16,
-    height: 36,
+    height: 44,
     borderRadius: 10,
     backgroundColor: 'rgba(232,116,97,0.12)',
     borderWidth: 1,

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -24,7 +24,7 @@ import { LinearGradient }  from 'expo-linear-gradient';
 import * as Haptics        from 'expo-haptics';
 import { useAuth }         from '../../src/context/AuthContext';
 import { useSubscription } from '../../src/hooks/useSubscription';
-import { colors as C, fonts as F } from '../../src/theme';
+import { colors as C, fonts as F, TAB_BAR_HEIGHT } from '../../src/theme';
 
 // ─── Components ───
 
@@ -284,7 +284,7 @@ export default function SettingsScreen() {
 
           <Text style={s.version}>Sturdy v1.0 · Made with ♥</Text>
 
-          <View style={{ height: 60 }} />
+          <View style={{ height: TAB_BAR_HEIGHT }} />
         </ScrollView>
       </SafeAreaView>
     </View>
@@ -299,7 +299,7 @@ const SAGE_BG = 'rgba(141,184,154,0.12)';
 const s = StyleSheet.create({
   root: { flex: 1, backgroundColor: C.background },
   safe: { flex: 1 },
-  scroll: { paddingHorizontal: 20, paddingTop: 16, paddingBottom: 60, gap: 6 },
+  scroll: { paddingHorizontal: 20, paddingTop: 16, paddingBottom: 20, gap: 6 },
 
   title: {
     fontFamily:    F.heading,

--- a/apps/mobile/app/result.tsx
+++ b/apps/mobile/app/result.tsx
@@ -302,7 +302,7 @@ const handleRetry = () => {
         locations={[0, 0.10, 0.25, 0.42, 0.58, 1]}
         style={StyleSheet.absoluteFill}
       />
-      <SafeAreaView style={{ flex: 1 }} edges={['top']}>
+      <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
 
       <ScrollView contentContainerStyle={s.scroll} showsVerticalScrollIndicator={false}>
         {/* Back */}

--- a/apps/mobile/app/welcome/index.tsx
+++ b/apps/mobile/app/welcome/index.tsx
@@ -16,7 +16,7 @@ import {
 } from 'react-native';
 import { router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
 import { useAuth } from '../../src/context/AuthContext';
@@ -85,7 +85,6 @@ const Background = () => {
 
 export default function WelcomeScreen() {
   const { session } = useAuth();
-  const insets = useSafeAreaInsets();
   const [page, setPage] = useState(0);
   const scrollRef = useRef<ScrollView>(null);
 
@@ -120,7 +119,7 @@ export default function WelcomeScreen() {
       <Background />
       
       <SafeAreaView style={s.safe} edges={['top', 'bottom']}>
-        
+
         {/* ─── Navigation Header ─── */}
         <View style={s.header}>
           <View style={s.progressContainer}>
@@ -128,7 +127,7 @@ export default function WelcomeScreen() {
               <View key={i} style={[s.progressLine, page === i && s.progressLineActive]} />
             ))}
           </View>
-          <Pressable onPress={handleGetStarted} hitSlop={10}>
+          <Pressable onPress={handleGetStarted} hitSlop={12}>
             <Text style={s.skipText}>Skip</Text>
           </Pressable>
         </View>
@@ -206,14 +205,12 @@ const s = StyleSheet.create({
   root: { flex: 1, backgroundColor: '#0d0b08' },
   safe: { flex: 1 },
   header: {
-    position: 'absolute',
-    top: 60,
-    left: 24,
-    right: 24,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    zIndex: 10,
+    paddingHorizontal: 24,
+    paddingTop: 12,
+    paddingBottom: 8,
   },
   progressContainer: { flexDirection: 'row', gap: 6 },
   progressLine: { width: 20, height: 2, backgroundColor: 'rgba(255,255,255,0.2)', borderRadius: 1 },
@@ -226,7 +223,7 @@ const s = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    paddingTop: 40,
+    paddingTop: 8,
   },
   haloWrapper: {
     width: W * 0.65,

--- a/apps/mobile/src/components/ui/PaywallSheet.tsx
+++ b/apps/mobile/src/components/ui/PaywallSheet.tsx
@@ -8,6 +8,7 @@
 // purchase button text + behaviour can stay identical.
 
 import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { colors as C, fonts as F } from '../../theme';
 import { useSubscription } from '../../hooks/useSubscription';
 
@@ -20,6 +21,7 @@ type Props = {
 
 export function PaywallSheet({ visible, onClose, feature, body }: Props) {
   const { purchase } = useSubscription();
+  const insets = useSafeAreaInsets();
 
  const handlePurchase = async () => {
   try {
@@ -39,7 +41,7 @@ export function PaywallSheet({ visible, onClose, feature, body }: Props) {
       onRequestClose={onClose}
     >
       <Pressable style={s.backdrop} onPress={onClose}>
-        <Pressable style={s.sheet} onPress={() => { /* stop bubble */ }}>
+        <Pressable style={[s.sheet, { paddingBottom: 24 + insets.bottom }]} onPress={() => { /* stop bubble */ }}>
           <Text style={s.lock}>🔒</Text>
           <Text style={s.title}>{feature} is part of Sturdy+</Text>
           {body ? <Text style={s.body}>{body}</Text> : null}
@@ -75,7 +77,7 @@ const s = StyleSheet.create({
     borderTopRightRadius: 24,
     paddingHorizontal: 24,
     paddingTop: 24,
-    paddingBottom: 36,
+    paddingBottom: 24,
     gap: 12,
   },
   lock:  { fontSize: 28, marginBottom: 4 },

--- a/apps/mobile/src/theme/index.ts
+++ b/apps/mobile/src/theme/index.ts
@@ -3,6 +3,10 @@
 
 export { colors, fonts } from './colors';
 
+// Height of the absolute-positioned tab bar (set in app/(tabs)/_layout.tsx).
+// Used by tab screens to ensure scroll content clears the floating tab bar.
+export const TAB_BAR_HEIGHT = 80;
+
 export const spacing = {
   xxs: 4,
   xs:  8,

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -68,7 +68,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1563,7 +1562,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1623,7 +1621,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -2149,7 +2146,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2493,7 +2489,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3062,7 +3057,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3248,7 +3242,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5488,7 +5481,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5498,7 +5490,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6187,7 +6178,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6350,7 +6340,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6626,7 +6615,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,41 +1,45 @@
 import HeroSection from "@/components/landing/HeroSection";
 import HowItWorksSection from "@/components/landing/HowItWorksSection";
 import ExampleScriptSection from "@/components/landing/ExampleScriptSection";
+import MobileMenu from "@/components/landing/MobileMenu";
 
 function TopNav() {
   return (
-      <header className="sticky top-0 z-40 border-b border-black/5 bg-white/85 backdrop-blur">
-            <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4 sm:px-8 lg:px-12">
-                    <div className="text-lg font-semibold text-neutral-950">Sturdy</div>
+    <header className="sticky top-0 z-40 border-b border-black/5 bg-white/85 backdrop-blur">
+      <div className="relative mx-auto flex max-w-6xl items-center justify-between px-6 py-4 sm:px-8 lg:px-12">
+        <div className="text-lg font-semibold text-neutral-950">Sturdy</div>
 
-                            <nav className="hidden items-center gap-8 text-sm text-neutral-600 md:flex">
-                                      <a href="#how-it-works" className="transition hover:text-neutral-950">
-                                                  How it works
-                                                            </a>
-                                                                      <a href="#example" className="transition hover:text-neutral-950">
-                                                                                  Example
-                                                                                            </a>
-                                                                                                    </nav>
+        <nav className="hidden items-center gap-8 text-sm text-neutral-600 md:flex">
+          <a href="#how-it-works" className="transition hover:text-neutral-950">
+            How it works
+          </a>
+          <a href="#example" className="transition hover:text-neutral-950">
+            Example
+          </a>
+        </nav>
 
-                                                                                                            <button className="rounded-2xl bg-neutral-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-neutral-800">
-                                                                                                                      Get script
-                                                                                                                              </button>
-                                                                                                                                    </div>
-                                                                                                                                        </header>
-                                                                                                                                          );
-                                                                                                                                          }
+        <div className="flex items-center gap-3">
+          <button className="rounded-2xl bg-neutral-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-neutral-800">
+            Get script
+          </button>
+          <MobileMenu />
+        </div>
+      </div>
+    </header>
+  );
+}
 
-                                                                                                                                          export default function Home() {
-                                                                                                                                            return (
-                                                                                                                                                <main className="min-h-screen bg-[#FCFBF8] text-neutral-900">
-                                                                                                                                                      <TopNav />
-                                                                                                                                                            <HeroSection />
-                                                                                                                                                                  <div id="how-it-works">
-                                                                                                                                                                          <HowItWorksSection />
-                                                                                                                                                                                </div>
-                                                                                                                                                                                      <div id="example">
-                                                                                                                                                                                              <ExampleScriptSection />
-                                                                                                                                                                                                    </div>
-                                                                                                                                                                                                        </main>
-                                                                                                                                                                                                          );
-                                                                                                                                                                                                          }
+export default function Home() {
+  return (
+    <main className="min-h-screen bg-[#FCFBF8] text-neutral-900">
+      <TopNav />
+      <HeroSection />
+      <div id="how-it-works">
+        <HowItWorksSection />
+      </div>
+      <div id="example">
+        <ExampleScriptSection />
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/landing/MobileMenu.tsx
+++ b/apps/web/src/components/landing/MobileMenu.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+
+export default function MobileMenu() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="md:hidden">
+      <button
+        aria-label={open ? "Close menu" : "Open menu"}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex h-10 w-10 items-center justify-center rounded-xl border border-black/10 bg-white text-neutral-700 shadow-sm transition hover:bg-neutral-50"
+      >
+        {open ? (
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+            <line x1="3" y1="3" x2="15" y2="15" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+            <line x1="15" y1="3" x2="3" y2="15" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+          </svg>
+        ) : (
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden>
+            <line x1="3" y1="5" x2="15" y2="5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+            <line x1="3" y1="9" x2="15" y2="9" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+            <line x1="3" y1="13" x2="15" y2="13" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+          </svg>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute left-0 right-0 top-full z-50 border-b border-black/5 bg-white/95 px-6 py-4 shadow-sm backdrop-blur">
+          <nav className="flex flex-col gap-4 text-sm text-neutral-700">
+            <a
+              href="#how-it-works"
+              onClick={() => setOpen(false)}
+              className="py-1 transition hover:text-neutral-950"
+            >
+              How it works
+            </a>
+            <a
+              href="#example"
+              onClick={() => setOpen(false)}
+              className="py-1 transition hover:text-neutral-950"
+            >
+              Example
+            </a>
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Resolves all 7 layout/mobile issues identified in the frontend audit. No backend, API, or database files were touched.

**Mobile app changes (React Native / Expo):**

- **Issue #1 — Family CTA hidden behind tab bar**: `SafeAreaView` now includes `bottom` edge; footer gets `marginBottom: TAB_BAR_HEIGHT` to clear the floating tab bar.
- **Issue #2 — Home/Settings scroll clipped by tab bar**: Extracted `TAB_BAR_HEIGHT = 80` constant to `src/theme/index.ts` (single source of truth). Home and Settings bottom spacers updated to use it.
- **Issue #3 — Result footer overlaps home indicator (iPhone X+)**: `SafeAreaView` changed from `edges={['top']}` to `edges={['top', 'bottom']}` so footer respects the safe area boundary on all devices.
- **Issue #4 — PaywallSheet missing home indicator clearance**: Added `useSafeAreaInsets()` hook; sheet `paddingBottom` is now `24 + insets.bottom` — device-adaptive on every model.
- **Issue #5 — Welcome screen: dead `insets` variable + fragile `top: 60` header**: Removed unused `useSafeAreaInsets` import/call; converted header from `position: absolute / top: 60` to normal flex flow with `paddingTop: 12` inside `SafeAreaView`.
- **Issue #7 — Touch targets below 44 × 44px**: Home screen send button (`40→44px`), Get Script button (`36→44px`), child pills (`padding: 4 → paddingVertical: 10`).

**Web app changes (Next.js):**

- **Issue #6 — No mobile navigation**: Added `MobileMenu.tsx` client component with accessible hamburger toggle and anchor-link dropdown, visible on viewports < 768px (`md` breakpoint). Desktop nav is unchanged.

## Test plan

- [ ] **Family tab**: "Add a child" button fully visible above tab bar on iPhone SE, iPhone 14, iPhone 14 Pro Max
- [ ] **Home tab**: Scroll to bottom — tone selector and "Always free" footer are not hidden behind tab bar
- [ ] **Settings tab**: Scroll to bottom — "Sturdy v1.0" footer and sign-out row clear the tab bar
- [ ] **Result screen**: Footer Save/Copy/Retry row is not behind home indicator on iPhone X+
- [ ] **PaywallSheet**: "Not right now" dismiss link is fully visible above home indicator on notch devices
- [ ] **Welcome screen**: Progress dots and Skip appear consistently near the top across iPhone SE, iPhone 14 Pro Max
- [ ] **Home touch targets**: Send arrow button, "Get Script" button, and child pills all have ≥ 44px tap height
- [ ] **Web (mobile viewport)**: Hamburger icon appears in nav on 375px viewport; tapping it reveals How it works / Example links; tapping a link closes the menu and scrolls to section
- [ ] All 36 Jest unit tests pass (`npm test` in `apps/mobile/`)
- [ ] No TypeScript errors (`npx tsc --noEmit` in both `apps/mobile/` and `apps/web/`)

https://claude.ai/code/session_018Vy6s4SrXPNGswzypVd2Lg

---
_Generated by [Claude Code](https://claude.ai/code/session_018Vy6s4SrXPNGswzypVd2Lg)_