### PR TITLE
Replace parchment gradient with home-screen background on child hub, …

### DIFF
--- a/apps/mobile/app/auth/index.tsx
+++ b/apps/mobile/app/auth/index.tsx
@@ -7,6 +7,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useState } from 'react';
 import {
+  Image,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -124,16 +125,14 @@ export default function AuthScreen() {
   return (
     <View style={s.root}>
       <StatusBar style="light" />
+      <Image
+        source={require('../../assets/golden-particles-bg.png')}
+        style={StyleSheet.absoluteFill}
+        resizeMode="cover"
+      />
       <LinearGradient
-        colors={[
-          C.gradientTop,
-          C.gradientMid1,
-          C.gradientMid2,
-          C.gradientMid3,
-          C.gradientMid4,
-          C.gradientBottom,
-        ]}
-        locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
+        colors={['rgba(0,0,0,0.50)', 'rgba(0,0,0,0.65)', 'rgba(0,0,0,0.80)', 'rgba(0,0,0,0.90)', 'rgba(0,0,0,0.95)']}
+        locations={[0, 0.25, 0.50, 0.72, 1]}
         style={StyleSheet.absoluteFill}
       />
       <SafeAreaView style={{ flex: 1 }} edges={['top', 'bottom']}>
@@ -272,7 +271,7 @@ export default function AuthScreen() {
       {/* Sticky CTA — hidden on confirm-email screen */}
       {screenState !== 'confirm-email' && <View style={s.stickyWrap}>
         <LinearGradient
-          colors={['transparent', 'rgba(12,12,12,0.85)', C.background]}
+          colors={['transparent', 'rgba(12,12,12,0.85)', '#0d0b08']}
           locations={[0, 0.45, 0.85]}
           style={s.stickyFade}
           pointerEvents="none"
@@ -315,7 +314,7 @@ export default function AuthScreen() {
 }
 
 const s = StyleSheet.create({
-  root:    { flex: 1, backgroundColor: C.background },
+  root:    { flex: 1, backgroundColor: '#0d0b08' },
   content: { paddingHorizontal: 28, paddingTop: 12, paddingBottom: 110, gap: 20 },
 
   back:     { alignSelf: 'flex-start', paddingVertical: 6 },
@@ -394,7 +393,7 @@ const s = StyleSheet.create({
   stickyWrap: { position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 },
   stickyFade: { height: 36 },
   stickyContent: {
-    backgroundColor:   C.background,
+    backgroundColor:   '#0d0b08',
     paddingHorizontal: 28,
     paddingTop:        4,
     paddingBottom:     28,

--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -6,6 +6,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Animated,
+  Image,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -115,18 +116,18 @@ function isHubMode(v: unknown): v is HubMode {
 
 function Background() {
   return (
-    <LinearGradient
-      colors={[
-        C.gradientTop,
-        C.gradientMid1,
-        C.gradientMid2,
-        C.gradientMid3,
-        C.gradientMid4,
-        C.gradientBottom,
-      ]}
-      locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
-      style={StyleSheet.absoluteFill}
-    />
+    <>
+      <Image
+        source={require('../../assets/golden-particles-bg.png')}
+        style={StyleSheet.absoluteFill}
+        resizeMode="cover"
+      />
+      <LinearGradient
+        colors={['rgba(0,0,0,0.50)', 'rgba(0,0,0,0.65)', 'rgba(0,0,0,0.80)', 'rgba(0,0,0,0.90)', 'rgba(0,0,0,0.95)']}
+        locations={[0, 0.25, 0.50, 0.72, 1]}
+        style={StyleSheet.absoluteFill}
+      />
+    </>
   );
 }
 
@@ -652,7 +653,7 @@ const card = {
 } as const;
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.background },
+  root: { flex: 1, backgroundColor: '#0d0b08' },
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingBottom: 20, gap: 22 },
 

--- a/apps/mobile/app/child/new.tsx
+++ b/apps/mobile/app/child/new.tsx
@@ -103,17 +103,15 @@ export default function NewChildScreen() {
     <SafeAreaView style={st.root} edges={['top', 'bottom']}>
       <StatusBar style="light" />
 
-      {/* Background — C-2 fast-fade gradient */}
+      {/* Background — golden particles + dark overlay */}
+      <Image
+        source={require('../../assets/golden-particles-bg.png')}
+        style={StyleSheet.absoluteFill}
+        resizeMode="cover"
+      />
       <LinearGradient
-        colors={[
-          C.gradientTop,
-          C.gradientMid1,
-          C.gradientMid2,
-          C.gradientMid3,
-          C.gradientMid4,
-          C.gradientBottom,
-        ]}
-        locations={[0, 0.14, 0.28, 0.42, 0.58, 1]}
+        colors={['rgba(0,0,0,0.50)', 'rgba(0,0,0,0.65)', 'rgba(0,0,0,0.80)', 'rgba(0,0,0,0.90)', 'rgba(0,0,0,0.95)']}
+        locations={[0, 0.25, 0.50, 0.72, 1]}
         style={StyleSheet.absoluteFill}
       />
 
@@ -129,10 +127,7 @@ export default function NewChildScreen() {
             <Text style={st.backText}>← Back</Text>
           </Pressable>
 
-          {/* Logo + Header */}
-          <View style={st.logoWrap}>
-            <Image source={require('../../assets/logo.png')} style={st.logo} resizeMode="contain" />
-          </View>
+          {/* Header */}
           <View style={st.header}>
             <Text style={st.title}>Add a child</Text>
             <Text style={st.subtitle}>The more Sturdy knows, the better the scripts.</Text>
@@ -278,14 +273,11 @@ export default function NewChildScreen() {
 
 // ─── Styles ───
 const st = StyleSheet.create({
-  root: { flex: 1, backgroundColor: C.background },
+  root: { flex: 1, backgroundColor: '#0d0b08' },
   scroll: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 24, gap: 20 },
 
   back:     { alignSelf: 'flex-start', paddingVertical: 6 },
   backText: { fontFamily: F.bodyMedium, fontSize: 16, color: C.textSecondary },
-
-  logoWrap: { alignItems: 'center' },
-  logo:     { width: 44, height: 44 },
 
   header:   { alignItems: 'center', gap: 6 },
   title:    { fontFamily: F.heading, fontSize: 26, color: C.text, textAlign: 'center', letterSpacing: -0.3 },


### PR DESCRIPTION
…auth, and add-child screens

Swaps the warm C.gradientTop gradient on three screens for the golden-particles-bg.png + dark rgba overlay system used by the home screen, making the background language consistent across core flows. Also removes the outdated logo.png from the add-child screen header.

https://claude.ai/code/session_018Vy6s4SrXPNGswzypVd2Lg