### PR TITLE
feat: SOS flow now calls API directly from home screen

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -33,7 +33,8 @@ import * as Haptics from 'expo-haptics';
 import { useAuth } from '../../src/context/AuthContext';
 import { useChildProfile } from '../../src/context/ChildProfileContext';
 import { supabase } from '../../src/lib/supabase';
-import { getQuestionResponse, CrisisDetectedError, RateLimitError, QuotaExceededError } from '../../src/lib/api';
+import { getParentingScript, getQuestionResponse, CrisisDetectedError, RateLimitError, QuotaExceededError } from '../../src/lib/api';
+import { incrementScriptCount } from '../../src/utils/profileNudge';
 import { colors as C, fonts as F, TAB_BAR_HEIGHT } from '../../src/theme';
 import { TrafficDots } from '../../src/components/ui/TrafficDots';
 import { useSubscription } from '../../src/hooks/useSubscription';
@@ -460,7 +461,7 @@ export default function HomeScreen() {
     }
   };
 
-  // ─── SOS handler — routes to child hub with prefill ───
+  // ─── SOS handler — calls API directly, bypasses child hub ───
   const handleSosSend = async () => {
     const text = sosInputText.trim();
     if (!text || sosSending) return;
@@ -471,18 +472,58 @@ export default function HomeScreen() {
       return;
     }
 
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     setSosSending(true);
+    setSosError('');
 
     try {
-      router.push({
-        pathname: `/child/${targetId}` as any,
-        params: { prefill: text, mode: 'sos' },
-      });
+      const child = kidList.find((k: any) => k.id === targetId);
+
+      const script = await getParentingScript({
+        childName:      child?.name || 'My child',
+        childAge:       child?.childAge ?? 4,
+        message:        text,
+        userId:         session?.user?.id,
+        childProfileId: child?.id,
+        intensity:      null,
+        mode:           'sos',
+        tone:           isPremium ? tone : 'gentle',
+      } as any);
+
+      if (child?.id) incrementScriptCount(child.id).catch(() => {});
+
       setSosInputText('');
+      router.push({
+        pathname: '/result',
+        params: {
+          source:              'home',
+          childId:             child?.id,
+          situationSummary:    script.situation_summary,
+          regulateAction:      script.regulate.parent_action,
+          regulateScript:      script.regulate.script,
+          regulateCoaching:    script.regulate.coaching ?? '',
+          regulateStrategies:  JSON.stringify(script.regulate.strategies ?? []),
+          connectAction:       script.connect.parent_action,
+          connectScript:       script.connect.script,
+          connectCoaching:     script.connect.coaching ?? '',
+          connectStrategies:   JSON.stringify(script.connect.strategies ?? []),
+          guideAction:         script.guide.parent_action,
+          guideScript:         script.guide.script,
+          guideCoaching:       script.guide.coaching ?? '',
+          guideStrategies:     JSON.stringify(script.guide.strategies ?? []),
+          avoid:               JSON.stringify(script.avoid),
+          childMessage:        text,
+          mode:                'sos',
+        },
+      });
     } catch (err) {
-      setSosError('Something went wrong. Please try again.');
-      console.error('[SOS HOME] send error:', err);
+      if (err instanceof CrisisDetectedError) {
+        router.push({ pathname: '/crisis', params: { crisisType: err.crisisType, riskLevel: err.riskLevel } });
+        return;
+      }
+      if (err instanceof QuotaExceededError) { router.push('/upgrade' as any); return; }
+      if (err instanceof RateLimitError) { setSosError(err.message); return; }
+      setSosError("Couldn't get a script right now. Please try again.");
     } finally {
       setSosSending(false);
     }

--- a/apps/mobile/app/result.tsx
+++ b/apps/mobile/app/result.tsx
@@ -56,7 +56,7 @@ const FALLBACKS = [
 ];
 
 function isValid(v: unknown): boolean { return typeof v === 'string' && (v as string).trim().length > 4; }
-type Params = { situationSummary?: string; regulateAction?: string; regulateScript?: string; regulateCoaching?: string; regulateStrategies?: string; connectAction?: string; connectScript?: string; connectCoaching?: string; connectStrategies?: string; guideAction?: string; guideScript?: string; guideCoaching?: string; guideStrategies?: string; avoid?: string; childMessage?: string; mode?: string; conversation_id?: string; childId?: string };const val = (v?: string | string[]) => Array.isArray(v) ? v[0] : v;
+type Params = { situationSummary?: string; regulateAction?: string; regulateScript?: string; regulateCoaching?: string; regulateStrategies?: string; connectAction?: string; connectScript?: string; connectCoaching?: string; connectStrategies?: string; guideAction?: string; guideScript?: string; guideCoaching?: string; guideStrategies?: string; avoid?: string; childMessage?: string; mode?: string; conversation_id?: string; childId?: string; source?: string };const val = (v?: string | string[]) => Array.isArray(v) ? v[0] : v;
 function parseStrategies(raw?: string): string[] { if (!raw) return []; try { const p = JSON.parse(raw); return Array.isArray(p) ? p : []; } catch { return []; } }
 
 // ─── Voice Player ───
@@ -273,6 +273,7 @@ export default function ResultScreen() {
   const handleCopy = () => { const text = [`Regulate: ${script.regulate.script}`, `Connect: ${script.connect.script}`, `Guide: ${script.guide.script}`].join('\n\n'); Clipboard.setStringAsync(text); setCopied(true); Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success); setTimeout(() => setCopied(false), 2000); };
 const handleRetry = () => {
   voice.stop();
+  if (val(params.source) === 'home') { router.replace('/(tabs)'); return; }
   const cid = typeof params.childId === 'string' ? params.childId : null;
   if (cid) navigation.push(`/child/${cid}` as any);
   else router.replace('/(tabs)');
@@ -307,7 +308,7 @@ const handleRetry = () => {
       <ScrollView contentContainerStyle={s.scroll} showsVerticalScrollIndicator={false}>
         {/* Back */}
         <View style={s.backRow}>
-          <Pressable onPress={() => { voice.stop(); const cid = typeof params.childId === 'string' ? params.childId : null; if (cid) router.replace(`/child/${cid}` as any); else router.back(); }} style={s.back}><Text style={s.backText}>← Back</Text></Pressable>
+          <Pressable onPress={() => { voice.stop(); if (val(params.source) === 'home') { router.replace('/(tabs)'); return; } const cid = typeof params.childId === 'string' ? params.childId : null; if (cid) router.replace(`/child/${cid}` as any); else router.back(); }} style={s.back}><Text style={s.backText}>← Back</Text></Pressable>
           <Pressable onPress={() => { voice.stop(); router.replace('/(tabs)'); }} style={s.homeBtn}><Text style={s.homeBtnText}>🏠</Text></Pressable>
         </View>
 


### PR DESCRIPTION
The SOS "Get Script" button on the home screen previously routed to the
child hub and required a second tap. It now calls getParentingScript()
inline and pushes directly to the result screen, saving a round-trip.

Back and Retry on the result screen return to Home when source='home'.

https://claude.ai/code/session_016YKmeeUEcnbmxnkqynKdUK