### PR TITLE
Warm app background gradients (Twilight → Warm Ember); keep gold accent

### DIFF
--- a/apps/mobile/app/(tabs)/family.tsx
+++ b/apps/mobile/app/(tabs)/family.tsx
@@ -54,7 +54,7 @@ export default function FamilyScreen() {
   return (
     <View style={s.root}>
       <LinearGradient
-        colors={['#020202','#060604','#0a0906','#0d0b08','#0c0a06','#050402']}
+        colors={[C.gradientTop, C.gradientMid1, C.gradientMid2, C.gradientMid3, C.gradientMid4, C.gradientBottom]}
         locations={[0, 0.16, 0.40, 0.58, 0.76, 1]}
         style={StyleSheet.absoluteFill}
       />
@@ -164,7 +164,7 @@ export default function FamilyScreen() {
 const s = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: '#020202',
+    backgroundColor: C.backgroundWarm,
   },
   safe: { flex: 1 },
   scroll: {

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -278,7 +278,7 @@ function Background() {
     <>
       {/* Twilight × Obsidian Gold */}
       <LinearGradient
-        colors={['#020202','#060604','#0a0906','#0d0b08','#0c0a06','#050402']}
+        colors={[C.gradientTop, C.gradientMid1, C.gradientMid2, C.gradientMid3, C.gradientMid4, C.gradientBottom]}
         locations={[0, 0.16, 0.40, 0.58, 0.76, 1]}
         style={StyleSheet.absoluteFill}
       />
@@ -859,7 +859,7 @@ export default function HomeScreen() {
 // ═══════════════════════════════════════════════
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: '#020202' },
+  root: { flex: 1, backgroundColor: C.backgroundWarm },
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingTop: 16, paddingBottom: 20 },
   centerGate: { flex: 1, alignItems: 'center', justifyContent: 'center' },

--- a/apps/mobile/app/auth/index.tsx
+++ b/apps/mobile/app/auth/index.tsx
@@ -126,7 +126,7 @@ export default function AuthScreen() {
       <StatusBar style="light" />
       {/* Night sky — Twilight × Obsidian Gold */}
       <LinearGradient
-        colors={['#020202','#060604','#0a0906','#0d0b08','#0c0a06','#050402']}
+        colors={[C.gradientTop, C.gradientMid1, C.gradientMid2, C.gradientMid3, C.gradientMid4, C.gradientBottom]}
         locations={[0, 0.16, 0.40, 0.58, 0.76, 1]}
         style={StyleSheet.absoluteFill}
       />
@@ -314,7 +314,7 @@ export default function AuthScreen() {
 }
 
 const s = StyleSheet.create({
-  root:    { flex: 1, backgroundColor: '#020202' },
+  root:    { flex: 1, backgroundColor: C.backgroundWarm },
   content: { paddingHorizontal: 28, paddingTop: 12, paddingBottom: 110, gap: 20 },
 
   back:     { alignSelf: 'flex-start', paddingVertical: 6 },
@@ -391,7 +391,7 @@ const s = StyleSheet.create({
   stickyWrap: { position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 },
   stickyFade: { height: 36 },
   stickyContent: {
-    backgroundColor:   '#020202',
+    backgroundColor:   C.backgroundDeep,
     paddingHorizontal: 28,
     paddingTop:        4,
     paddingBottom:     28,

--- a/apps/mobile/app/auth/index.tsx
+++ b/apps/mobile/app/auth/index.tsx
@@ -271,7 +271,7 @@ export default function AuthScreen() {
       {/* Sticky CTA — hidden on confirm-email screen */}
       {screenState !== 'confirm-email' && <View style={s.stickyWrap}>
         <LinearGradient
-          colors={['transparent', 'rgba(2,2,2,0.88)', C.gradientTop]}
+          colors={['transparent', 'rgba(26,18,6,0.88)', C.gradientTop]}
           locations={[0, 0.45, 0.85]}
           style={s.stickyFade}
           pointerEvents="none"
@@ -391,7 +391,7 @@ const s = StyleSheet.create({
   stickyWrap: { position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 },
   stickyFade: { height: 36 },
   stickyContent: {
-    backgroundColor:   C.backgroundDeep,
+    backgroundColor:   C.gradientTop,
     paddingHorizontal: 28,
     paddingTop:        4,
     paddingBottom:     28,

--- a/apps/mobile/app/child-profile/[id].tsx
+++ b/apps/mobile/app/child-profile/[id].tsx
@@ -156,7 +156,7 @@ export default function ChildProfileScreen() {
     <View style={s.root}>
       <StatusBar style="light" />
       <LinearGradient
-        colors={['#020202','#060604','#0a0906','#0d0b08','#0c0a06','#050402']}
+        colors={[C.gradientTop, C.gradientMid1, C.gradientMid2, C.gradientMid3, C.gradientMid4, C.gradientBottom]}
         locations={[0, 0.16, 0.40, 0.58, 0.76, 1]}
         style={StyleSheet.absoluteFill}
       />
@@ -400,7 +400,7 @@ export default function ChildProfileScreen() {
 // ═══════════════════════════════════════════════
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: '#020202' },
+  root: { flex: 1, backgroundColor: C.backgroundWarm },
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 32, gap: 22 },
   centerGate: { flex: 1, alignItems: 'center', justifyContent: 'center' },

--- a/apps/mobile/app/child/[id].tsx
+++ b/apps/mobile/app/child/[id].tsx
@@ -119,7 +119,7 @@ function Background() {
     <>
       {/* Twilight × Obsidian Gold */}
       <LinearGradient
-        colors={['#020202','#060604','#0a0906','#0d0b08','#0c0a06','#050402']}
+        colors={[C.gradientTop, C.gradientMid1, C.gradientMid2, C.gradientMid3, C.gradientMid4, C.gradientBottom]}
         locations={[0, 0.16, 0.40, 0.58, 0.76, 1]}
         style={StyleSheet.absoluteFill}
       />
@@ -654,7 +654,7 @@ const card = {
 } as const;
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: '#020202' },
+  root: { flex: 1, backgroundColor: C.backgroundWarm },
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingBottom: 20, gap: 22 },
 

--- a/apps/mobile/app/child/new.tsx
+++ b/apps/mobile/app/child/new.tsx
@@ -113,7 +113,7 @@ export default function NewChildScreen() {
 
       {/* Background — Twilight × Obsidian Gold */}
       <LinearGradient
-        colors={['#020202','#060604','#0a0906','#0d0b08','#0c0a06','#050402']}
+        colors={[C.gradientTop, C.gradientMid1, C.gradientMid2, C.gradientMid3, C.gradientMid4, C.gradientBottom]}
         locations={[0, 0.16, 0.40, 0.58, 0.76, 1]}
         style={StyleSheet.absoluteFill}
       />
@@ -290,7 +290,7 @@ export default function NewChildScreen() {
 
 // ─── Styles ───
 const st = StyleSheet.create({
-  root: { flex: 1, backgroundColor: '#020202' },
+  root: { flex: 1, backgroundColor: C.backgroundWarm },
   scroll: { paddingHorizontal: 24, paddingTop: 12, paddingBottom: 24, gap: 20 },
 
   back:     { alignSelf: 'flex-start', paddingVertical: 6 },

--- a/apps/mobile/app/result.tsx
+++ b/apps/mobile/app/result.tsx
@@ -431,7 +431,7 @@ const handleRetry = () => {
       {/* Footer */}
       <View style={s.footer}>
         <LinearGradient
-          colors={['transparent', 'rgba(2,2,2,0.88)', '#020202']}
+          colors={['transparent', 'rgba(5,4,2,0.88)', C.backgroundDeep]}
           locations={[0, 0.35, 0.75]}
           style={s.footerFade}
           pointerEvents="none"
@@ -479,7 +479,7 @@ const card = {
 } as const;
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: '#020202' },
+  root: { flex: 1, backgroundColor: C.backgroundWarm },
   scroll: { paddingHorizontal: 24, paddingTop: 8, paddingBottom: 40, gap: 14 },
 
   backRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
@@ -547,7 +547,7 @@ const s = StyleSheet.create({
 
   footer: { position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 10 },
   footerFade: { height: 40 },
-  footerContent: { backgroundColor: '#020202', paddingHorizontal: 24, paddingBottom: 28, paddingTop: 4 },
+  footerContent: { backgroundColor: C.backgroundDeep, paddingHorizontal: 24, paddingBottom: 28, paddingTop: 4 },
   footerRow: { flexDirection: 'row', gap: 10 },
   footerGhost: { flex: 1, borderRadius: 16, minHeight: 50, alignItems: 'center', justifyContent: 'center', backgroundColor: C.surface, borderWidth: 1, borderColor: C.border, borderTopWidth: 1, borderTopColor: C.borderHi },
   footerGhostText: { fontFamily: F.bodyMedium, fontSize: 14, color: C.text },

--- a/apps/mobile/app/thought/[id].tsx
+++ b/apps/mobile/app/thought/[id].tsx
@@ -218,7 +218,7 @@ export default function ThoughtScreen() {
       <StatusBar style="light" />
 
       <LinearGradient
-        colors={['#020202','#060604','#0a0906','#0d0b08','#0c0a06','#050402']}
+        colors={[C.gradientTop, C.gradientMid1, C.gradientMid2, C.gradientMid3, C.gradientMid4, C.gradientBottom]}
         locations={[0, 0.16, 0.40, 0.58, 0.76, 1]}
         style={StyleSheet.absoluteFill}
       />
@@ -344,7 +344,7 @@ export default function ThoughtScreen() {
 // ═══════════════════════════════════════════════
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: '#020202' },
+  root: { flex: 1, backgroundColor: C.backgroundWarm },
   safe: { flex: 1 },
   scroll: { paddingHorizontal: 24, paddingBottom: 20, gap: 22 },
 

--- a/apps/mobile/app/welcome/index.tsx
+++ b/apps/mobile/app/welcome/index.tsx
@@ -77,8 +77,8 @@ const Background = () => {
         resizeMode="cover"
       />
       <LinearGradient
-        // TODO: update rgba stops to new base rgb(14,12,8)
-        colors={['rgba(13,11,8,0.4)', 'rgba(13,11,8,0.6)', 'rgba(13,11,8,0.85)', C.background]}
+        // Warm-ember scrim over the particles photo, fading into the warm base (#15100a = rgb(21,16,10))
+        colors={['rgba(21,16,10,0.4)', 'rgba(21,16,10,0.6)', 'rgba(21,16,10,0.85)', C.background]}
         locations={[0, 0.4, 0.7, 1]}
         style={StyleSheet.absoluteFill}
       />

--- a/apps/mobile/src/theme/colors.ts
+++ b/apps/mobile/src/theme/colors.ts
@@ -1,10 +1,15 @@
 // src/theme/colors.ts
-// Sturdy v7 — Twilight × Obsidian Gold (locked May 26 2026)
+// Sturdy v8 — Warm Ember × Obsidian Gold (palette warmed May 31 2026)
 //
-// Visual identity: pure black night-sky base (#020202 → #0e0c08 → #050402),
+// Visual identity: warm-brown base rising to near-black (#1a1206 → #15100a → #050402),
 // yellow-gold accent (#c9a85c → #a8843a → #8a6820), horizon glow rising
 // from the bottom. Cards are frosted-glass ultra-thin (rgba(255,255,255,0.04))
-// with gold-tinted borders. Stars animated in the night sky background.
+// with gold-tinted borders. Stars animated in the warm-ember background.
+//
+// v8 palette shift (Twilight → Warm Ember): the gradient TOP/upper-mid stops
+// warmed from pure black #020202 toward warm brown #1a1206 to lift the app's
+// "gloomy" feel, while the BOTTOM stop stays a warm near-black #050402 so
+// content-rich screens stay calm. Gold accent unchanged — background only.
 //
 // Gold shifted: #C8883A (orange-amber) → #c9a85c (yellow-gold, more celestial)
 // Card glass shifted: rgba(26,24,22,0.78) → rgba(255,255,255,0.04) (lighter veil)
@@ -16,9 +21,9 @@ export const colors = {
   // ═══════════════════════════════════════════════
   // SURFACES
   // ═══════════════════════════════════════════════
-  background:       '#0e0c08',                       // warm dark night-sky base
-  backgroundDeep:   '#050402',                       // deepest gradient stop
-  backgroundWarm:   '#020202',                       // pure black (night sky top)
+  background:       '#15100a',                       // warm ember base (flat backgrounds)
+  backgroundDeep:   '#050402',                       // deepest gradient stop (warm near-black nadir)
+  backgroundWarm:   '#1a1206',                       // warm brown (gradient top)
   surface:          'rgba(255,255,255,0.04)',         // card bg — frosted glass veil
   surfaceRaised:    'rgba(255,255,255,0.028)',        // elevated card (SOS card weight)
   surfaceSubtle:    'rgba(255,255,255,0.025)',        // barely-there separator
@@ -122,25 +127,25 @@ export const colors = {
 
   // ═══════════════════════════════════════════════
   // GRADIENTS (use with LinearGradient)
-  // Night sky: pure black top → warm dark bottom (horizon glow from bottom)
+  // Warm Ember: warm brown top → warm near-black bottom (horizon glow from bottom)
   // ═══════════════════════════════════════════════
-  gradientTop:      '#020202',                        // pure black (night sky zenith)
-  gradientMid1:     '#060604',                        // ~16%
-  gradientMid2:     '#0a0906',                        // ~40%
-  gradientMid3:     '#0d0b07',                        // ~58%
-  gradientMid4:     '#0c0a06',                        // ~70%
-  gradientBottom:   '#050402',                        // deep warm black (nadir)
+  gradientTop:      '#1a1206',                        // warm brown (zenith)
+  gradientMid1:     '#171009',                        // ~16%
+  gradientMid2:     '#13100a',                        // ~40%
+  gradientMid3:     '#100c08',                        // ~58%
+  gradientMid4:     '#0a0806',                        // ~70%
+  gradientBottom:   '#050402',                        // warm near-black (nadir, kept calm)
 
-  // Result screen gradient (same night-sky palette)
-  gradientResultTop:    '#020202',
-  gradientResultMid1:   '#060604',                    // ~10%
-  gradientResultMid2:   '#0a0906',                    // ~25%
-  gradientResultMid3:   '#0d0b07',                    // ~42%
+  // Result screen gradient (same Warm Ember palette)
+  gradientResultTop:    '#1a1206',
+  gradientResultMid1:   '#171009',                    // ~10%
+  gradientResultMid2:   '#13100a',                    // ~25%
+  gradientResultMid3:   '#100c08',                    // ~42%
 
-  // Settings gradient (same night-sky palette)
-  gradientSettingsTop:  '#020202',
-  gradientSettingsMid1: '#060604',                    // ~12%
-  gradientSettingsMid2: '#0a0906',                    // ~26%
+  // Settings gradient (same Warm Ember palette)
+  gradientSettingsTop:  '#1a1206',
+  gradientSettingsMid1: '#171009',                    // ~12%
+  gradientSettingsMid2: '#13100a',                    // ~26%
 
   // Ambient glow (radial gradient overlays — horizon warmth from bottom)
   glowAmber:        'rgba(184,142,74,0.07)',           // horizon glow (bottom bleed)
@@ -176,9 +181,9 @@ export const colors = {
   // v3/v4/v5 token names. Drop each alias when its consumer migrates.
   // ═══════════════════════════════════════════════
 
-  // Old surface names → new night-sky surfaces
-  base:             '#0e0c08',
-  backgroundLight:  '#0e0c08',
+  // Old surface names → new warm-ember surfaces
+  base:             '#15100a',
+  backgroundLight:  '#15100a',
   raised:           'rgba(255,255,255,0.04)',
   elevated:         'rgba(255,255,255,0.028)',
   subtle:           'rgba(255,255,255,0.025)',
@@ -223,10 +228,10 @@ export const colors = {
   disabledText:     'rgba(255,255,255,0.20)',
   pressed:          'rgba(255,255,255,0.04)',
 
-  // Old gradient stops → night sky
-  gradStart:        '#020202',
-  gradMid1:         '#060604',
-  gradMid2:         '#0a0906',
+  // Old gradient stops → warm ember (kept in sync with gradient* tokens)
+  gradStart:        '#1a1206',
+  gradMid1:         '#171009',
+  gradMid2:         '#13100a',
   gradEnd:          '#050402',
 
   // Old category card backgrounds (now dark card system)
@@ -292,7 +297,7 @@ export const fonts = {
 // Home, Auth, Child Hub, and Add Child screens.
 // ═══════════════════════════════════════════════
 
-export const particlesBg = '#0e0c08';
+export const particlesBg = '#15100a';
 export const particlesOverlay = [
   'rgba(0,0,0,0.50)',
   'rgba(0,0,0,0.65)',


### PR DESCRIPTION
Warm the gradient top/upper-mid stops from pure black toward warm brown
(#020202 -> #1a1206) app-wide via the colors.ts tokens, keeping the bottom
stop a calm warm near-black (#050402). Gold accent and all copy unchanged.

Repoint screens that hardcoded the night-sky gradient array / #020202 roots
to the gradient* and background* tokens so the warming actually propagates:
(tabs)/index, (tabs)/family, auth, child/new, child/[id], child-profile/[id],
thought/[id], result, and the welcome photo scrim.