### PR TITLE
Family tab restructure + 1-child limit gate

### DIFF
--- a/apps/mobile/app/(tabs)/family.tsx
+++ b/apps/mobile/app/(tabs)/family.tsx
@@ -18,6 +18,8 @@ import * as Haptics from 'expo-haptics';
 import { useChildProfile } from '../../src/context/ChildProfileContext';
 import { loadChildInsights, type ChildInsights } from '../../src/lib/loadChildInsights';
 import { colors as C, fonts as F, TAB_BAR_HEIGHT } from '../../src/theme';
+import { useSubscription } from '../../src/hooks/useSubscription';
+import { PaywallSheet } from '../../src/components/ui/PaywallSheet';
 
 const CHILD_GRADIENTS: Array<[string, string]> = [
   [C.iconTalkStart, C.iconTalkEnd],
@@ -30,6 +32,8 @@ export default function FamilyScreen() {
   const { children } = useChildProfile() as any;
   const kidList = Array.isArray(children) ? children : [];
   const [childInsights, setChildInsights] = useState<Record<string, ChildInsights>>({});
+  const { isPremium } = useSubscription();
+  const [showPaywall, setShowPaywall] = useState(false);
 
   useFocusEffect(
     useCallback(() => {
@@ -78,7 +82,7 @@ export default function FamilyScreen() {
                 key={kid.id}
                 onPress={() => {
                   Haptics.selectionAsync();
-                  router.push(`/child/${kid.id}` as any);
+                  router.push(`/child-profile/${kid.id}` as any);
                 }}
                 style={({ pressed }) => [s.card, pressed && { opacity: 0.85 }]}
                 accessibilityRole="button"
@@ -128,6 +132,10 @@ export default function FamilyScreen() {
           <Pressable
             onPress={() => {
               Haptics.selectionAsync();
+              if (!isPremium && kidList.length >= 1) {
+                setShowPaywall(true);
+                return;
+              }
               router.push('/child/new');
             }}
             style={({ pressed }) => [pressed && { opacity: 0.92, transform: [{ scale: 0.98 }] }]}
@@ -143,6 +151,12 @@ export default function FamilyScreen() {
           </Pressable>
         </View>
       </SafeAreaView>
+
+      <PaywallSheet
+        visible={showPaywall}
+        onClose={() => setShowPaywall(false)}
+        feature="Add more children"
+      />
     </View>
   );
 }

--- a/apps/mobile/app/child/new.tsx
+++ b/apps/mobile/app/child/new.tsx
@@ -4,7 +4,7 @@
 // Arrow age picker + slider + contextual hint + optional personality notes.
 // Per docs/PRODUCT_PRINCIPLES.md §1: no neurotype selection UI.
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Dimensions,
   KeyboardAvoidingView,
@@ -24,6 +24,7 @@ import * as Haptics         from 'expo-haptics';
 import { useAuth }          from '../../src/context/AuthContext';
 import { useChildProfile }  from '../../src/context/ChildProfileContext';
 import { useSubscription }  from '../../src/hooks/useSubscription';
+import { PaywallSheet }     from '../../src/components/ui/PaywallSheet';
 import { supabase }         from '../../src/lib/supabase';
 import { colors as C, fonts as F } from '../../src/theme/colors';
 
@@ -55,6 +56,13 @@ export default function NewChildScreen() {
   const [saving, setSaving] = useState(false);
   const [showNotes, setShowNotes] = useState(false);
   const [nameFocused, setNameFocused] = useState(false);
+  const [showPaywall, setShowPaywall] = useState(false);
+
+  useEffect(() => {
+    if (!isPremium && Array.isArray(children) && children.length >= 1) {
+      setShowPaywall(true);
+    }
+  }, [isPremium, children]);
 
   const canSave = name.trim().length > 0;
   const sliderProgress = (age / MAX_AGE) * 100;
@@ -267,6 +275,15 @@ export default function NewChildScreen() {
           </Pressable>
         </View>
       </KeyboardAvoidingView>
+
+      <PaywallSheet
+        visible={showPaywall}
+        onClose={() => {
+          setShowPaywall(false);
+          router.back();
+        }}
+        feature="Add more children"
+      />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
## Summary

- **Family tab routing**: Child cards now navigate to `/child-profile/[id]` instead of `/child/[id]`. The profile screen (triggers, saved scripts, what works) is the insight layer — the moment parents feel "Sturdy knows my kid," which is the conversion trigger. The child hub `/child/[id]` is untouched and still serves mode chips from the home screen.
- **1-child paywall gate (family tab)**: Free users with ≥1 child who tap "Add a child" see `PaywallSheet` with `feature="Add more children"` instead of routing to `/child/new`.
- **1-child paywall gate (child/new.tsx)**: Belt-and-suspenders `useEffect` check on screen mount — if a free user with ≥1 child reaches the screen via any path, `PaywallSheet` fires and closing it navigates back.

## Files changed

- `apps/mobile/app/(tabs)/family.tsx` — reroute + paywall gate + `PaywallSheet`
- `apps/mobile/app/child/new.tsx` — `useEffect` gate + `PaywallSheet` (imports were already present)

## Test plan

- [ ] Family tab: tapping a child card → navigates to `/child-profile/[id]`, NOT `/child/[id]`
- [ ] Family tab: free user with 1 child taps "Add a child" → `PaywallSheet` appears with "Add more children" copy
- [ ] Family tab: premium user with 1 child taps "Add a child" → navigates to `/child/new` directly
- [ ] Family tab: free user with 0 children taps "Add a child" → navigates to `/child/new` directly (no gate)
- [ ] `/child/new` direct nav: free user with 1 child → `PaywallSheet` appears, closing navigates back
- [ ] Child profile screen loads correctly from family tab: shows triggers, saved scripts, profile basics
- [ ] Home screen SOS flow completely unaffected
- [ ] Mode chips (Reconnect/Understand/Conversation) still route to `/child/[id]?mode=` correctly

https://claude.ai/code/session_01UrgZ1mFNgJ64c5XhaTVRNb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrgZ1mFNgJ64c5XhaTVRNb)_