### PR TITLE
feat: child profile redesign — premium conversion hub

### DIFF
--- a/apps/mobile/app/child-profile/[id].tsx
+++ b/apps/mobile/app/child-profile/[id].tsx
@@ -1,16 +1,8 @@
 // app/child-profile/[id].tsx
-// v2 — Twilight × Obsidian Gold. Theme only.
-// "Your Child" profile screen — Master Blueprint's explicit conversion
-// trigger ("parents pay when they see Sturdy knows their child").
-//
-// Sections:
-//   1. Header — avatar, name, age
-//   2. Common triggers — top 5 trigger categories from interaction_logs
-//   3. What works — saved scripts for this child (proxy for "what helped")
-//   4. Profile basics — read-only name / age (editing TBD)
-//
-// Empty states are load-bearing: they tell the parent the profile gets
-// smarter the more they use Sturdy. That IS the conversion hook.
+// v3 — Premium Conversion Hub
+// Full redesign: Triggers (partial free / full premium), Session History,
+// Saved Scripts, Patterns (V2 informational). Every locked section is a
+// conversion moment via PaywallSheet.
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -28,10 +20,47 @@ import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
 
 import { useChildProfile } from '../../src/context/ChildProfileContext';
+import { supabase } from '../../src/lib/supabase';
 import { loadSavedScripts, type SavedScriptRow } from '../../src/lib/loadSavedScripts';
 import { loadChildInsights, type ChildInsights } from '../../src/lib/loadChildInsights';
 import { colors as C, fonts as F } from '../../src/theme';
+import { useSubscription } from '../../src/hooks/useSubscription';
+import { PaywallSheet } from '../../src/components/ui/PaywallSheet';
 
+// ═══════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════
+
+type SessionItem = {
+  id: string;
+  mode: string;
+  trigger_category: string | null;
+  situation_summary: string | null;
+  created_at: string;
+};
+
+// ═══════════════════════════════════════════════
+// HELPERS
+// ═══════════════════════════════════════════════
+
+const MODE_LABELS: Record<string, string> = {
+  sos:          'SOS',
+  reconnect:    'Reconnect',
+  understand:   'Understand',
+  conversation: 'Conversation',
+  question:     'Question',
+};
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const diff = now.getTime() - d.getTime();
+  const days = Math.floor(diff / 86400000);
+  if (days === 0) return 'Today';
+  if (days === 1) return 'Yesterday';
+  if (days < 7) return `${days} days ago`;
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
 
 // ═══════════════════════════════════════════════
 // SCREEN
@@ -40,15 +69,18 @@ import { colors as C, fonts as F } from '../../src/theme';
 export default function ChildProfileScreen() {
   const params = useLocalSearchParams<{ id?: string }>();
   const { children } = useChildProfile() as any;
+  const { isPremium } = useSubscription();
 
   const child = useMemo(() => {
     if (!params.id || !Array.isArray(children)) return null;
     return children.find((c: any) => c?.id === params.id) ?? null;
   }, [params.id, children]);
 
-  const [insights, setInsights]     = useState<ChildInsights | null>(null);
-  const [savedScripts, setSavedScripts] = useState<SavedScriptRow[]>([]);
-  const [isLoading, setIsLoading]   = useState(true);
+  const [insights, setInsights]             = useState<ChildInsights | null>(null);
+  const [savedScripts, setSavedScripts]     = useState<SavedScriptRow[]>([]);
+  const [sessions, setSessions]             = useState<SessionItem[]>([]);
+  const [isLoading, setIsLoading]           = useState(true);
+  const [paywallFeature, setPaywallFeature] = useState<string | null>(null);
 
   // Bounce home if the child id doesn't resolve.
   useEffect(() => {
@@ -61,14 +93,22 @@ export default function ChildProfileScreen() {
     if (!child?.id) return;
     setIsLoading(true);
     try {
-      const [ins, all] = await Promise.all([
+      const [ins, all, sessionData] = await Promise.all([
         loadChildInsights(child.id),
         loadSavedScripts(),
+        supabase
+          .from('interaction_logs')
+          .select('id, mode, trigger_category, situation_summary, created_at')
+          .eq('child_profile_id', child.id)
+          .order('created_at', { ascending: false })
+          .limit(5)
+          .then(({ data }) => (data ?? []) as SessionItem[]),
       ]);
       setInsights(ins);
       setSavedScripts(all.filter((s) => s.child_profile_id === child.id));
+      setSessions(sessionData);
     } catch {
-      // Both helpers swallow their own errors — empty states render either way.
+      // Helpers swallow their own errors — empty states render either way.
     } finally {
       setIsLoading(false);
     }
@@ -111,7 +151,6 @@ export default function ChildProfileScreen() {
   const initial = (child?.name?.trim()?.[0] ?? '?').toUpperCase();
   const totalInteractions = insights?.totalInteractions ?? 0;
   const topTriggers = insights?.topTriggers ?? [];
-  const isNewProfile = totalInteractions < 0 && !isLoading;
 
   return (
     <View style={s.root}>
@@ -121,7 +160,6 @@ export default function ChildProfileScreen() {
         locations={[0, 0.16, 0.40, 0.58, 0.76, 1]}
         style={StyleSheet.absoluteFill}
       />
-
       <SafeAreaView style={s.safe} edges={['top']}>
         <ScrollView
           contentContainerStyle={s.scroll}
@@ -139,30 +177,35 @@ export default function ChildProfileScreen() {
             <View style={s.avatar}>
               <Text style={s.avatarText}>{initial}</Text>
             </View>
-            <Text style={s.childName}>{child.name}'s profile</Text>
+            <Text style={s.childName}>{child.name}</Text>
             <Text style={s.childAge}>Age {child.childAge}</Text>
             {totalInteractions > 0 ? (
-              <Text style={s.interactionMeta}>
-                {totalInteractions} {totalInteractions === 1 ? 'interaction' : 'interactions'} so far
+              <Text style={s.sessionCount}>
+                {totalInteractions} {totalInteractions === 1 ? 'session' : 'sessions'} with Sturdy
               </Text>
-            ) : null}
+            ) : (
+              <Text style={s.sessionCount}>Just getting started</Text>
+            )}
           </View>
 
-          {/* ─── 1. Common triggers ─── */}
+          {/* ══════════════════════════════════════════ */}
+          {/* SECTION 1: TRIGGERS                        */}
+          {/* Free: top 1 only. Premium: all 5.          */}
+          {/* ══════════════════════════════════════════ */}
           <View style={s.section}>
             <Text style={s.sectionTitle}>What sets {child.name} off</Text>
+
             {topTriggers.length === 0 ? (
               <View style={s.emptyCard}>
                 <Text style={s.emptyEmoji}>🌱</Text>
-                <Text style={s.emptyTitle}>Sturdy is just getting started</Text>
+                <Text style={s.emptyTitle}>Building up</Text>
                 <Text style={s.emptyBody}>
-                  Use Sturdy a few more times and this section will fill in with the moments
-                  that come up most for {child.name}.
+                  Use Sturdy a few more times and the patterns will start showing up here.
                 </Text>
               </View>
             ) : (
               <View style={s.card}>
-                {topTriggers.map((t) => {
+                {(isPremium ? topTriggers : topTriggers.slice(0, 1)).map((t) => {
                   const max = topTriggers[0]?.count || 1;
                   const widthPct = Math.max(8, Math.round((t.count / max) * 100));
                   return (
@@ -177,20 +220,109 @@ export default function ChildProfileScreen() {
                     </View>
                   );
                 })}
+
+                {!isPremium && topTriggers.length > 1 && (
+                  <Pressable
+                    onPress={() => setPaywallFeature('Full trigger history')}
+                    style={s.lockedRow}
+                  >
+                    <Text style={s.lockedRowText}>
+                      +{topTriggers.length - 1} more trigger{topTriggers.length - 1 > 1 ? 's' : ''} — unlock with Sturdy+
+                    </Text>
+                    <Text style={s.lockedRowArrow}>→</Text>
+                  </Pressable>
+                )}
               </View>
             )}
           </View>
 
-          {/* ─── 2. What works ─── */}
+          {/* ══════════════════════════════════════════ */}
+          {/* SECTION 2: SESSION HISTORY                 */}
+          {/* Fully locked for free users.               */}
+          {/* ══════════════════════════════════════════ */}
+          <View style={s.section}>
+            <Text style={s.sectionTitle}>Sessions</Text>
+
+            {!isPremium ? (
+              <Pressable
+                onPress={() => setPaywallFeature('Session history')}
+                style={s.lockedCard}
+              >
+                <View style={s.lockedCardInner}>
+                  <Text style={s.lockedIcon}>🔒</Text>
+                  <View style={{ flex: 1, gap: 4 }}>
+                    <Text style={s.lockedTitle}>Every session with {child.name}</Text>
+                    <Text style={s.lockedBody}>
+                      See every moment you've used Sturdy — what happened, which mode, what you said.
+                    </Text>
+                  </View>
+                </View>
+                <View style={s.premiumPill}>
+                  <Text style={s.premiumPillText}>STURDY+</Text>
+                </View>
+              </Pressable>
+            ) : sessions.length === 0 ? (
+              <View style={s.emptyCard}>
+                <Text style={s.emptyEmoji}>📋</Text>
+                <Text style={s.emptyTitle}>No sessions yet</Text>
+                <Text style={s.emptyBody}>
+                  Sessions with {child.name} will appear here as you use Sturdy.
+                </Text>
+              </View>
+            ) : (
+              <View style={s.card}>
+                {sessions.map((item) => (
+                  <View key={item.id} style={s.sessionRow}>
+                    <View style={s.sessionMeta}>
+                      <View style={s.modeBadge}>
+                        <Text style={s.modeBadgeText}>
+                          {MODE_LABELS[item.mode] ?? item.mode}
+                        </Text>
+                      </View>
+                      <Text style={s.sessionDate}>{formatDate(item.created_at)}</Text>
+                    </View>
+                    {item.situation_summary ? (
+                      <Text style={s.sessionSummary} numberOfLines={2}>
+                        {item.situation_summary}
+                      </Text>
+                    ) : null}
+                  </View>
+                ))}
+              </View>
+            )}
+          </View>
+
+          {/* ══════════════════════════════════════════ */}
+          {/* SECTION 3: SAVED SCRIPTS                   */}
+          {/* Fully locked for free users.               */}
+          {/* ══════════════════════════════════════════ */}
           <View style={s.section}>
             <Text style={s.sectionTitle}>What's helped before</Text>
-            {savedScripts.length === 0 ? (
+
+            {!isPremium ? (
+              <Pressable
+                onPress={() => setPaywallFeature('Saved scripts')}
+                style={s.lockedCard}
+              >
+                <View style={s.lockedCardInner}>
+                  <Text style={s.lockedIcon}>🔒</Text>
+                  <View style={{ flex: 1, gap: 4 }}>
+                    <Text style={s.lockedTitle}>Scripts that worked</Text>
+                    <Text style={s.lockedBody}>
+                      Save scripts after a session. Find them again the next time something similar comes up.
+                    </Text>
+                  </View>
+                </View>
+                <View style={s.premiumPill}>
+                  <Text style={s.premiumPillText}>STURDY+</Text>
+                </View>
+              </Pressable>
+            ) : savedScripts.length === 0 ? (
               <View style={s.emptyCard}>
                 <Text style={s.emptyEmoji}>💛</Text>
                 <Text style={s.emptyTitle}>Nothing saved yet</Text>
                 <Text style={s.emptyBody}>
-                  When a script lands, save it. They'll show up here so you can find them
-                  again the next time something similar comes up.
+                  When a script lands, save it. It'll show up here so you can find it again.
                 </Text>
               </View>
             ) : (
@@ -223,26 +355,42 @@ export default function ChildProfileScreen() {
             )}
           </View>
 
-          {/* ─── 4. Profile basics (read-only for now) ─── */}
+          {/* ══════════════════════════════════════════ */}
+          {/* SECTION 4: PATTERNS (V2 — locked for all) */}
+          {/* Informational only — no paywall on tap.   */}
+          {/* ══════════════════════════════════════════ */}
           <View style={s.section}>
-            <Text style={s.sectionTitle}>Profile</Text>
-            <View style={s.card}>
-              <View style={s.basicRow}>
-                <Text style={s.basicLabel}>Name</Text>
-                <Text style={s.basicValue}>{child.name ?? '—'}</Text>
+            <Text style={s.sectionTitle}>Patterns</Text>
+            <View style={s.lockedCard}>
+              <View style={s.lockedCardInner}>
+                <Text style={s.lockedIcon}>🔭</Text>
+                <View style={{ flex: 1, gap: 4 }}>
+                  <Text style={s.lockedTitle}>What Sturdy is noticing</Text>
+                  <Text style={s.lockedBody}>
+                    After enough sessions, Sturdy will surface what it's seeing about {child.name} — coming soon.
+                  </Text>
+                </View>
               </View>
-              <View style={s.divider} />
-              <View style={s.basicRow}>
-                <Text style={s.basicLabel}>Age</Text>
-                <Text style={s.basicValue}>{child.childAge}</Text>
-              </View>
-              <Text style={s.basicHint}>Editing coming soon.</Text>
             </View>
           </View>
 
-          <View style={{ height: 32 }} />
+          {/* ─── Edit link ─── */}
+          <Pressable
+            onPress={() => router.push(`/child/${child.id}?edit=1` as any)}
+            style={s.editBtn}
+          >
+            <Text style={s.editText}>Edit {child.name}'s profile</Text>
+          </Pressable>
+
+          <View style={{ height: 40 }} />
         </ScrollView>
       </SafeAreaView>
+
+      <PaywallSheet
+        visible={paywallFeature !== null}
+        onClose={() => setPaywallFeature(null)}
+        feature={paywallFeature ?? ''}
+      />
     </View>
   );
 }
@@ -262,41 +410,24 @@ const s = StyleSheet.create({
   backBtn:  { paddingVertical: 6, paddingHorizontal: 4 },
   backText: { fontFamily: F.bodyMedium, fontSize: 15, color: C.textSecondary },
 
-  // Identity header (warm zone)
+  // Identity header
   identity: { alignItems: 'center', gap: 6, paddingTop: 4 },
   avatar: {
-    width:          80,
-    height:         80,
-    borderRadius:   40,
-    alignItems:     'center',
-    justifyContent: 'center',
+    width: 80, height: 80, borderRadius: 40,
+    alignItems: 'center', justifyContent: 'center',
     backgroundColor: C.amber,
-    shadowColor:    C.amber,
-    shadowOpacity:  0.35,
-    shadowRadius:   20,
-    shadowOffset:   { width: 0, height: 6 },
-    elevation:      4,
-    marginBottom:   8,
+    shadowColor: C.amber, shadowOpacity: 0.35,
+    shadowRadius: 20, shadowOffset: { width: 0, height: 6 },
+    elevation: 4, marginBottom: 8,
   },
-  avatarText: {
-    fontFamily: F.heading, fontSize: 32, color: C.text, letterSpacing: -0.4,
-  },
-  childName: {
-    fontFamily: F.heading, fontSize: 24, color: C.text,
-    letterSpacing: -0.3, textAlign: 'center',
-  },
-  childAge: {
-    fontFamily: F.body, fontSize: 14, color: C.textSecondary,
-  },
-  interactionMeta: {
-    fontFamily: F.body, fontSize: 12, color: C.textMuted, marginTop: 4,
-  },
+  avatarText:   { fontFamily: F.heading, fontSize: 32, color: C.text, letterSpacing: -0.4 },
+  childName:    { fontFamily: F.heading, fontSize: 24, color: C.text, letterSpacing: -0.3 },
+  childAge:     { fontFamily: F.body, fontSize: 14, color: C.textSecondary },
+  sessionCount: { fontFamily: F.body, fontSize: 12, color: C.textMuted, marginTop: 4 },
 
   // Sections
-  section: { gap: 10 },
-  sectionTitle: {
-    fontFamily: F.subheading, fontSize: 16, color: C.text, letterSpacing: -0.2,
-  },
+  section:      { gap: 10 },
+  sectionTitle: { fontFamily: F.subheading, fontSize: 16, color: C.text, letterSpacing: -0.2 },
 
   // Generic card
   card: {
@@ -305,67 +436,71 @@ const s = StyleSheet.create({
     borderRadius: 18, padding: 16, gap: 14,
   },
 
-  // Empty state card (warm, not punitive)
+  // Empty state
   emptyCard: {
     backgroundColor: C.surface,
     borderColor: C.border, borderWidth: 1,
     borderRadius: 18, padding: 18, gap: 8,
-    alignItems: 'flex-start',
   },
   emptyEmoji: { fontSize: 22, marginBottom: 2 },
-  emptyTitle: {
-    fontFamily: F.subheading, fontSize: 15, color: C.text, letterSpacing: -0.1,
-  },
-  emptyBody: {
-    fontFamily: F.body, fontSize: 14, color: C.textSecondary, lineHeight: 21,
-  },
+  emptyTitle: { fontFamily: F.subheading, fontSize: 15, color: C.text, letterSpacing: -0.1 },
+  emptyBody:  { fontFamily: F.body, fontSize: 14, color: C.textSecondary, lineHeight: 21 },
 
-  // Triggers
-  triggerRow: { gap: 6 },
-  triggerHeader: { flexDirection: 'row', justifyContent: 'space-between' },
-  triggerLabel: { fontFamily: F.bodyMedium, fontSize: 14, color: C.text },
-  triggerCount: { fontFamily: F.body, fontSize: 13, color: C.textSecondary },
-  triggerBarBg: {
-    height: 6, borderRadius: 3, backgroundColor: C.surface,
-    overflow: 'hidden',
-  },
-  triggerBarFill: {
-    height: '100%', backgroundColor: C.amber, borderRadius: 3,
-  },
-
-  // What works
-  workRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
-  workDot: {
-    width: 8, height: 8, borderRadius: 4, marginTop: 7,
-    backgroundColor: C.sage,
-  },
-  workTitle: { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
-  workQuote: { fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 19, marginTop: 2 },
-  workSeeAll: { paddingTop: 4 },
-  workSeeAllText: { fontFamily: F.bodyMedium, fontSize: 13, color: C.amber },
-
-  // Locked / coming-soon card
+  // Locked card (full section lock)
   lockedCard: {
     backgroundColor: C.surface,
     borderColor: C.border, borderWidth: 1,
-    borderRadius: 18, padding: 16, gap: 8,
+    borderRadius: 18, padding: 16, gap: 12,
   },
-  lockedHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  lockedIcon: { fontSize: 16 },
-  lockedPill: {
-    fontFamily: F.label, fontSize: 9, letterSpacing: 0.8,
-    color: C.amber, backgroundColor: C.amberBadge,
-    paddingHorizontal: 8, paddingVertical: 3,
-    borderRadius: 999, overflow: 'hidden',
+  lockedCardInner: { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
+  lockedIcon:      { fontSize: 20, marginTop: 2 },
+  lockedTitle:     { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
+  lockedBody:      { fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 19 },
+  premiumPill: {
+    alignSelf: 'flex-start',
+    backgroundColor: C.amberBadge,
+    borderRadius: 999, paddingHorizontal: 8, paddingVertical: 3,
   },
-  lockedBody: {
-    fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 19,
+  premiumPillText: {
+    fontFamily: F.label, fontSize: 9, letterSpacing: 0.8, color: C.amber,
   },
 
-  // Profile basics (read-only)
-  basicRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'baseline' },
-  basicLabel: { fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, letterSpacing: 0.3 },
-  basicValue: { fontFamily: F.bodySemi, fontSize: 15, color: C.text },
-  divider:    { height: 1, backgroundColor: C.divider },
-  basicHint:  { fontFamily: F.body, fontSize: 12, color: C.textMuted, marginTop: 4 },
+  // Locked row inside partial trigger card
+  lockedRow: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingTop: 6, borderTopWidth: 1, borderTopColor: C.divider,
+  },
+  lockedRowText:  { fontFamily: F.bodyMedium, fontSize: 13, color: C.amber },
+  lockedRowArrow: { fontFamily: F.bodySemi, fontSize: 15, color: C.amber },
+
+  // Triggers
+  triggerRow:     { gap: 6 },
+  triggerHeader:  { flexDirection: 'row', justifyContent: 'space-between' },
+  triggerLabel:   { fontFamily: F.bodyMedium, fontSize: 14, color: C.text },
+  triggerCount:   { fontFamily: F.body, fontSize: 13, color: C.textSecondary },
+  triggerBarBg:   { height: 6, borderRadius: 3, backgroundColor: C.surface, overflow: 'hidden' },
+  triggerBarFill: { height: '100%' as any, backgroundColor: C.amber, borderRadius: 3 },
+
+  // Sessions
+  sessionRow:     { gap: 6, paddingBottom: 10, borderBottomWidth: 1, borderBottomColor: C.divider },
+  sessionMeta:    { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  modeBadge: {
+    backgroundColor: C.amberBadge, borderRadius: 6,
+    paddingHorizontal: 8, paddingVertical: 2,
+  },
+  modeBadgeText:  { fontFamily: F.label, fontSize: 10, color: C.amber, letterSpacing: 0.4 },
+  sessionDate:    { fontFamily: F.body, fontSize: 12, color: C.textMuted },
+  sessionSummary: { fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 19 },
+
+  // Saved scripts
+  workRow:        { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
+  workDot:        { width: 8, height: 8, borderRadius: 4, marginTop: 7, backgroundColor: C.sage },
+  workTitle:      { fontFamily: F.bodySemi, fontSize: 14, color: C.text },
+  workQuote:      { fontFamily: F.body, fontSize: 13, color: C.textSecondary, lineHeight: 19, marginTop: 2 },
+  workSeeAll:     { paddingTop: 4 },
+  workSeeAllText: { fontFamily: F.bodyMedium, fontSize: 13, color: C.amber },
+
+  // Edit link
+  editBtn:  { alignSelf: 'center', paddingVertical: 8 },
+  editText: { fontFamily: F.bodyMedium, fontSize: 13, color: C.textMuted, textDecorationLine: 'underline' },
 });

--- a/apps/mobile/src/components/ui/PaywallSheet.tsx
+++ b/apps/mobile/src/components/ui/PaywallSheet.tsx
@@ -46,8 +46,8 @@ export function PaywallSheet({ visible, onClose, feature, body }: Props) {
           <Text style={s.title}>{feature} is part of Sturdy+</Text>
           {body ? <Text style={s.body}>{body}</Text> : null}
           <Text style={s.body}>
-            Sturdy+ unlocks tone, voice playback, weekly insights, and the full
-            child profile. Try it free, cancel any time.
+            Sturdy+ unlocks the full child profile, session history, saved scripts,
+            tone selector, and unlimited scripts. Try it free, cancel any time.
           </Text>
           <Pressable
             onPress={handlePurchase}


### PR DESCRIPTION
## Summary

- **Child profile full redesign** (`child-profile/[id].tsx`) — replaces static read-only screen with a proper conversion hub
- **PaywallSheet copy fix** — removes vaporware "weekly insights" reference, lists actual shipped features

## What changed

### child-profile/[id].tsx

**Header:** Avatar, name, age, session count ("X sessions with Sturdy" / "Just getting started")

**Section 1 — Triggers:** Free users see top 1 trigger + a locked row ("+N more — unlock with Sturdy+") that opens PaywallSheet. Premium users see all 5 triggers with bar chart.

**Section 2 — Sessions:** Free users see a locked card that opens PaywallSheet on tap. Premium users see last 5 `interaction_logs` entries: mode badge, relative date, situation summary. Session data fetched directly in the existing `refresh()` via `Promise.all`.

**Section 3 — Saved Scripts:** Free users see a locked card. Premium users see up to 3 saved scripts + "See all →" to `/saved`.

**Section 4 — Patterns (V2):** Informational-only card for all users. No paywall, no data behind it. Copy: "After enough sessions, Sturdy will surface what it's seeing — coming soon."

**Footer:** "Edit [name]'s profile" link → `/child/[id]?edit=1`

New additions: `SessionItem` type, `MODE_LABELS`, `formatDate` helper, `useSubscription`, `PaywallSheet`, `supabase` direct query for session history.

### PaywallSheet.tsx

Updated default body copy from `"tone, voice playback, weekly insights, and the full child profile"` → `"the full child profile, session history, saved scripts, tone selector, and unlimited scripts"`.

## Test plan

- [ ] Free user, child with 3 triggers: sees top 1 trigger + locked row "2 more triggers — unlock with Sturdy+"
- [ ] Free user taps locked row → PaywallSheet fires with "Full trigger history"
- [ ] Free user: Session history shows locked card, not empty state
- [ ] Free user taps session history locked card → PaywallSheet fires with "Session history"
- [ ] Free user: Saved scripts shows locked card with PaywallSheet on tap
- [ ] Patterns section shows for all users — informational only, no paywall on tap
- [ ] Premium user: all sections unlocked, data renders correctly
- [ ] Premium user, 0 sessions: sees empty state not locked card
- [ ] Premium user, 0 saved scripts: sees empty state not locked card
- [ ] Back button works
- [ ] "Edit profile" link routes to `/child/[id]?edit=1`

https://claude.ai/code/session_01HrWAF22s7M6d5YKDgZ1Ujn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrWAF22s7M6d5YKDgZ1Ujn)_