### PR TITLE
Fix JSX syntax error crashing app on load (welcome/index.tsx)

### DIFF
--- a/apps/mobile/app/welcome/index.tsx
+++ b/apps/mobile/app/welcome/index.tsx
@@ -75,7 +75,8 @@ const Background = () => {
         resizeMode="cover"
       />
       <LinearGradient
-        colors={['rgba(13,11,8,0.4)', 'rgba(13,11,8,0.6)', 'rgba(13,11,8,0.85)', C.background]}{/* TODO: update rgba stops to new base rgb(14,12,8) */}
+        // TODO: update rgba stops to new base rgb(14,12,8)
+        colors={['rgba(13,11,8,0.4)', 'rgba(13,11,8,0.6)', 'rgba(13,11,8,0.85)', C.background]}
         locations={[0, 0.4, 0.7, 1]}
         style={StyleSheet.absoluteFill}
       />


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes a syntax error in `apps/mobile/app/welcome/index.tsx` line 78 that crashed the app on load in Expo Go
- A JSX comment `{/* ... */}` was placed between JSX attributes on the `<LinearGradient>` component — this is invalid JSX syntax (comments between attributes must use `//` or `/* */`, not `{/* */}`)
- Replaced with a standard `//` line comment above the `colors` prop

## Test plan

- [ ] Reload the app in Expo Go — the red error screen should no longer appear
- [ ] Welcome screen loads and displays correctly
- [ ] No TypeScript errors (`npx tsc --noEmit` in `apps/mobile/`)

https://claude.ai/code/session_01YQvd8U6xa5wLicka2c1Rp9
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQvd8U6xa5wLicka2c1Rp9)_