### PR TITLE
Fix second JSX syntax error crashing app on load (welcome/index.tsx line 153)

### DIFF
--- a/apps/mobile/app/welcome/index.tsx
+++ b/apps/mobile/app/welcome/index.tsx
@@ -150,7 +150,8 @@ export default function WelcomeScreen() {
                   <View style={s.imageCrop}>
                     <Image source={beat.image} style={s.beatImage} resizeMode="cover" />
                     <LinearGradient
-                      colors={['transparent', 'rgba(13,11,8,0.5)']}{/* TODO: update rgba stop to new base rgb(14,12,8) */}
+                      // TODO: update rgba stop to new base rgb(14,12,8)
+                      colors={['transparent', 'rgba(13,11,8,0.5)']}
                       style={StyleSheet.absoluteFill}
                     />
                   </View>


### PR DESCRIPTION
## Summary

- Fixes a second instance of the same JSX syntax error in `apps/mobile/app/welcome/index.tsx` (line 153)
- A `{/* TODO: ... */}` comment was placed between attributes on a `<LinearGradient>` component — invalid JSX
- Converted to a `//` line comment above the `colors` prop
- Scanned the rest of `app/` and `src/` — no other occurrences of this pattern

## Test plan

- [ ] Reload app in Expo Go — welcome screen should load without the red error screen
- [ ] Swipe through all 5 welcome pages to confirm beat cards render correctly

https://claude.ai/code/session_01YQvd8U6xa5wLicka2c1Rp9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQvd8U6xa5wLicka2c1Rp9)_